### PR TITLE
docs(phase-0): PRD, TD, dan pemecahan issue untuk Foundation

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -29,24 +29,13 @@ _(kosong)_
 
 ## Berikutnya
 
-**Buka Phase 0 — Foundation:** tulis `docs/phases/00-foundation/{prd,td,issues}.md`, lalu buat issue-nya di GitHub. Prosedur: `docs/workflow.md` bagian 1.
+**Issue #1 — Project skeleton: config, logging, error, health, CI**
 
-Cakupan dan acceptance criteria: `docs/architecture/freeze.md` bagian 4 (Phase 0) dan 13.2.
+PRD & TD Phase 0 sudah ditulis, issue #1–#3 sudah dibuat. Setelah PR PRD/TD di-merge, pengerjaan dimulai dari issue #1.
 
-Ringkas:
-- Struktur project Go + `cmd/api`
-- Docker Compose (app + PostgreSQL)
-- Config dari env, ter-validasi saat boot
-- Structured logging + request ID
-- Penanganan & mapping error terpusat
-- Tooling migration + `0001_baseline` (fungsi `set_updated_at()`)
-- Health check
-- Test harness (PostgreSQL asli, bukan mock)
-- CI: lint + test + build
-
-**Tidak termasuk:** business logic, endpoint domain, tabel domain, auth.
-
-Sebelum mulai: tulis `docs/features/foundation/spec.md`.
+- Cakupan & acceptance: [issue #1](https://github.com/Pravasta/jualin-crm/issues/1)
+- TD: `docs/phases/00-foundation/td.md` §2–§7, §12–§14
+- Urutan: #1 → #2 → #3 (berurutan, tidak bisa diparalelkan)
 
 ---
 
@@ -87,7 +76,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 
 | Phase | Nama | PRD | TD | Issues | Selesai |
 |---|---|---|---|---|---|
-| 0 | Foundation | ⬜ | ⬜ | ⬜ | ⬜ |
+| 0 | Foundation | ✅ | ✅ | ✅ #1–#3 | ⬜ |
 | 1 | Auth & Organization | ⬜ | ⬜ | ⬜ | ⬜ |
 | 2 | CRM Core | ⬜ | ⬜ | ⬜ | ⬜ |
 | 3 | Owner Dashboard | ⬜ | ⬜ | ⬜ | ⬜ |

--- a/docs/phases/00-foundation/issues.md
+++ b/docs/phases/00-foundation/issues.md
@@ -1,0 +1,56 @@
+# Phase 0 — Foundation · Issues
+
+> Indeks pekerjaan. **Tanpa kolom status** — status hidup di GitHub ([ADR-008](../../decisions/ADR-008-delivery-workflow.md)).
+>
+> Status terkini: `gh issue list --milestone "Phase 0 — Foundation"`
+
+**Milestone:** [Phase 0 — Foundation](https://github.com/Pravasta/jualin-crm/milestone/1)
+
+---
+
+## Daftar
+
+| # | Judul | Cakupan | TD |
+|---|---|---|---|
+| [1](https://github.com/Pravasta/jualin-crm/issues/1) | Project skeleton: config, logging, error, health, CI | Go module, struktur paket, config ter-validasi saat boot, slog + request ID, error envelope, `/health`, Makefile, CI | §2–§7, §12–§14 |
+| [2](https://github.com/Pravasta/jualin-crm/issues/2) | Database, Docker Compose, dan migration tooling | Dockerfile, compose + PostgreSQL 17, pgxpool, `db.InTx`, goose, `0001_baseline`, `/health/ready` | §8–§10 |
+| [3](https://github.com/Pravasta/jualin-crm/issues/3) | Test harness terhadap PostgreSQL asli | testcontainers, `NewTestDB`, test migration round-trip, config, error mapping, health | §11, §12, §15 |
+
+---
+
+## Urutan
+
+Ketiganya **berurutan**, tidak bisa diparalelkan:
+
+```
+#1 skeleton ──► #2 database ──► #3 test harness
+```
+
+| Dependensi | Alasan |
+|---|---|
+| #2 → #1 | Butuh config, logger, dan kerangka HTTP |
+| #3 → #2 | Butuh database dan migration untuk diuji |
+
+**CI sengaja masuk di #1**, bukan di akhir, supaya PR #2 dan #3 sudah tergerbang lint/test/build sejak awal.
+
+---
+
+## Cakupan per issue — batas yang mengikat
+
+| Issue | Berhenti di |
+|---|---|
+| #1 | Belum menyentuh database sama sekali. `/health` tidak melakukan ping. |
+| #2 | Belum ada tabel domain. `0001` **hanya** fungsi `set_updated_at()`. |
+| #3 | Belum ada harness isolasi tenant — belum ada tabel tenant-scoped untuk diuji. |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Setelah ketiganya selesai
+
+Phase 0 dinyatakan tutup bila **7 acceptance criteria** di [`prd.md`](./prd.md) terpenuhi. Lalu:
+
+1. `docs/STATUS.md` — Phase 0 ✅, utang teknis dicatat
+2. `docs/architecture/overview.md` dibuat (TD §16)
+3. Buka **Phase 1 — Auth & Organization**: tulis PRD + TD, pecah issue

--- a/docs/phases/00-foundation/prd.md
+++ b/docs/phases/00-foundation/prd.md
@@ -1,0 +1,102 @@
+# Phase 0 — Foundation · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md).
+> Sumber: [`architecture/freeze.md`](../../architecture/freeze.md) bagian 4 (Phase 0) & 13.2
+
+---
+
+## Tujuan
+
+Menegakkan **setiap pola yang akan ditiru oleh 15+ session berikutnya**, sebelum ada satu pun business logic yang menutupinya.
+
+Phase ini tidak menghasilkan nilai bagi pengguna akhir. Nilainya seluruhnya internal: setelah selesai, setiap session berikutnya punya jawaban yang sudah jadi untuk pertanyaan "bagaimana cara membaca config di sini", "bagaimana bentuk error di sini", "bagaimana menulis test yang menyentuh database di sini".
+
+> Fondasi yang dibuat sambil lalu di tengah feature auth akan ditiru oleh semua session sesudahnya. Karena itu ia dikerjakan terpisah, dengan review tersendiri.
+
+---
+
+## Kebutuhan
+
+Bukan kebutuhan pengguna akhir — kebutuhan **developer yang mengerjakan phase berikutnya**.
+
+| # | Sebagai developer, saya butuh… | Supaya… |
+|---|---|---|
+| 1 | Menjalankan seluruh sistem dengan satu perintah | Tidak ada langkah setup manual yang tidak tercatat |
+| 2 | Aplikasi gagal seketika saat config salah, dengan pesan yang jelas | Salah konfigurasi ketahuan saat startup, bukan saat request pertama di produksi |
+| 3 | Setiap baris log bisa dilacak ke satu request | Debugging tidak menebak-nebak |
+| 4 | Bentuk error yang sama di seluruh endpoint | Client tidak perlu menangani banyak bentuk |
+| 5 | Menjalankan & membatalkan migration dengan aman | Perubahan schema bisa dicoba tanpa takut |
+| 6 | Menulis test yang menyentuh PostgreSQL **asli** | Bug isolasi tenant nanti benar-benar tertangkap — mock tidak akan pernah menangkapnya |
+| 7 | CI menolak kode yang tidak lolos lint/test/build | Kualitas tidak bergantung pada ingatan reviewer |
+
+---
+
+## Acceptance Criteria
+
+Phase 0 dinyatakan selesai bila **ketujuhnya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | `docker compose up` → API merespons `GET /health` |
+| 2 | Migration `up` lalu `down` berjalan bersih, tanpa objek tersisa |
+| 3 | Config invalid → proses **gagal saat startup** dengan pesan yang menyebut variabel mana yang bermasalah |
+| 4 | Log berbentuk JSON terstruktur dan memuat `request_id` di setiap baris yang berasal dari request |
+| 5 | Error mengembalikan bentuk konsisten `{"error":{"code","message"}}` sesuai [`architecture/api.md`](../../architecture/api.md) |
+| 6 | `go test ./...` berjalan terhadap PostgreSQL asli tanpa setup manual |
+| 7 | CI hijau: lint + test + build |
+
+---
+
+## Di luar cakupan
+
+Ditulis eksplisit karena tiga di antaranya akan terasa "sekalian saja".
+
+| Tidak dikerjakan | Ke phase |
+|---|---|
+| Business logic apapun | 1+ |
+| Endpoint domain | 1+ |
+| **Tabel domain** (`organizations`, `users`, `memberships`) | 1 |
+| Autentikasi, JWT, session | 1 |
+| `internal/shared/tenant` — `TenantContext` | 1 |
+| Harness test isolasi tenant | 1 |
+| Rate limiting | 1 |
+| Pengiriman email | 1 |
+| Deployment ke server / CD | Setelah Phase 5 |
+
+> **`TenantContext` sengaja ditunda.** Ia baru punya bentuk yang benar setelah ada principal untuk diisi. Membuatnya di Phase 0 berarti menebak, dan tebakan itu akan ditiru repository pertama.
+
+> **Tabel domain sengaja ditunda.** Migration `0001` hanya berisi utilitas lintas tabel. Tabel yang dibuat di Phase 0 akan menjadi schema mati yang tidak dipakai kode manapun.
+
+---
+
+## Dependensi
+
+Tidak ada. Ini phase pertama.
+
+**Prasyarat yang sudah terpenuhi:** architecture freeze · bootstrap documentation · repository + label + milestone · `docs/workflow.md`
+
+---
+
+## Pembagian issue
+
+Freeze memetakan Foundation sebagai **satu** session. Setelah ADR-008 menetapkan 1 issue = 1 session = 1 PR, pemetaan itu menghasilkan PR berisi ~30 berkas — terlalu besar untuk direview dengan teliti, padahal justru PR inilah yang menetapkan pola untuk semua session berikutnya.
+
+**Dipecah menjadi tiga**, dengan urutan yang mengikat:
+
+| Urut | Issue | Alasan urutan |
+|---|---|---|
+| 1 | Project skeleton + config + logging + error + **CI** | CI lebih dulu supaya PR #2 dan #3 sudah tergerbang sejak awal |
+| 2 | Docker Compose + PostgreSQL + migration | Butuh kerangka dari #1 |
+| 3 | Test harness terhadap PostgreSQL asli | Butuh database dari #2 |
+
+Ini **penyimpangan dari peta session di freeze**, dicatat di sini agar terlihat, bukan disembunyikan. Bila Anda lebih memilih satu PR utuh, cukup katakan saat review — issue tinggal digabung.
+
+Rincian: [`issues.md`](./issues.md)
+
+---
+
+## Bukan tujuan phase ini
+
+- **Bukan** memilih hosting atau menyiapkan deployment
+- **Bukan** mengoptimasi apapun — belum ada beban untuk diukur
+- **Bukan** membangun abstraksi untuk kebutuhan Phase 1 yang belum berbentuk (Aturan #27)

--- a/docs/phases/00-foundation/td.md
+++ b/docs/phases/00-foundation/td.md
@@ -1,0 +1,363 @@
+# Phase 0 — Foundation · Technical Design
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+>
+> Dokumen ini memuat **delta** untuk Phase 0. Aturan yang sudah ada di [`architecture/freeze.md`](../../architecture/freeze.md) dan konvensi kode di `.claude/skills/jualin-backend/` **tidak diulang** — hanya dirujuk.
+
+---
+
+## 1. Toolchain
+
+| Komponen | Versi | Catatan |
+|---|---|---|
+| Go | **1.25** | Terpasang di mesin dev: `go1.25.4` |
+| PostgreSQL | **17** | Freeze menetapkan 16/17. Tidak bergantung fitur PG 18. |
+| Docker Compose | v2+ | Terpasang: `v5.0.1` |
+| Module path | `github.com/Pravasta/jualin-crm` | Mengikuti repository |
+
+### Dependensi
+
+| Paket | Untuk | Alasan |
+|---|---|---|
+| `github.com/gin-gonic/gin` | HTTP router | Ditetapkan freeze |
+| `github.com/jackc/pgx/v5` + `pgxpool` | Driver & pool | Bukan ORM (Aturan layering) |
+| `github.com/pressly/goose/v3` | Migration | SQL-only, bisa di-embed, punya `down` yang benar |
+| `github.com/google/uuid` | UUIDv7 | `uuid.NewV7()` — Aturan #12 |
+| `github.com/caarlos0/env/v11` | Parsing env | Deklaratif, mudah divalidasi saat boot |
+| `github.com/testcontainers/testcontainers-go` | Test DB | Test berjalan tanpa setup manual |
+| `log/slog` | Logging | Stdlib, tanpa dependensi |
+
+> **Tanpa** Redis, message broker, atau ORM. Bila terasa butuh salah satunya, berhenti dan diskusikan (Aturan #27).
+
+---
+
+## 2. Struktur project
+
+```
+cmd/
+  api/main.go                 HTTP server
+  migrate/main.go             runner migration
+
+internal/shared/
+  config/config.go            parsing + validasi env
+  logger/logger.go            slog setup
+  httpx/
+    response.go               envelope {data,meta}
+    error.go                  sentinel + mapping ke HTTP
+    middleware.go             request id, recovery, logging
+  db/
+    db.go                     pgxpool
+    tx.go                     InTx
+
+migrations/
+  0001_baseline.sql
+
+Dockerfile
+docker-compose.yml
+Makefile
+.env.example
+.golangci.yml
+.github/workflows/ci.yml
+```
+
+Mengikuti struktur di `.claude/skills/jualin-backend/`. **Paket domain (`internal/lead`, dst.) belum dibuat** — Aturan #28.
+
+---
+
+## 3. Config
+
+`internal/shared/config` — dibaca **sekali** saat boot, divalidasi, lalu di-passing sebagai struct. Tidak ada `os.Getenv` yang tersebar.
+
+| Variabel | Tipe | Default | Wajib |
+|---|---|---|---|
+| `APP_ENV` | `development` \| `production` | `development` | — |
+| `HTTP_PORT` | int | `8080` | — |
+| `HTTP_READ_TIMEOUT` | duration | `10s` | — |
+| `HTTP_WRITE_TIMEOUT` | duration | `10s` | — |
+| `HTTP_SHUTDOWN_TIMEOUT` | duration | `15s` | — |
+| `DATABASE_URL` | string | — | ✅ |
+| `DB_MAX_CONNS` | int | `10` | — |
+| `LOG_LEVEL` | `debug`\|`info`\|`warn`\|`error` | `info` | — |
+
+### Kegagalan config
+
+Proses **exit non-zero saat startup**, dengan pesan yang menyebut variabel mana:
+
+```
+config invalid: DATABASE_URL is required
+config invalid: APP_ENV must be one of [development production], got "prod"
+```
+
+**Bukan** panic tanpa konteks, bukan fallback diam-diam ke nilai default.
+
+> `.env` hanya untuk pengembangan lokal dan **tidak pernah** di-commit. `.env.example` di-commit sebagai dokumentasi variabel.
+
+---
+
+## 4. Logging
+
+`log/slog`. Handler dipilih berdasarkan `APP_ENV`:
+
+| Env | Handler |
+|---|---|
+| `production` | JSON |
+| `development` | Text (lebih terbaca) |
+
+### Wajib ada di setiap log yang berasal dari request
+
+```json
+{
+  "time": "2026-08-17T09:30:00Z",
+  "level": "INFO",
+  "msg": "request completed",
+  "request_id": "01931f2e-8c4a-7...",
+  "method": "GET",
+  "path": "/health",
+  "status": 200,
+  "duration_ms": 3
+}
+```
+
+Logger diambil dari `context`, bukan variabel global, sehingga `request_id` ikut otomatis.
+
+### Redaksi (Aturan #26)
+
+Tidak pernah dicatat: password · raw API key · token · payload lead lengkap.
+Ditegakkan di **logger**, bukan di setiap call site.
+
+---
+
+## 5. Request ID
+
+Middleware paling luar:
+
+1. Baca header `X-Request-ID` bila ada — agar bisa dikorelasikan dengan reverse proxy
+2. Bila tidak ada, generate **UUIDv7**
+3. Simpan di `context`
+4. Kembalikan di response header `X-Request-ID`
+
+Nilai ini nanti mengisi `TenantContext.RequestID` (Phase 1) dan `audit_logs.request_id`.
+
+---
+
+## 6. Error
+
+Sesuai [`architecture/api.md`](../../architecture/api.md). Bentuk response:
+
+```json
+{ "error": { "code": "not_found", "message": "Resource tidak ditemukan." } }
+```
+
+### Pola
+
+Sentinel error di domain, **mapping terpusat** di `httpx`. Handler tidak menentukan status code sendiri.
+
+```go
+// internal/shared/httpx/error.go
+var (
+    ErrNotFound       = errors.New("not found")
+    ErrValidation     = errors.New("validation failed")
+    ErrInternal       = errors.New("internal error")
+)
+
+func MapError(err error) (int, ErrorBody)
+```
+
+### Katalog yang aktif di Phase 0
+
+| HTTP | `code` |
+|---|---|
+| 404 | `not_found` — route tidak dikenal |
+| 405 | `method_not_allowed` |
+| 500 | `internal_error` |
+
+Kode lain menyusul bersama fiturnya.
+
+### Recovery middleware
+
+Panic → log **beserta stack trace** → response `500 internal_error`.
+**Detail internal tidak pernah bocor ke response.**
+
+---
+
+## 7. Health check
+
+| Endpoint | Memeriksa | Dipakai untuk |
+|---|---|---|
+| `GET /health` | Proses hidup. **Tanpa** menyentuh database. | Liveness probe |
+| `GET /health/ready` | Ping database (timeout 2 detik) | Readiness probe |
+
+```json
+{ "status": "ok", "version": "dev" }
+```
+
+`/health/ready` mengembalikan **503** dengan `{"status":"degraded","database":"unreachable"}` bila DB tidak terjangkau.
+
+### ⚠️ Pengecualian versioning yang disengaja
+
+Aturan #33 mensyaratkan prefix `/v1/` pada seluruh endpoint. **Health check dikecualikan** — ia infrastruktur, bukan API produk, dan dikonsumsi oleh orchestrator yang tidak mengenal versi produk.
+
+> Ditulis eksplisit agar session mendatang tidak "memperbaikinya" menjadi `/v1/health`.
+
+---
+
+## 8. Database
+
+`internal/shared/db` — `pgxpool` dengan konfigurasi dari config, plus transaction manager:
+
+```go
+func InTx(ctx context.Context, pool *pgxpool.Pool, fn func(tx pgx.Tx) error) error
+```
+
+`InTx` menangani begin / commit / rollback-on-error / rollback-on-panic.
+
+> **Ini satu-satunya jalan masuk ke transaksi.** Aturan #32 (efek samping di luar transaksi) dan Lapis 3 multi-tenancy (penyisipan `SET LOCAL` bila RLS diaktifkan nanti) sama-sama bergantung pada adanya **satu** titik ini.
+
+---
+
+## 9. Migration
+
+### Tooling
+
+`goose` dengan migration **SQL-only**, di-`embed` ke dalam binary `cmd/migrate` sehingga tidak ada berkas yang perlu ikut di-deploy terpisah.
+
+```
+migrate up        jalankan semua yang tertunda
+migrate down      turunkan satu langkah
+migrate status    tampilkan status
+```
+
+### `0001_baseline`
+
+**Isi:** hanya fungsi trigger `set_updated_at()`.
+
+**Tidak berisi:** tabel domain, extension, seed data.
+
+```sql
+-- +goose Up
+CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- +goose Down
+DROP FUNCTION IF EXISTS set_updated_at();
+```
+
+> Migration ini **kecil dengan sengaja**. Tugasnya membuktikan `up` dan `down` bekerja bersih; sebuah fungsi sudah cukup untuk itu. Tabel domain dimulai di `0002` (Phase 1), sesuai freeze bagian 8.
+
+### Konvensi
+
+Sesuai skill: penomoran berurutan dan **tidak pernah diubah** setelah merge · setiap migration punya `down` yang benar-benar bekerja · nama constraint eksplisit · alasan JSONB ditulis sebagai komentar SQL.
+
+---
+
+## 10. Docker
+
+### `Dockerfile`
+
+Multi-stage: builder Go → runtime **distroless/alpine non-root**. Binary statis, tanpa toolchain di image akhir.
+
+### `docker-compose.yml`
+
+| Service | Isi |
+|---|---|
+| `postgres` | `postgres:17-alpine`, named volume, healthcheck `pg_isready` |
+| `api` | build dari Dockerfile, `depends_on: postgres (service_healthy)`, port dari config |
+
+`docker compose up` harus cukup — tanpa langkah manual tambahan.
+
+---
+
+## 11. Test harness
+
+**Repository diuji terhadap PostgreSQL asli, bukan mock** (skill: *"mock database tidak akan pernah menangkap bug isolasi tenant"*).
+
+### Mekanisme
+
+`testcontainers-go` + modul postgres. Container di-start **sekali per paket test** (`TestMain`), migration dijalankan otomatis, lalu helper menyediakan koneksi bersih:
+
+```go
+func NewTestDB(t *testing.T) *pgxpool.Pool
+```
+
+Setiap test mendapat state bersih — **truncate**, bukan re-migrate, agar cepat.
+
+### Yang diuji di Phase 0
+
+| Test | Memastikan |
+|---|---|
+| Migration round-trip | `up` lalu `down` bersih, tanpa objek tersisa |
+| Fungsi `set_updated_at()` | Trigger benar-benar memperbarui `updated_at` |
+| Config | Env invalid → error yang menyebut variabelnya |
+| Error mapping | Setiap sentinel error → status & `code` yang benar |
+| Health | `/health` 200 · `/health/ready` 503 saat DB mati |
+
+> Harness **isolasi tenant** adalah Phase 1 — belum ada tabel tenant-scoped untuk diuji.
+
+---
+
+## 12. CI
+
+`.github/workflows/ci.yml` — jalan pada PR ke `main` dan push ke `main`.
+
+| Job | Isi |
+|---|---|
+| `lint` | `golangci-lint run` |
+| `test` | `go test -race ./...` (runner GitHub sudah menyediakan Docker untuk testcontainers) |
+| `build` | `go build ./...` |
+
+Ketiganya harus hijau sebelum PR bisa di-merge.
+
+### `.golangci.yml`
+
+Linter awal: `govet` · `errcheck` · `staticcheck` · `ineffassign` · `misspell` · `gosec` · `bodyclose` · `sqlclosecheck`
+
+Ditambah seperlunya. Linter yang menghasilkan banyak temuan tanpa nilai akan dimatikan **dengan alasan tertulis** di berkas config.
+
+---
+
+## 13. Makefile
+
+| Target | Isi |
+|---|---|
+| `make dev` | `docker compose up --build` |
+| `make down` | `docker compose down` |
+| `make test` | `go test -race ./...` |
+| `make lint` | `golangci-lint run` |
+| `make migrate-up` / `migrate-down` / `migrate-status` | Jalankan `cmd/migrate` |
+| `make tidy` | `go mod tidy` |
+
+---
+
+## 14. Graceful shutdown
+
+`cmd/api` menangkap `SIGINT`/`SIGTERM` → berhenti menerima koneksi baru → menunggu request berjalan selesai sampai `HTTP_SHUTDOWN_TIMEOUT` → menutup pool database.
+
+Murah dilakukan sekarang, menyakitkan ditambal setelah ada trafik.
+
+---
+
+## 15. Risiko teknis
+
+| Risiko | Mitigasi |
+|---|---|
+| **testcontainers lambat** — startup container per paket menambah waktu CI | Container di-share per paket via `TestMain`; reset antar-test memakai truncate, bukan re-migrate. Bila terbukti mengganggu, pindah ke `services:` PostgreSQL di GitHub Actions — perubahan lokal di satu helper. |
+| **Over-scaffolding** — godaan menyiapkan `tenant`, `auth`, atau paket domain "sekalian" | Daftar di luar cakupan PRD bersifat mengikat. Yang tidak dipakai kode Phase 0 tidak dibuat. |
+| **Abstraksi logger/error terlalu dini** | Bentuk paling sederhana yang memenuhi 7 acceptance criteria. Abstraksi menyusul saat ada pemakai kedua yang nyata (Aturan #27). |
+| **Docker di CI** | Runner GitHub `ubuntu-latest` sudah menyediakan Docker. Tidak perlu setup tambahan. |
+
+---
+
+## 16. Yang berubah pada dokumentasi
+
+Setelah Phase 0 selesai:
+
+| Berkas | Perubahan |
+|---|---|
+| `docs/architecture/api.md` | Katalog error diperbarui bila ada kode baru |
+| `docs/architecture/overview.md` | **Dibuat** — struktur project & alur boot yang benar-benar terwujud |
+| `docs/STATUS.md` | Phase 0 ditandai selesai, utang teknis dicatat |
+| `docs/phases/00-foundation/notes.md` | Satu bagian per issue |


### PR DESCRIPTION
Refs #1 #2 #3

## Apa yang berubah

Membuka **Phase 0 — Foundation** sesuai `docs/workflow.md` bagian 1.

| Berkas | Isi |
|---|---|
| `docs/phases/00-foundation/prd.md` | Tujuan, 7 kebutuhan developer, 7 acceptance criteria, di luar cakupan |
| `docs/phases/00-foundation/td.md` | Toolchain, struktur project, config, logging, request ID, error, health, DB, migration, Docker, test harness, CI, risiko |
| `docs/phases/00-foundation/issues.md` | Indeks #1–#3 tanpa kolom status |
| `docs/STATUS.md` | Phase 0 PRD/TD ✅, "Berikutnya" menunjuk issue #1 |

Issue #1, #2, #3 sudah dibuat di milestone Phase 0.

Belum ada kode aplikasi.

## Kenapa

Phase 0 tidak menghasilkan nilai bagi pengguna akhir — nilainya seluruhnya internal. Ia menetapkan setiap pola yang akan ditiru 15+ session berikutnya, jadi dikerjakan terpisah dengan review tersendiri.

## Penyimpangan dari rencana

**Freeze memetakan Foundation sebagai satu session; di sini dipecah menjadi tiga issue.**

Setelah ADR-008 menetapkan 1 issue = 1 session = 1 PR, pemetaan lama menghasilkan PR berisi ~30 berkas — terlalu besar untuk direview teliti, padahal justru PR ini yang menetapkan konvensi untuk semua session berikutnya.

Urutannya mengikat: `#1 skeleton → #2 database → #3 test harness`. CI sengaja masuk di #1 supaya PR #2 dan #3 sudah tergerbang sejak awal.

Dicatat di `prd.md` bagian *Pembagian issue*. **Bila Anda lebih memilih satu PR utuh, katakan saja — issue tinggal digabung dan ketiganya saya tutup.**

## Keputusan teknis yang perlu perhatian

| Hal | Keputusan | Catatan |
|---|---|---|
| Migration tool | **goose** | SQL-only, bisa di-`embed`, `down` yang benar |
| Env parsing | `caarlos0/env` | Deklaratif, mudah divalidasi saat boot |
| Test DB | **testcontainers** | `go test ./...` jalan tanpa setup manual. Risiko kecepatan + rencana mundur ada di TD §15. |
| `/health` tanpa `/v1/` | **Pengecualian disengaja** terhadap Aturan #33 | Health adalah infrastruktur, bukan API produk. Ditulis eksplisit di TD §7 agar tidak "diperbaiki" nanti. |
| Go 1.25 · PostgreSQL 17 | Sesuai toolchain mesin dev & freeze | |

## Cara menguji

```bash
# Dokumentasi saja — belum ada kode untuk dijalankan
gh issue list --milestone "Phase 0 — Foundation"
```

Yang perlu direview: apakah pembagian tiga issue masuk akal, apakah acceptance criteria cukup tegas, dan apakah ada yang seharusnya masuk/keluar cakupan Phase 0.

## Checklist

- [x] Tidak ada rahasia ter-commit
- [x] `docs/STATUS.md` diperbarui
- [x] Tidak ada kolom status di `issues.md` (ADR-008)
- [x] PR memakai `Refs`, bukan `Closes`
- [ ] ~~Test~~ — belum ada kode
- [ ] ~~Isolasi tenant~~ — belum ada tabel tenant-scoped

## Catatan untuk reviewer

Dua hal yang paling ingin saya konfirmasi:

1. **Pembagian tiga issue** — ini penyimpangan dari peta session di freeze.
2. **Batas cakupan `0001_baseline`** — hanya fungsi `set_updated_at()`, tanpa tabel domain. Konsekuensinya migration pertama terasa "kosong", tapi tabel domain di Phase 0 akan jadi schema mati yang tidak dipakai kode manapun.
