### PR TITLE
docs(phase-1): PRD, TD, dan pemecahan issue untuk Auth & Organization

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 18 Agustus 2026 — Issue #3 selesai, Phase 0 tutup
-**Phase sekarang:** Phase 0 — Foundation **selesai** (3/3 issue). Berikutnya: buka Phase 1.
+**Last updated:** 18 Agustus 2026 — PRD & TD Phase 1 ditulis
+**Phase sekarang:** Phase 1 — Auth & Organization (PRD/TD selesai, implementasi belum mulai)
 
 ---
 
@@ -34,13 +34,13 @@ _(kosong)_
 
 ## Berikutnya
 
-**Buka Phase 1 — Auth & Organization**
+**Issue #8 — Schema 0002, tenant context, pola repository, test katalog**
 
-Phase 0 selesai. Sebelum implementasi apapun: tulis `docs/phases/01-auth-organization/{prd,td,issues}.md` (prosedur: `docs/workflow.md` bagian 1), lalu buat issue-nya di GitHub dengan milestone Phase 1.
+PRD & TD Phase 1 sudah ditulis, issue #8–#11 sudah dibuat. Setelah PR PRD/TD di-merge, pengerjaan dimulai dari #8.
 
-Cakupan sesuai `docs/architecture/freeze.md` bagian 4 (Phase 1): `organizations`, `users`, `memberships`, `invitations`, token tables, `subscriptions` minimal, `audit_logs` · registrasi atomik · verifikasi email · login · refresh + rotasi · undangan employee · penonaktifan membership · tenant context · RBAC · **harness test isolasi tenant** (freeze lapis 4 — dibangun di atas `dbtest` dari issue #3).
-
-Keputusan identity (B1–B5) sudah final di freeze bagian 7 — tidak ada yang memblokir migration `0002`.
+- Cakupan & acceptance: [issue #8](https://github.com/Pravasta/jualin-crm/issues/8)
+- TD: `docs/phases/01-auth-organization/td.md` §1, §7, §8, §14
+- Urutan: #8 → #9 → #10 → #11 (berurutan, tidak bisa diparalelkan)
 
 ---
 
@@ -113,7 +113,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | Phase | Nama | PRD | TD | Issues | Selesai |
 |---|---|---|---|---|---|
 | 0 | Foundation | ✅ | ✅ | ✅ #1–#3 | ✅ |
-| 1 | Auth & Organization | ⬜ | ⬜ | ⬜ | ⬜ |
+| 1 | Auth & Organization | ✅ | ✅ | ✅ #8–#11 | ⬜ |
 | 2 | CRM Core | ⬜ | ⬜ | ⬜ | ⬜ |
 | 3 | Owner Dashboard | ⬜ | ⬜ | ⬜ | ⬜ |
 | 4 | Public API | ⬜ | ⬜ | ⬜ | ⬜ |

--- a/docs/phases/01-auth-organization/issues.md
+++ b/docs/phases/01-auth-organization/issues.md
@@ -1,0 +1,65 @@
+# Phase 1 — Auth & Organization · Issues
+
+> Indeks pekerjaan. **Tanpa kolom status** — status hidup di GitHub ([ADR-008](../../decisions/ADR-008-delivery-workflow.md)).
+>
+> Status terkini: `gh issue list --milestone "Phase 1 — Auth & Organization"`
+
+**Milestone:** [Phase 1 — Auth & Organization](https://github.com/Pravasta/jualin-crm/milestone/2)
+
+---
+
+## Daftar
+
+| # | Judul | Cakupan | TD |
+|---|---|---|---|
+| [8](https://github.com/Pravasta/jualin-crm/issues/8) | Schema 0002, tenant context, pola repository, test katalog | 9 tabel + composite FK, `tenant.Context`, repository tenant-scoped, test katalog | §1, §7, §8, §14 |
+| [9](https://github.com/Pravasta/jualin-crm/issues/9) | Registrasi atomik, argon2id, dan verifikasi email | Registrasi satu transaksi, password hashing, token verifikasi, `Mailer`/`LogMailer` | §2, §3, §6, §10, §11, §12 |
+| [10](https://github.com/Pravasta/jualin-crm/issues/10) | Login, refresh rotation, logout, reset password, CSRF | Access JWT + refresh opaque, rotasi + deteksi reuse, cookie vs bearer, CSRF | §2, §4, §5, §6, §11, §12, §13 |
+| [11](https://github.com/Pravasta/jualin-crm/issues/11) | RBAC, invitation, penonaktifan membership, harness isolasi tenant | Otorisasi 4 role, undangan dua cabang, cabut sesi, **harness lapis 4** | §6, §6.1, §9, §12, §14, §17 |
+
+---
+
+## Urutan
+
+Keempatnya **berurutan**, tidak bisa diparalelkan:
+
+```
+#8 schema & pola ──► #9 registrasi ──► #10 sesi ──► #11 otorisasi & harness
+```
+
+| Dependensi | Alasan |
+|---|---|
+| #9 → #8 | Butuh tabel, `tenant.Context`, dan pola repository |
+| #10 → #9 | Login butuh user yang bisa didaftarkan dan diverifikasi |
+| #11 → #10 | Harness isolasi butuh endpoint terautentikasi untuk ditembak |
+
+**Test katalog sengaja masuk di #8**, bukan di akhir — begitu ia ada, setiap tabel baru di #9–#11 (dan seluruh Phase 2+) otomatis ikut ditegakkan tanpa ada yang perlu mengingatnya.
+
+---
+
+## Batas per issue
+
+| Issue | Berhenti di |
+|---|---|
+| #8 | **Tidak ada endpoint sama sekali.** Hanya schema, pola, dan test struktural. |
+| #9 | Belum ada login — user terdaftar dan terverifikasi, tapi belum bisa masuk. |
+| #10 | Belum ada otorisasi per-role — semua user terautentikasi setara. |
+| #11 | Aturan "reassign lead terbuka" **tidak** dikerjakan — tabel `leads` baru ada di Phase 2 (TD §17). |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Setelah keempatnya selesai
+
+Phase 1 tutup bila **11 acceptance criteria** di [`prd.md`](./prd.md) terpenuhi. Lalu:
+
+1. `architecture/authentication.md` dan `authorization.md` dibuat (TD §16)
+2. `docs/STATUS.md` — Phase 1 ✅, utang teknis dicatat
+3. Buka **Phase 2 — CRM Core**: PRD + TD, pecah issue
+
+---
+
+## Catatan lead time
+
+Provider email sungguhan **tidak** memblokir Phase 1 — `LogMailer` menutup seluruh alur untuk development dan test. Tapi domain + SPF/DKIM/DMARC adalah item lead-time di [`STATUS.md`](../../STATUS.md) yang perlu jalan paralel, karena verifikasi email menggerbangi login di produksi.

--- a/docs/phases/01-auth-organization/prd.md
+++ b/docs/phases/01-auth-organization/prd.md
@@ -1,0 +1,104 @@
+# Phase 1 — Auth & Organization · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md).
+> Sumber: [`architecture/freeze.md`](../../architecture/freeze.md) bagian 4 (Phase 1), 7 (keputusan B1–B5), 8.3 (migration `0002`) · [ADR-007](../../decisions/ADR-007-user-organization-cardinality.md)
+
+---
+
+## Tujuan
+
+Menegakkan **fondasi tenancy yang benar sebelum ada satu pun data bisnis**.
+
+Setiap tabel, endpoint, dan query di Phase 2 dan seterusnya akan bergantung pada bentuk `organization_id`, `TenantContext`, dan pola repository yang ditetapkan di sini. Kesalahan di lapisan ini tidak terlihat sebagai bug — ia terlihat sebagai data satu pelanggan yang muncul di layar pelanggan lain.
+
+> Kegagalan di area ini bersifat fatal dan tidak bisa dipulihkan dengan permintaan maaf. Karena itu Phase 1 dikerjakan sebelum Lead, Customer, atau apapun yang terasa seperti "produk".
+
+---
+
+## Kebutuhan
+
+| # | Sebagai… | Saya butuh… | Supaya… |
+|---|---|---|---|
+| 1 | Calon pelanggan | Mendaftar dengan nama organisasi, nama saya, email, dan password | Punya ruang kerja sendiri tanpa menunggu siapapun |
+| 2 | Calon pelanggan | Memverifikasi email saya | Akun saya terbukti milik saya, dan email sistem sampai ke alamat yang benar |
+| 3 | Owner | Login dan tetap login tanpa memasukkan password berulang kali | Bekerja tanpa gangguan |
+| 4 | Owner | Mengundang anggota tim lewat email | Mereka bisa bekerja tanpa saya membuatkan akun manual |
+| 5 | Orang yang diundang | Menerima undangan meski **sudah punya akun Jualin** | Tidak perlu membuat email kedua hanya untuk bergabung |
+| 6 | Owner | Menonaktifkan anggota yang keluar | Akses mereka berhenti seketika, tapi riwayat pekerjaannya tetap utuh |
+| 7 | Owner | Yakin data organisasi saya tidak terlihat organisasi lain | Saya bisa memercayakan data pelanggan saya ke sistem ini |
+| 8 | Siapa pun | Mereset password yang terlupa | Tidak kehilangan akses permanen |
+
+---
+
+## Acceptance Criteria
+
+Phase 1 selesai bila **semuanya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | Registrasi membuat `user` + `organization` + `membership(owner)` + `subscription(free)` dalam **satu transaksi** — gagal di salah satunya berarti tidak ada satupun yang tersimpan |
+| 2 | Email verifikasi terkirim **setelah** transaksi commit, dan kegagalan pengiriman **tidak** membatalkan registrasi |
+| 3 | Login ditolak sebelum email terverifikasi, dengan kode error yang bisa dibedakan client agar bisa menawarkan "kirim ulang" |
+| 4 | Login berhasil menerbitkan access token (JWT, pendek) + refresh token opaque yang tersimpan di database dan bisa direvoke |
+| 5 | Refresh token dirotasi setiap dipakai; memakai token lama yang sudah dirotasi **mencabut seluruh family** dan memaksa login ulang |
+| 6 | Owner bisa mengundang email baru **maupun** email yang sudah punya akun — cabang kedua **wajib** melalui login, tidak pernah menyetel password |
+| 7 | Menonaktifkan membership mencabut seluruh sesi aktifnya dalam transaksi yang sama |
+| 8 | RBAC ditegakkan di **service layer** untuk keempat role, bukan hanya disembunyikan di UI |
+| 9 | **Harness test isolasi tenant** berjalan di CI dan **terbukti bisa gagal** — menghapus `organization_id` dari satu query membuatnya merah |
+| 10 | Test katalog memastikan setiap tabel tenant-scoped punya `organization_id` **dan** `UNIQUE (id, organization_id)` |
+| 11 | Setiap endpoint yang mengirim email dibatasi per alamat email **dan** per IP |
+
+---
+
+## Di luar cakupan
+
+| Tidak dikerjakan | Ke |
+|---|---|
+| Lead, Customer, Activity, Task | Phase 2 |
+| Dashboard UI apapun | Phase 3 |
+| API Key & endpoint publik | Phase 4 |
+| Mobile app | Phase 5 |
+| Organization switcher, UI "buat organisasi kedua" | Tidak dijadwalkan — [ADR-007](../../decisions/ADR-007-user-organization-cardinality.md) |
+| Penegakan limit / usage / plan | Phase 8 — `subscriptions` di sini hanya baris `free`, tanpa mesin apapun |
+| Integrasi provider email sungguhan | Menunggu domain + provider (lihat `STATUS.md` bagian lead time) |
+| Entity `Team` | Tidak dijadwalkan — Manager melihat seluruh organization |
+| RBAC dinamis / custom role | Tidak dijadwalkan — role adalah enum |
+
+### Dua hal yang sengaja tertahan
+
+**Provider email sungguhan.** Phase 1 mengirim lewat `LogMailer` yang mencatat isi email ke log, bukan mengirimnya. Seluruh alur registrasi → verifikasi → login bisa diuji end-to-end tanpa domain dan tanpa akun provider. Adapter sungguhan adalah pertukaran satu implementasi interface, dikerjakan begitu domain + provider siap (item lead-time di `STATUS.md`).
+
+**Aturan "reassign lead terbuka" saat menonaktifkan membership.** Freeze mensyaratkan operasi ini menolak berjalan bila masih ada lead terbuka. Di Phase 1 **belum ada tabel lead**, sehingga aturan itu belum bisa ditegakkan. Yang **wajib** ada sekarang adalah pencabutan sesi. Titik penegakan lead ditambahkan di Phase 2 — dicatat sebagai kewajiban eksplisit di `td.md`, bukan diserahkan pada ingatan.
+
+---
+
+## Dependensi
+
+Phase 0 selesai — struktur project, config, logger, error envelope, `db.InTx`, tooling migration, dan harness `dbtest` semuanya sudah ada dan menjadi fondasi langsung phase ini.
+
+**Tidak ada keputusan yang memblokir.** B1–B5 final di freeze bagian 7; kardinalitas User↔Organization final di ADR-007.
+
+---
+
+## Pembagian issue
+
+Freeze memetakan Phase 1 sebagai **tiga** session. Setelah melihat isinya — 9 tabel dengan composite FK, ~12 endpoint, argon2id, rotasi token dengan deteksi reuse, RBAC, dan dua harness test — saya pecah menjadi **empat**, dengan urutan mengikat:
+
+| Urut | Issue | Kenapa dipisah |
+|---|---|---|
+| 1 | Schema `0002` + tenant context + pola repository + test katalog | Menetapkan pola yang ditiru **seluruh** issue berikutnya. Sama seperti issue #1 di Phase 0: PR yang menetapkan konvensi layak direview tersendiri, sebelum ada yang menumpuk di atasnya. |
+| 2 | Registrasi + verifikasi email | Alur tulis pertama yang menyentuh transaksi atomik dan efek samping di luar transaksi |
+| 3 | Login + refresh rotation + logout + reset password | Siklus hidup sesi, satu kesatuan yang tidak masuk akal dipecah |
+| 4 | RBAC + invitation + penonaktifan membership + **harness isolasi** | Otorisasi butuh endpoint dari #2 dan #3 untuk diuji |
+
+Ini **penyimpangan dari peta session di freeze**, dicatat di sini agar terlihat. Bila Anda lebih memilih tiga PR, katakan saat review — issue tinggal digabung.
+
+Rincian: [`issues.md`](./issues.md)
+
+---
+
+## Bukan tujuan phase ini
+
+- **Bukan** membangun UI apapun — seluruh verifikasi lewat test dan `curl`
+- **Bukan** mengoptimasi query — belum ada volume untuk diukur
+- **Bukan** menyiapkan struktur untuk Lead yang "sudah pasti datang" di Phase 2 (Aturan #27, #28)

--- a/docs/phases/01-auth-organization/td.md
+++ b/docs/phases/01-auth-organization/td.md
@@ -1,0 +1,473 @@
+# Phase 1 — Auth & Organization · Technical Design
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+>
+> Memuat **delta** untuk Phase 1. Yang sudah ada di [`freeze.md`](../../architecture/freeze.md), [`multi-tenancy.md`](../../architecture/multi-tenancy.md), [`api.md`](../../architecture/api.md), dan `.claude/skills/jualin-backend/` **tidak diulang** — hanya dirujuk.
+
+---
+
+## 1. Schema — migration `0002_identity`
+
+Spesifikasi kolom lengkap ada di **[freeze bagian 8.3](../../architecture/freeze.md)**. Bagian ini hanya memuat ringkasan dan hal yang freeze belum tetapkan.
+
+| Tabel | Kelas | Catatan |
+|---|---|---|
+| `organizations` | tenant root | `timezone` default `Asia/Jakarta` |
+| `users` | **global** | Tanpa `organization_id`. `email` UNIQUE + `CHECK (email = lower(email))` |
+| `memberships` | tenant-scoped | **Jangkar composite FK seluruh database** |
+| `subscriptions` | tenant-scoped | Versi minimal: `plan_code='free'`, tanpa mesin limit |
+| `invitations` | tenant-scoped | `role <> 'owner'` |
+| `email_verification_tokens` | global | Terikat user, bukan org |
+| `password_reset_tokens` | global | Bentuk sama, **tabel terpisah** — jangan digabung |
+| `refresh_tokens` | session | Terikat membership + organization |
+| `audit_logs` | tenant-scoped | Append-only |
+
+### Yang freeze belum tetapkan — diputuskan di sini
+
+| Hal | Keputusan |
+|---|---|
+| `memberships` index untuk login | `CREATE INDEX ix_memberships_user ON memberships (user_id) WHERE deleted_at IS NULL` — dipakai resolusi membership saat login |
+| `refresh_tokens` index | `ix_refresh_tokens_family (family_id)` untuk revoke-family · `uq_refresh_tokens_hash (token_hash)` UNIQUE |
+| Token hash | **SHA-256**, bukan argon2 — alasan identik [ADR-004](../../decisions/ADR-004-api-key-format.md): token di-generate `crypto/rand` (256-bit), sehingga hash lambat tidak menambah keamanan tapi memperlambat setiap refresh |
+| Panjang token | 32 byte `crypto/rand`, di-encode base64url tanpa padding |
+| `users.password_hash` | `NOT NULL`. User hanya dibuat saat registrasi atau penerimaan undangan oleh orang baru — keduanya menyetel password. |
+
+### Larangan yang berlaku pada migration ini
+
+- **Tidak ada** tabel domain CRM (`leads`, dst.) — Phase 2
+- **Tidak ada** `UNIQUE(user_id)` pada `memberships` — [ADR-007](../../decisions/ADR-007-user-organization-cardinality.md), disengaja
+- Setiap FK ke tabel tenant-scoped **wajib composite** (Aturan #3)
+
+---
+
+## 2. Config — variabel baru
+
+| Variabel | Default | Wajib | Catatan |
+|---|---|---|---|
+| `JWT_SECRET` | — | ✅ | Minimal 32 byte. Divalidasi saat boot (Aturan #36). |
+| `ACCESS_TOKEN_TTL` | `15m` | — | |
+| `REFRESH_TOKEN_TTL_DASHBOARD` | `720h` (30 hari) | — | |
+| `REFRESH_TOKEN_TTL_MOBILE` | `2160h` (90 hari) | — | Lebih panjang, sesuai freeze 5.6 |
+| `APP_BASE_URL` | `http://localhost:3000` | — | Basis tautan di email |
+| `MAIL_FROM` | `no-reply@localhost` | — | |
+| `MAIL_PROVIDER` | `log` | — | `log` \| (provider sungguhan menyusul) |
+| `COOKIE_DOMAIN` | kosong | — | Kosong = host-only cookie, benar untuk localhost |
+| `COOKIE_SECURE` | `false` di development | — | **Wajib `true`** saat `APP_ENV=production` — divalidasi saat boot |
+
+> `COOKIE_SECURE=false` di production adalah kesalahan konfigurasi yang mengirim token lewat HTTP polos. Validasi config **menolak** kombinasi itu, konsisten dengan Aturan #36.
+
+---
+
+## 3. Password — argon2id
+
+`golang.org/x/crypto/argon2`.
+
+| Parameter | Nilai |
+|---|---|
+| Varian | `argon2id` |
+| Memory | 19 MiB (`19456`) |
+| Iterations | 2 |
+| Parallelism | 1 |
+| Salt | 16 byte `crypto/rand` |
+| Key length | 32 byte |
+
+Disimpan dalam **format PHC**: `$argon2id$v=19$m=19456,t=2,p=1$<salt-b64>$<hash-b64>`
+
+> Parameter ikut tersimpan di dalam string hash, sehingga menaikkannya nanti tidak memerlukan migration — verifikasi membaca parameter dari hash yang tersimpan, dan re-hash saat login berikutnya bila parameternya lebih rendah dari yang sekarang.
+
+**Verifikasi wajib `subtle.ConstantTimeCompare`.**
+
+### Kebijakan password
+
+| Aturan | Nilai |
+|---|---|
+| Panjang minimum | 12 karakter |
+| Aturan komposisi | **Tidak ada** — NIST SP 800-63B |
+| Cek daftar bocor (HIBP) | **Ditunda** — butuh panggilan HTTP eksternal; dicatat sebagai kandidat, bukan cakupan Phase 1 |
+
+---
+
+## 4. Token
+
+### Access token — JWT
+
+`github.com/golang-jwt/jwt/v5`, algoritma **HS256** (satu service menerbitkan dan memverifikasi; asimetris tidak memberi manfaat di sini).
+
+```json
+{
+  "sub": "<user_id>",
+  "org": "<organization_id>",
+  "mem": "<membership_id>",
+  "role": "owner|admin|manager|employee",
+  "iat": 1755500000,
+  "exp": 1755500900,
+  "jti": "<uuidv7>"
+}
+```
+
+> `org` dan `mem` ada **di dalam token**, bukan dikirim client. Ini penegakan Aturan #5 di level kriptografi: `organization_id` tidak bisa dipalsukan tanpa memalsukan tanda tangan token.
+
+### Refresh token — opaque
+
+| Aspek | Ketentuan |
+|---|---|
+| Bentuk | 32 byte `crypto/rand`, base64url |
+| Disimpan | SHA-256 di `refresh_tokens.token_hash` |
+| Lookup | Langsung by hash (deterministik — tidak perlu pola `key_id` seperti API key) |
+| Rotasi | Setiap refresh menerbitkan token baru, menyetel `replaced_by_id` pada yang lama |
+
+### Deteksi penggunaan ulang
+
+```
+Refresh diterima
+  ├── token tidak ditemukan            → 401
+  ├── token kedaluwarsa                → 401
+  ├── token sudah punya replaced_by_id
+  │   atau revoked_at                  → 🚨 REVOKE SELURUH family_id
+  │                                       + audit log + 401
+  └── token valid                      → terbitkan pasangan baru, rotasi
+```
+
+Token yang sudah dirotasi lalu dipakai lagi berarti **satu dari dua pihak memegang salinan curian**. Karena tidak mungkin tahu yang mana, seluruh family dicabut dan keduanya dipaksa login ulang.
+
+---
+
+## 5. Dashboard vs Mobile — dua cara mengirim token
+
+Freeze mensyaratkan token dashboard di cookie `HttpOnly` (Aturan #25) sementara mobile memakai secure storage. Endpoint-nya sama, jadi request harus menyatakan jenis client — dan `refresh_tokens.client` sudah ada di schema untuk itu.
+
+```
+POST /v1/auth/login  { email, password, client: "dashboard" | "mobile" }
+```
+
+| `client` | Response |
+|---|---|
+| `dashboard` | Set cookie `HttpOnly; Secure; SameSite=Lax` untuk access + refresh. **Body tidak memuat token sama sekali.** |
+| `mobile` | Token di body. **Tidak ada cookie yang di-set.** |
+
+> Ini membuat Aturan #25 **struktural, bukan imbauan**: dashboard secara harfiah tidak pernah menerima token dalam bentuk yang bisa ditaruh di `localStorage`, karena ia tidak pernah melihatnya.
+
+### CSRF — konsekuensi wajib dari cookie
+
+Karena cookie dikirim otomatis oleh browser, endpoint yang menerima autentikasi cookie **wajib** diproteksi CSRF (Aturan #25).
+
+| Aspek | Ketentuan |
+|---|---|
+| Pola | Double-submit token |
+| Cookie | `csrf_token` — **bukan** HttpOnly, agar bisa dibaca JavaScript |
+| Header | `X-CSRF-Token` wajib pada semua request non-GET yang terautentikasi **lewat cookie** |
+| Perbandingan | `subtle.ConstantTimeCompare` |
+| Dikecualikan | Request yang terautentikasi lewat `Authorization: Bearer` (mobile) — bearer token tidak dikirim otomatis browser, jadi tidak bisa di-CSRF |
+
+> Meski dashboard baru dibangun di Phase 3, cookie sudah **diterbitkan** sejak Phase 1. Menunda CSRF berarti meninggalkan lubang terbuka selama dua phase.
+
+---
+
+## 6. Endpoint
+
+Seluruhnya berprefix `/v1` (Aturan #33). Bentuk response mengikuti [`api.md`](../../architecture/api.md).
+
+### Auth — publik
+
+| Method | Path | Isi |
+|---|---|---|
+| `POST` | `/v1/auth/register` | `{organization_name, full_name, email, password}` → 201 |
+| `POST` | `/v1/auth/verify-email` | `{token}` → 200 |
+| `POST` | `/v1/auth/verify-email/resend` | `{email}` → 202 (selalu, lihat catatan enumerasi) |
+| `POST` | `/v1/auth/login` | `{email, password, client, organization_id?}` → 200 |
+| `POST` | `/v1/auth/refresh` | Cookie atau `{refresh_token}` → 200 |
+| `POST` | `/v1/auth/logout` | → 204, mencabut refresh token yang dipakai |
+| `POST` | `/v1/auth/password/forgot` | `{email}` → 202 (selalu) |
+| `POST` | `/v1/auth/password/reset` | `{token, password}` → 200, **mencabut seluruh sesi user** |
+
+### Auth — terautentikasi
+
+| Method | Path | Isi |
+|---|---|---|
+| `GET` | `/v1/me` | Profil + membership aktif + organization |
+
+### Invitation
+
+| Method | Path | Role | Isi |
+|---|---|---|---|
+| `POST` | `/v1/invitations` | owner, admin | `{email, role}` — `role <> owner` |
+| `GET` | `/v1/invitations` | owner, admin | Daftar yang masih tertunda |
+| `DELETE` | `/v1/invitations/{id}` | owner, admin | Batalkan |
+| `GET` | `/v1/invitations/token/{token}` | publik | `{organization_name, email, user_exists}` |
+| `POST` | `/v1/invitations/accept` | publik **atau** terautentikasi | Bercabang — lihat 6.1 |
+
+### Membership
+
+| Method | Path | Role | Isi |
+|---|---|---|---|
+| `GET` | `/v1/memberships` | owner, admin, manager | Daftar anggota organization |
+| `PATCH` | `/v1/memberships/{id}` | owner, admin¹ | Ubah role |
+| `DELETE` | `/v1/memberships/{id}` | owner, admin¹ | Nonaktifkan (soft delete) |
+
+¹ Admin tidak boleh menyentuh Owner, tidak boleh mengangkat siapapun jadi Owner (freeze 6.2)
+
+### 6.1 Penerimaan undangan — dua cabang (B4)
+
+```
+POST /v1/invitations/accept
+
+  ├── email belum punya user   → body: {token, full_name, password}
+  │                              buat user (email_verified_at = now) + membership
+  │
+  └── email SUDAH punya user   → WAJIB terautentikasi (cookie/bearer)
+                                 body: {token}
+                                 verifikasi: user login == email yang diundang
+                                 tambah membership
+```
+
+**Larangan mutlak pada cabang kedua:** tidak boleh menerima `password` dan tidak boleh menyetel password. Bila diizinkan, siapapun yang bisa mengundang sebuah alamat email bisa menyetel ulang password pemiliknya — undangan menjadi jalur pengambilalihan akun.
+
+> Ini **wajib punya test keamanan tersendiri**, bukan sekadar dicatat (freeze bagian 7).
+
+### 6.2 Login saat user punya > 1 membership (B2)
+
+```
+409 Conflict
+{
+  "error": {
+    "code": "organization_selection_required",
+    "message": "Pilih organization untuk melanjutkan.",
+    "organizations": [{"id": "...", "name": "..."}]
+  }
+}
+```
+
+Client memanggil ulang `/v1/auth/login` dengan `organization_id` terisi.
+
+> **Perluasan yang disengaja terhadap envelope error di `api.md`**: `error` boleh membawa field domain `organizations` untuk kasus ini. Alternatifnya — alur dua langkah dengan token seleksi berumur pendek — menambah tabel dan endpoint untuk cabang yang, menurut [ADR-007](../../decisions/ADR-007-user-organization-cardinality.md), dialami di bawah 1% pengguna. `api.md` diperbarui saat issue ini dikerjakan.
+
+### 6.3 Mencegah enumerasi email
+
+`register`, `verify-email/resend`, dan `password/forgot` **selalu** mengembalikan response yang sama, terlepas dari apakah email itu ada.
+
+| Endpoint | Perilaku |
+|---|---|
+| `register` dengan email yang sudah ada | 409 `email_already_registered` — **pengecualian sadar**: registrasi memang harus memberi tahu, atau pengguna terjebak pada form yang gagal diam-diam. Diimbangi rate limit per IP. |
+| `verify-email/resend` | 202 selalu. Email hanya benar-benar dikirim bila akunnya ada dan belum terverifikasi. |
+| `password/forgot` | 202 selalu. |
+
+---
+
+## 7. Tenant context & middleware
+
+```
+RequestID → Logging → Recovery → [Auth] → [CSRF] → [RBAC] → Handler
+```
+
+```go
+type Context struct {
+    OrganizationID uuid.UUID
+    PrincipalType  PrincipalType // user | api_key | public_form | system
+    MembershipID   *uuid.UUID
+    UserID         *uuid.UUID
+    Role           Role
+    APIKeyID       *uuid.UUID
+    RequestID      string
+}
+```
+
+Di Phase 1 hanya `PrincipalType = user` yang terwujud. Field `APIKeyID` tetap ada agar bentuknya tidak berubah saat Phase 4 — **satu-satunya** future-proofing yang diizinkan di sini, dan biayanya satu field nil.
+
+`organization_id` **selalu** dari klaim token. Tidak ada DTO yang boleh punya field itu (Aturan #5).
+
+---
+
+## 8. Repository — pola yang ditiru seluruh phase berikutnya
+
+```go
+func (r *MembershipRepository) FindByID(
+    ctx context.Context,
+    t tenant.Context,
+    id uuid.UUID,
+) (*Membership, error)
+```
+
+| Aturan | |
+|---|---|
+| `tenant.Context` **selalu** parameter kedua | Aturan #4 |
+| `organization_id` di-inject **di dalam** repository | Bukan diserahkan ke caller |
+| Method tanpa tenant **tidak boleh ada** | Bukan sekadar tidak dipakai |
+| Resource tenant lain → `ErrNotFound` (404) | Aturan #6 — **tidak pernah** 403 |
+
+**Pengecualian yang harus ditulis eksplisit:** `users` dan tabel token bersifat global. Repository-nya **tidak** menerima `tenant.Context` — dan justru karena itu, setiap method di sana wajib punya komentar yang menyatakan kenapa ia dikecualikan. Pengecualian tanpa alasan tertulis akan disalin ke tempat yang salah.
+
+---
+
+## 9. RBAC
+
+Matriks lengkap: [freeze bagian 6.2](../../architecture/freeze.md).
+
+Implementasi: enum action + fungsi tunggal, **bukan** tabel permission.
+
+```go
+authz.Require(t tenant.Context, action Action) error
+```
+
+### Empat aturan yang harus punya test tersendiri
+
+| # | Aturan |
+|---|---|
+| 1 | Employee hanya melihat resource miliknya — ditegakkan di **repository**, bukan handler |
+| 2 | Owner terakhir tidak bisa menghapus atau menurunkan dirinya sendiri |
+| 3 | Tidak ada yang bisa mengubah role dirinya sendiri |
+| 4 | Admin tidak bisa menyentuh Owner, tidak bisa mengangkat Owner |
+
+Aturan #2 dan #3 adalah eskalasi hak akses bila luput — bukan kenyamanan UI.
+
+---
+
+## 10. Email
+
+```go
+type Mailer interface {
+    Send(ctx context.Context, msg Message) error
+}
+```
+
+| Implementasi | Kapan |
+|---|---|
+| `LogMailer` | Development & test — mencatat isi email ke log, tidak mengirim |
+| Provider sungguhan | Menyusul saat domain + provider siap (item lead-time di `STATUS.md`) |
+
+> Interface dengan satu implementasi biasanya melanggar Aturan #27. Dibenarkan di sini karena implementasi kedua **sudah pasti datang dan sudah diketahui bentuknya** — dan tanpa interface ini, Phase 1 terblokir menunggu keputusan domain yang berada di luar kendali phase ini.
+
+**Pengiriman selalu setelah commit** (Aturan #32, [ADR-010](../../decisions/ADR-010-fail-fast-startup.md) bagian efek samping). Kegagalan kirim dicatat sebagai error terstruktur dan **tidak** membatalkan operasi yang sudah commit.
+
+Email yang dikirim di Phase 1: verifikasi, kirim ulang verifikasi, undangan, reset password.
+
+---
+
+## 11. Rate limiting
+
+In-memory (freeze: tanpa Redis di MVP), di balik interface agar bisa ditukar.
+
+| Endpoint | Batas |
+|---|---|
+| `login` | per IP **dan** per email — backoff progresif, **tanpa** lockout permanen |
+| `register` | per IP |
+| `verify-email/resend` | per email **dan** per IP (Aturan #34) |
+| `password/forgot` | per email **dan** per IP (Aturan #34) |
+| `invitations` (create) | per organization |
+
+> Lockout permanen ditolak: ia mengubah brute-force menjadi serangan DoS terhadap pengguna yang sah.
+
+Header `X-RateLimit-*` + `Retry-After` dikirim sejak sekarang ([`api.md`](../../architecture/api.md)).
+
+---
+
+## 12. Audit log
+
+Tenant-scoped, append-only. Aksi yang dicatat di Phase 1:
+
+```
+user.registered          email.verified
+auth.login               auth.logout
+auth.refresh_reused      ← 🚨 keamanan
+password.reset_requested password.reset_completed
+invitation.created       invitation.accepted        invitation.revoked
+membership.role_changed  membership.deactivated
+```
+
+**Login gagal TIDAK masuk audit log** — ia belum punya tenant, dan `audit_logs.organization_id` adalah `NOT NULL`. Login gagal masuk **log aplikasi** (freeze bagian 7, keputusan default).
+
+---
+
+## 13. Error code baru
+
+Ditambahkan ke katalog di [`api.md`](../../architecture/api.md):
+
+| HTTP | `code` |
+|---|---|
+| 401 | `invalid_credentials` |
+| 403 | `email_not_verified` |
+| 409 | `email_already_registered` |
+| 409 | `organization_selection_required` |
+| 400 | `invalid_token` — verifikasi / reset / undangan tidak valid atau kedaluwarsa |
+| 409 | `invitation_already_accepted` |
+| 401 | `authentication_required` — cabang undangan untuk user yang sudah ada |
+| 403 | `csrf_token_invalid` |
+| 409 | `last_owner_cannot_be_removed` |
+| 429 | `rate_limited` |
+
+---
+
+## 14. Rencana test
+
+### Test katalog — penegak otomatis Aturan #1 & #2
+
+```sql
+-- Setiap tabel tenant-scoped wajib punya organization_id
+-- DAN UNIQUE (id, organization_id)
+-- Allowlist global: users, email_verification_tokens,
+--                   password_reset_tokens, goose_db_version
+```
+
+Sekali ditulis, ia menangkap **setiap tabel baru** yang lupa mengikuti konvensi — untuk selamanya, tanpa ada yang perlu mengingatnya saat review.
+
+### Harness isolasi tenant — [multi-tenancy.md lapis 4](../../architecture/multi-tenancy.md)
+
+Generik atas daftar route, **bukan** manual per endpoint.
+
+| # | Kasus | Menjaga |
+|---|---|---|
+| 1 | Baca resource tenant lain → 404 | Lapis 1 |
+| 2 | Ubah/hapus resource tenant lain → 404 | Lapis 1 |
+| 3 | Menunjuk membership tenant lain di body → ditolak **database** | Lapis 2 |
+| 4 | **User dengan dua membership** tidak melihat data org yang tidak aktif di token | [ADR-007](../../decisions/ADR-007-user-organization-cardinality.md) |
+
+**Kriteria kualitas:** harness harus **terbukti bisa gagal**. Hapus `organization_id` dari satu query dengan sengaja; bila test tetap hijau, harness-nya belum benar.
+
+> Test isolasi yang selalu hijau karena tidak benar-benar menguji apapun **lebih berbahaya daripada tidak ada test** — ia memberi rasa aman palsu pada seluruh session berikutnya.
+
+### Test keamanan wajib
+
+| Skenario | Harapan |
+|---|---|
+| Undangan untuk email yang sudah punya akun, tanpa autentikasi | 401 — **tidak pernah** menyetel password |
+| Refresh token dipakai ulang setelah rotasi | Seluruh family dicabut |
+| Owner terakhir menghapus dirinya | 409 |
+| Mengubah role diri sendiri | 403 |
+| Request cookie tanpa `X-CSRF-Token` | 403 |
+| `COOKIE_SECURE=false` + `APP_ENV=production` | Gagal saat boot |
+
+Semua test yang menyentuh database memakai `dbtest` dari Phase 0.
+
+---
+
+## 15. Risiko teknis
+
+| Risiko | Mitigasi |
+|---|---|
+| **Harness isolasi yang tidak benar-benar menguji** — risiko terbesar phase ini | Kriteria "terbukti bisa gagal" di atas dijadikan bagian acceptance, bukan catatan |
+| **Argon2 memperlambat test** — 19 MiB × banyak test | Parameter lebih rendah khusus test lewat build tag/env; parameter produksi tetap dipakai di test yang memverifikasi hashing itu sendiri |
+| **Alur undangan bercabang** — cabang yang salah = pengambilalihan akun | Test keamanan tersendiri (14), bukan hanya test alur bahagia |
+| **Deteksi reuse token salah positif** — race saat client mengirim dua refresh bersamaan | Rotasi dalam satu transaksi + `SELECT ... FOR UPDATE` pada baris token; race yang tersisa memang seharusnya dianggap mencurigakan |
+| **Cookie + bearer di endpoint yang sama** membingungkan aturan CSRF | CSRF ditegakkan **hanya** untuk request yang terautentikasi lewat cookie — diputuskan di middleware auth, bukan ditebak per handler |
+
+---
+
+## 16. Yang berubah pada dokumentasi
+
+| Berkas | Perubahan |
+|---|---|
+| [`api.md`](../../architecture/api.md) | Katalog error (13) + perluasan envelope untuk `organization_selection_required` (6.2) |
+| `architecture/authentication.md` | **Dibuat** — tiga jalur, token, rotasi, cookie vs bearer, CSRF |
+| `architecture/authorization.md` | **Dibuat** — matriks RBAC yang terwujud + empat aturan bertest |
+| [`multi-tenancy.md`](../../architecture/multi-tenancy.md) | Diperbarui dengan harness yang benar-benar dibangun |
+| `STATUS.md` | Phase 1 selesai, utang teknis |
+| `phases/01-auth-organization/notes.md` | Satu bagian per issue |
+
+---
+
+## 17. Kewajiban yang diteruskan ke Phase 2
+
+Ditulis di sini agar tidak bergantung pada ingatan:
+
+> **Penonaktifan membership wajib menolak berjalan bila masih ada lead terbuka**, kecuali disertai keputusan eksplisit (reassign atau lepas assignment) — [freeze bagian 2.3](../../architecture/freeze.md).
+>
+> Di Phase 1 aturan ini **belum bisa ditegakkan** karena tabel `leads` belum ada. Yang sudah wajib sekarang hanyalah pencabutan sesi. Titik penegakannya ditambahkan bersama `leads` di Phase 2.


### PR DESCRIPTION
Refs #8 #9 #10 #11

## Apa yang berubah

Membuka **Phase 1 — Auth & Organization** sesuai `docs/workflow.md` bagian 1.

| Berkas | Isi |
|---|---|
| `docs/phases/01-auth-organization/prd.md` | Tujuan, 8 kebutuhan, **11 acceptance criteria**, di luar cakupan |
| `docs/phases/01-auth-organization/td.md` | 17 bagian — schema delta, config, argon2id, token, cookie vs bearer, CSRF, endpoint, tenant context, repository, RBAC, email, rate limit, audit, error code, rencana test, risiko |
| `docs/phases/01-auth-organization/issues.md` | Indeks #8–#11 tanpa kolom status |
| `docs/STATUS.md` | Phase 1 PRD/TD ✅, "Berikutnya" menunjuk #8 |

Issue #8–#11 sudah dibuat di milestone Phase 1. Belum ada kode.

## Penyimpangan dari rencana

**Freeze memetakan Phase 1 sebagai tiga session; di sini dipecah menjadi empat issue.**

Isinya: 9 tabel dengan composite FK, ~12 endpoint, argon2id, rotasi refresh token dengan deteksi reuse, RBAC 4 role, dan dua harness test. Tiga PR untuk itu terlalu besar untuk direview teliti.

Urutan mengikat: `#8 schema & pola → #9 registrasi → #10 sesi → #11 otorisasi & harness`.

Dicatat di `prd.md` bagian *Pembagian issue*. **Bila Anda lebih memilih tiga PR, katakan saat review.**

## Keputusan yang TD tetapkan, yang freeze belum

| Hal | Keputusan | Kenapa |
|---|---|---|
| **`client` field pada login** | `dashboard` → cookie HttpOnly, **token tidak ada di body sama sekali**. `mobile` → body, tanpa cookie. | Membuat Aturan #25 **struktural**: dashboard secara harfiah tidak pernah menerima token dalam bentuk yang bisa ditaruh di `localStorage`. Kolom `refresh_tokens.client` sudah ada di schema untuk ini. |
| **CSRF di Phase 1, bukan Phase 3** | Double-submit token, wajib untuk request cookie non-GET, dikecualikan untuk bearer | Cookie sudah **diterbitkan** sejak Phase 1. Menunda CSRF ke Phase 3 meninggalkan lubang terbuka selama dua phase. |
| **`COOKIE_SECURE=false` + production → gagal boot** | Divalidasi saat startup | Konsisten Aturan #36. Salah konfigurasi ini mengirim token lewat HTTP polos. |
| **Refresh token pakai SHA-256, bukan argon2** | Alasan identik ADR-004 | Token 256-bit dari `crypto/rand` — hash lambat tidak menambah keamanan, hanya memperlambat setiap refresh. |
| **Login > 1 membership** | 409 `organization_selection_required`, error body membawa daftar organization | **Perluasan sadar** terhadap envelope error di `api.md`. Alternatifnya (token seleksi + endpoint kedua) menambah tabel dan endpoint untuk cabang yang menurut ADR-007 dialami <1% pengguna. |
| **`Mailer` interface dengan satu implementasi** | `LogMailer` sekarang, provider sungguhan menyusul | Biasanya melanggar Aturan #27. Dibenarkan karena implementasi kedua sudah pasti datang, dan tanpanya Phase 1 terblokir menunggu keputusan domain di luar kendali phase ini. |

## Yang sengaja tertahan

**Aturan "reassign lead terbuka" saat menonaktifkan membership** — freeze mensyaratkannya, tapi tabel `leads` baru ada di Phase 2. Yang wajib sekarang hanyalah pencabutan sesi. Kewajiban ini ditulis eksplisit di TD §17 agar tidak bergantung pada ingatan.

## Cara menguji

```bash
gh issue list --milestone "Phase 1 — Auth & Organization"
```

Yang perlu direview: apakah pembagian empat issue masuk akal, apakah 11 acceptance criteria cukup tegas, dan apakah keputusan di tabel di atas — terutama `client` field dan CSRF di Phase 1 — sudah tepat.

## Checklist

- [x] Tidak ada rahasia ter-commit
- [x] `docs/STATUS.md` diperbarui
- [x] Tidak ada kolom status di `issues.md` (ADR-008)
- [x] PR memakai `Refs`, bukan `Closes`
- [ ] ~~Test~~ — belum ada kode
- [ ] ~~Isolasi tenant~~ — harness dibangun di #11

## Catatan untuk reviewer

Paling ingin dikonfirmasi:

1. **Pembagian empat issue** — penyimpangan dari peta session di freeze
2. **`client: dashboard|mobile` pada login** — ini menentukan bentuk endpoint yang akan dipakai dashboard dan mobile selamanya
3. **Perluasan envelope error** untuk `organization_selection_required` — satu-satunya tempat `error` membawa field domain
