### PR TITLE
feat(be): atomic registration, argon2id, and email verification

### DIFF
--- a/crm_be/cmd/api/health_ready_test.go
+++ b/crm_be/cmd/api/health_ready_test.go
@@ -14,7 +14,7 @@ import (
 func TestHealthReady_ReturnsOK_WhenDatabaseReachable(t *testing.T) {
 	pool := dbtest.NewPool(t)
 
-	r := newRouter(testLogger(), pool)
+	r := newRouter(testLogger(), pool, testConfig())
 	req := httptest.NewRequest(http.MethodGet, "/health/ready", nil)
 	w := httptest.NewRecorder()
 
@@ -47,7 +47,7 @@ func TestHealthReady_Returns503_WhenDatabaseUnreachable(t *testing.T) {
 	}
 	t.Cleanup(pool.Close)
 
-	r := newRouter(testLogger(), pool)
+	r := newRouter(testLogger(), pool, testConfig())
 	req := httptest.NewRequest(http.MethodGet, "/health/ready", nil)
 	w := httptest.NewRecorder()
 
@@ -80,7 +80,7 @@ func TestHealth_UnaffectedByDatabaseState(t *testing.T) {
 	}
 	t.Cleanup(pool.Close)
 
-	r := newRouter(testLogger(), pool)
+	r := newRouter(testLogger(), pool, testConfig())
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 

--- a/crm_be/cmd/api/main.go
+++ b/crm_be/cmd/api/main.go
@@ -15,10 +15,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Pravasta/jualin-crm/crm_be/internal/auth"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/config"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/logger"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/mailer"
 )
 
 const readyPingTimeout = 2 * time.Second
@@ -47,7 +49,7 @@ func main() {
 	}
 	defer pool.Close()
 
-	router := newRouter(log, pool)
+	router := newRouter(log, pool, cfg)
 
 	srv := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.HTTPPort),
@@ -67,12 +69,16 @@ func main() {
 	waitForShutdown(srv, log, cfg.HTTPShutdownTimeout)
 }
 
-func newRouter(log *slog.Logger, pool *pgxpool.Pool) *gin.Engine {
+func newRouter(log *slog.Logger, pool *pgxpool.Pool, cfg *config.Config) *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.HandleMethodNotAllowed = true
 
 	r.Use(httpx.RequestID(), httpx.Logging(log), httpx.Recovery(log))
+
+	mail := newMailer(cfg, log)
+	authService := auth.NewService(pool, mail, log, cfg.AppBaseURL)
+	auth.NewHandler(authService).RegisterRoutes(r)
 
 	r.NoRoute(func(c *gin.Context) {
 		httpx.RespondError(c, http.StatusNotFound, "not_found", "Route tidak ditemukan.")
@@ -106,6 +112,19 @@ func newRouter(log *slog.Logger, pool *pgxpool.Pool) *gin.Engine {
 	})
 
 	return r
+}
+
+// newMailer picks the mailer implementation for cfg.MailProvider.
+// "log" (LogMailer) is the only option today — config.validate rejects
+// any other value, so the default case here is unreachable, not a
+// silent fallback.
+func newMailer(cfg *config.Config, log *slog.Logger) mailer.Mailer {
+	switch cfg.MailProvider {
+	case "log":
+		return mailer.NewLogMailer(log)
+	default:
+		panic(fmt.Sprintf("unreachable: unknown MAIL_PROVIDER %q passed config validation", cfg.MailProvider))
+	}
 }
 
 func waitForShutdown(srv *http.Server, log *slog.Logger, timeout time.Duration) {

--- a/crm_be/cmd/api/router_test.go
+++ b/crm_be/cmd/api/router_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/config"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
 )
 
@@ -18,12 +19,23 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+// testConfig returns a minimal config sufficient for newRouter — no
+// DATABASE_URL is set because these router-level tests never touch the
+// database directly.
+func testConfig() *config.Config {
+	return &config.Config{
+		AppEnv:       "development",
+		MailProvider: "log",
+		AppBaseURL:   "http://localhost:3000",
+	}
+}
+
 func TestHealth_ReturnsOK(t *testing.T) {
 	// nil pool is safe here: none of these tests hit /health/ready, and
 	// newRouter only closes over the pool — it never dereferences it at
 	// build time. /health/ready's DB-down path needs a real database and
 	// is covered by the testcontainers harness in issue #3.
-	r := newRouter(testLogger(), nil)
+	r := newRouter(testLogger(), nil, testConfig())
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 
@@ -51,7 +63,7 @@ func TestUnknownRoute_Returns404WithErrorEnvelope(t *testing.T) {
 	// newRouter only closes over the pool — it never dereferences it at
 	// build time. /health/ready's DB-down path needs a real database and
 	// is covered by the testcontainers harness in issue #3.
-	r := newRouter(testLogger(), nil)
+	r := newRouter(testLogger(), nil, testConfig())
 	req := httptest.NewRequest(http.MethodGet, "/this-does-not-exist", nil)
 	w := httptest.NewRecorder()
 
@@ -79,7 +91,7 @@ func TestWrongMethod_Returns405(t *testing.T) {
 	// newRouter only closes over the pool — it never dereferences it at
 	// build time. /health/ready's DB-down path needs a real database and
 	// is covered by the testcontainers harness in issue #3.
-	r := newRouter(testLogger(), nil)
+	r := newRouter(testLogger(), nil, testConfig())
 	req := httptest.NewRequest(http.MethodPost, "/health", nil)
 	w := httptest.NewRecorder()
 

--- a/crm_be/go.mod
+++ b/crm_be/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/pressly/goose/v3 v3.27.3
-	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.44.0
+	golang.org/x/crypto v0.54.0
 )
 
 require (
@@ -76,6 +76,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.6 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
+	github.com/testcontainers/testcontainers-go v0.44.0 // indirect
 	github.com/tklauser/go-sysconf v0.4.0 // indirect
 	github.com/tklauser/numcpus v0.12.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
@@ -89,7 +90,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect
-	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/crm_be/internal/auditlog/auditlog.go
+++ b/crm_be/internal/auditlog/auditlog.go
@@ -1,0 +1,24 @@
+// Package auditlog records sensitive actions. Entries are append-only —
+// no update or delete path exists anywhere in this codebase, and none
+// should ever be added.
+package auditlog
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+type Entry struct {
+	ID                uuid.UUID
+	OrganizationID    uuid.UUID
+	ActorType         tenant.PrincipalType
+	ActorMembershipID *uuid.UUID
+	Action            string
+	EntityType        *string
+	EntityID          *uuid.UUID
+	RequestID         *string
+	CreatedAt         time.Time
+}

--- a/crm_be/internal/auditlog/repository.go
+++ b/crm_be/internal/auditlog/repository.go
@@ -1,0 +1,48 @@
+package auditlog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+type Repository struct {
+	q db.Querier
+}
+
+func New(q db.Querier) *Repository {
+	return &Repository{q: q}
+}
+
+// Record inserts one audit log entry. It has no failed-login counterpart
+// on purpose — audit_logs.organization_id is NOT NULL, and a failed
+// login attempt has no tenant to attach to yet (freeze bagian 7,
+// keputusan default). Failed logins go to the application logger, not
+// here.
+func (r *Repository) Record(
+	ctx context.Context,
+	t tenant.Context,
+	actorMembershipID *uuid.UUID,
+	action string,
+) error {
+	id := uuid.Must(uuid.NewV7())
+
+	const q = `
+		INSERT INTO audit_logs (id, organization_id, actor_type, actor_membership_id, action, request_id)
+		VALUES ($1, $2, $3, $4, $5, $6)`
+
+	var requestID *string
+	if t.RequestID != "" {
+		requestID = &t.RequestID
+	}
+
+	_, err := r.q.Exec(ctx, q, id, t.OrganizationID, t.PrincipalType, actorMembershipID, action, requestID)
+	if err != nil {
+		return fmt.Errorf("auditlog: record: %w", err)
+	}
+	return nil
+}

--- a/crm_be/internal/auth/handler.go
+++ b/crm_be/internal/auth/handler.go
@@ -1,0 +1,128 @@
+package auth
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/ratelimit"
+)
+
+// Rate limit figures are deliberately conservative defaults, not final
+// numbers — freeze leaves "strategi rate limit final" open until real
+// traffic exists to tune against (docs/STATUS.md). What matters now is
+// that every email-sending endpoint has *some* limit (Rule #34), not the
+// exact figure.
+const (
+	registerLimit  = 5
+	registerWindow = time.Hour
+	resendLimit    = 3
+	resendWindow   = time.Hour
+	resendIPLimit  = 10
+	resendIPWindow = time.Hour
+)
+
+// Handler wires HTTP to Service. Rate limiting is checked here rather
+// than in Service: the "per email" dimension for resend needs the
+// parsed request body, which only the handler has — Service's job is
+// business logic, not request shaping.
+type Handler struct {
+	service *Service
+
+	registerLimiter    ratelimit.Limiter
+	resendEmailLimiter ratelimit.Limiter
+	resendIPLimiter    ratelimit.Limiter
+}
+
+func NewHandler(service *Service) *Handler {
+	return &Handler{
+		service:            service,
+		registerLimiter:    ratelimit.NewFixedWindow(registerLimit, registerWindow),
+		resendEmailLimiter: ratelimit.NewFixedWindow(resendLimit, resendWindow),
+		resendIPLimiter:    ratelimit.NewFixedWindow(resendIPLimit, resendIPWindow),
+	}
+}
+
+// RegisterRoutes mounts every /v1/auth/* endpoint this issue implements.
+// Login, refresh, and password endpoints are added in #10.
+func (h *Handler) RegisterRoutes(r gin.IRouter) {
+	g := r.Group("/v1/auth")
+	g.POST("/register", h.register)
+	g.POST("/verify-email", h.verifyEmail)
+	g.POST("/verify-email/resend", h.resendVerification)
+}
+
+type registerRequest struct {
+	OrganizationName string `json:"organization_name"`
+	FullName         string `json:"full_name"`
+	Email            string `json:"email"`
+	Password         string `json:"password"`
+}
+
+func (h *Handler) register(c *gin.Context) {
+	if !h.registerLimiter.Allow("ip:" + c.ClientIP()) {
+		httpx.RespondError(c, http.StatusTooManyRequests, "rate_limited", "Terlalu banyak percobaan. Coba lagi nanti.")
+		return
+	}
+
+	var req registerRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	out, err := h.service.Register(c.Request.Context(), RegisterInput(req))
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+
+	httpx.OK(c, http.StatusCreated, gin.H{
+		"user_id":         out.UserID,
+		"organization_id": out.OrganizationID,
+	})
+}
+
+type verifyEmailRequest struct {
+	Token string `json:"token"`
+}
+
+func (h *Handler) verifyEmail(c *gin.Context) {
+	var req verifyEmailRequest
+	if err := c.ShouldBindJSON(&req); err != nil || req.Token == "" {
+		httpx.WriteError(c, invalidTokenError())
+		return
+	}
+
+	if err := h.service.VerifyEmail(c.Request.Context(), req.Token); err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+
+	httpx.OK(c, http.StatusOK, gin.H{"status": "verified"})
+}
+
+type resendVerificationRequest struct {
+	Email string `json:"email"`
+}
+
+// resendVerification always answers 202, whether or not the email exists
+// or is already verified (TD §6.3, anti-enumeration).
+func (h *Handler) resendVerification(c *gin.Context) {
+	var req resendVerificationRequest
+	if err := c.ShouldBindJSON(&req); err != nil || req.Email == "" {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "email", Code: "required"}))
+		return
+	}
+
+	if !h.resendEmailLimiter.Allow("email:"+req.Email) || !h.resendIPLimiter.Allow("ip:"+c.ClientIP()) {
+		httpx.RespondError(c, http.StatusTooManyRequests, "rate_limited", "Terlalu banyak percobaan. Coba lagi nanti.")
+		return
+	}
+
+	h.service.ResendVerification(c.Request.Context(), req.Email)
+
+	c.JSON(http.StatusAccepted, gin.H{"data": gin.H{"status": "accepted"}})
+}

--- a/crm_be/internal/auth/handler_test.go
+++ b/crm_be/internal/auth/handler_test.go
@@ -1,0 +1,170 @@
+package auth_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/auth"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+)
+
+func newTestRouter(t *testing.T) (*gin.Engine, *spyMailer) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pool := dbtest.NewPool(t)
+	m := &spyMailer{}
+	svc := auth.NewService(pool, m, testLogger(), "http://localhost:3000")
+
+	r := gin.New()
+	auth.NewHandler(svc).RegisterRoutes(r)
+	return r, m
+}
+
+func doJSON(r *gin.Engine, method, path string, body any) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(method, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestHandler_Register_ReturnsCreated(t *testing.T) {
+	r, _ := newTestRouter(t)
+
+	w := doJSON(r, http.MethodPost, "/v1/auth/register", map[string]string{
+		"organization_name": "Toko ABC",
+		"full_name":         "Budi Santoso",
+		"email":             "handler@example.com",
+		"password":          "correct horse battery staple",
+	})
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Data struct {
+			UserID         string `json:"user_id"`
+			OrganizationID string `json:"organization_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body.Data.UserID == "" || body.Data.OrganizationID == "" {
+		t.Errorf("expected non-empty user_id and organization_id, got %+v", body.Data)
+	}
+}
+
+func TestHandler_Register_DuplicateEmail_Returns409(t *testing.T) {
+	r, _ := newTestRouter(t)
+
+	payload := map[string]string{
+		"organization_name": "Toko ABC",
+		"full_name":         "Budi Santoso",
+		"email":             "dup-handler@example.com",
+		"password":          "correct horse battery staple",
+	}
+	doJSON(r, http.MethodPost, "/v1/auth/register", payload)
+	w := doJSON(r, http.MethodPost, "/v1/auth/register", payload)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body.Error.Code != "email_already_registered" {
+		t.Errorf("expected code email_already_registered, got %q", body.Error.Code)
+	}
+}
+
+func TestHandler_VerifyEmail_InvalidToken_Returns400(t *testing.T) {
+	r, _ := newTestRouter(t)
+
+	w := doJSON(r, http.MethodPost, "/v1/auth/verify-email", map[string]string{"token": "nonsense"})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_ResendVerification_AlwaysReturns202(t *testing.T) {
+	r, _ := newTestRouter(t)
+
+	// Unknown email — must still be 202 (anti-enumeration, TD §6.3).
+	w := doJSON(r, http.MethodPost, "/v1/auth/verify-email/resend", map[string]string{
+		"email": "nobody-handler@example.com",
+	})
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 even for an unknown email, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandler_Register_RateLimited proves the rate limit is actually
+// enforced at the HTTP layer, not just present in code — the acceptance
+// criterion is "rate limit terbukti aktif di test".
+func TestHandler_Register_RateLimited(t *testing.T) {
+	r, _ := newTestRouter(t)
+
+	// httptest.NewRequest defaults RemoteAddr to the same value across
+	// calls, so every request in this test shares one rate-limit key.
+	var last *httptest.ResponseRecorder
+	for i := 0; i < 6; i++ {
+		last = doJSON(r, http.MethodPost, "/v1/auth/register", map[string]string{
+			"organization_name": fmt.Sprintf("Org %d", i),
+			"full_name":         "Test User",
+			"email":             fmt.Sprintf("ratelimit-%d@example.com", i),
+			"password":          "correct horse battery staple",
+		})
+	}
+
+	if last.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected the 6th registration from the same IP within the window to be rate limited (429), got %d: %s", last.Code, last.Body.String())
+	}
+
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(last.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body.Error.Code != "rate_limited" {
+		t.Errorf("expected code rate_limited, got %q", body.Error.Code)
+	}
+}
+
+// TestHandler_ResendVerification_RateLimitedPerEmail proves the
+// per-email dimension specifically — repeatedly resending for the SAME
+// email must eventually be limited even though each request could come
+// from a different IP in principle.
+func TestHandler_ResendVerification_RateLimitedPerEmail(t *testing.T) {
+	r, _ := newTestRouter(t)
+
+	var last *httptest.ResponseRecorder
+	for i := 0; i < 4; i++ {
+		last = doJSON(r, http.MethodPost, "/v1/auth/verify-email/resend", map[string]string{
+			"email": "same-email@example.com",
+		})
+	}
+
+	if last.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected the 4th resend for the same email within the window to be rate limited, got %d: %s", last.Code, last.Body.String())
+	}
+}

--- a/crm_be/internal/auth/service.go
+++ b/crm_be/internal/auth/service.go
@@ -1,0 +1,263 @@
+// Package auth orchestrates the flows that create and verify identity:
+// registration (atomic across four tables), email verification, and
+// resend. Login, refresh, and password reset are issue #10; RBAC,
+// invitations, and membership deactivation are issue #11.
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/auditlog"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/membership"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/organization"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/mailer"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/password"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/token"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/subscription"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/user"
+)
+
+const minPasswordLength = 12
+
+type Service struct {
+	pool    *pgxpool.Pool
+	mailer  mailer.Mailer
+	logger  *slog.Logger
+	baseURL string
+}
+
+func NewService(pool *pgxpool.Pool, m mailer.Mailer, logger *slog.Logger, baseURL string) *Service {
+	return &Service{pool: pool, mailer: m, logger: logger, baseURL: baseURL}
+}
+
+type RegisterInput struct {
+	OrganizationName string
+	FullName         string
+	Email            string
+	Password         string
+}
+
+type RegisterOutput struct {
+	UserID         uuid.UUID
+	OrganizationID uuid.UUID
+}
+
+// Register creates an organization, its owner user, the owner
+// membership, and a free subscription in one transaction (freeze bagian
+// A1) — a failure at any point leaves nothing behind. The verification
+// email is sent only after that transaction commits (Rule #32); a send
+// failure is logged but never rolls back the registration.
+func (s *Service) Register(ctx context.Context, in RegisterInput) (*RegisterOutput, error) {
+	if verr := validateRegisterInput(in); verr != nil {
+		return nil, verr
+	}
+
+	hash, err := password.Hash(in.Password)
+	if err != nil {
+		return nil, fmt.Errorf("auth: register: hash password: %w", err)
+	}
+
+	rawToken, tokenHash, err := token.Generate()
+	if err != nil {
+		return nil, fmt.Errorf("auth: register: generate verification token: %w", err)
+	}
+
+	orgID := uuid.Must(uuid.NewV7())
+	userID := uuid.Must(uuid.NewV7())
+	membershipID := uuid.Must(uuid.NewV7())
+	subID := uuid.Must(uuid.NewV7())
+	verificationID := uuid.Must(uuid.NewV7())
+
+	var createdUser *user.User
+
+	txErr := db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		orgRepo := organization.New(tx)
+		userRepo := user.New(tx)
+		membershipRepo := membership.New(tx)
+		subRepo := subscription.New(tx)
+		verifyRepo := newVerificationRepository(tx)
+		auditRepo := auditlog.New(tx)
+
+		if _, err := orgRepo.Create(ctx, orgID, in.OrganizationName); err != nil {
+			return err
+		}
+
+		u, err := userRepo.Create(ctx, userID, in.Email, hash, in.FullName)
+		if err != nil {
+			return err // may be user.ErrEmailTaken — translated after InTx returns
+		}
+		createdUser = u
+
+		t := tenant.Context{OrganizationID: orgID, PrincipalType: tenant.PrincipalUser}
+
+		if _, err := membershipRepo.Create(ctx, t, membershipID, u.ID, tenant.RoleOwner); err != nil {
+			return err
+		}
+		if _, err := subRepo.CreateFree(ctx, t, subID); err != nil {
+			return err
+		}
+		if err := verifyRepo.Create(ctx, verificationID, u.ID, tokenHash); err != nil {
+			return err
+		}
+		if err := auditRepo.Record(ctx, t, &membershipID, "user.registered"); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if txErr != nil {
+		if errors.Is(txErr, user.ErrEmailTaken) {
+			return nil, &httpx.DomainError{
+				Status:  http.StatusConflict,
+				Code:    "email_already_registered",
+				Message: "Email sudah terdaftar.",
+			}
+		}
+		return nil, fmt.Errorf("auth: register: %w", txErr)
+	}
+
+	s.sendVerificationEmail(ctx, createdUser.Email, rawToken)
+
+	return &RegisterOutput{UserID: createdUser.ID, OrganizationID: orgID}, nil
+}
+
+// VerifyEmail consumes a verification token. Missing, expired, and
+// already-used tokens are all indistinguishable at the repository layer
+// (httpx.ErrNotFound) and are translated to the same invalid_token
+// response here — a client can't use response differences to enumerate
+// which case applies.
+func (s *Service) VerifyEmail(ctx context.Context, rawToken string) error {
+	hash := token.Hash(rawToken)
+
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		verifyRepo := newVerificationRepository(tx)
+		userRepo := user.New(tx)
+		membershipRepo := membership.New(tx)
+		auditRepo := auditlog.New(tx)
+
+		vt, err := verifyRepo.FindValidByHash(ctx, hash)
+		if err != nil {
+			if errors.Is(err, httpx.ErrNotFound) {
+				return invalidTokenError()
+			}
+			return err
+		}
+
+		if err := verifyRepo.MarkUsed(ctx, vt.ID); err != nil {
+			return err
+		}
+		if err := userRepo.MarkEmailVerified(ctx, vt.UserID); err != nil {
+			return err
+		}
+
+		// A freshly registered user has exactly one membership — audit
+		// logging needs an organization to attach to. This assumption
+		// holds through Phase 1; revisit once #11 makes multi-org
+		// membership common at verification time.
+		memberships, err := membershipRepo.FindActiveByUserID(ctx, vt.UserID)
+		if err != nil {
+			return err
+		}
+		if len(memberships) > 0 {
+			m := memberships[0]
+			t := tenant.Context{OrganizationID: m.OrganizationID, PrincipalType: tenant.PrincipalUser}
+			if err := auditRepo.Record(ctx, t, &m.ID, "email.verified"); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// ResendVerification always returns nil (202) regardless of whether the
+// email exists or is already verified — anti-enumeration (Rule: TD §6.3).
+// An email is only actually sent when there's a real, unverified account
+// to send it to.
+func (s *Service) ResendVerification(ctx context.Context, email string) {
+	u, err := user.New(s.pool).FindByEmail(ctx, email)
+	if err != nil {
+		return // unknown email — silently do nothing, still 202 to caller
+	}
+	if u.EmailVerifiedAt != nil {
+		return // already verified — nothing to resend
+	}
+
+	rawToken, tokenHash, err := token.Generate()
+	if err != nil {
+		s.logger.Error("failed to generate resend verification token", "err", err, "user_id", u.ID)
+		return
+	}
+
+	verificationID := uuid.Must(uuid.NewV7())
+	if err := newVerificationRepository(s.pool).Create(ctx, verificationID, u.ID, tokenHash); err != nil {
+		s.logger.Error("failed to store resend verification token", "err", err, "user_id", u.ID)
+		return
+	}
+
+	s.sendVerificationEmail(ctx, u.Email, rawToken)
+}
+
+func (s *Service) sendVerificationEmail(ctx context.Context, email, rawToken string) {
+	link := fmt.Sprintf("%s/verify-email?token=%s", s.baseURL, rawToken)
+	err := s.mailer.Send(ctx, mailer.Message{
+		To:      email,
+		Subject: "Verifikasi email Jualin CRM Anda",
+		Body:    fmt.Sprintf("Klik tautan berikut untuk memverifikasi email Anda: %s\n\nTautan berlaku 24 jam.", link),
+	})
+	if err != nil {
+		// Rule #32: send failure never rolls back work that already
+		// committed. Logged structurally so it's visible, not silent.
+		s.logger.Error("failed to send verification email", "err", err, "to", email)
+	}
+}
+
+func invalidTokenError() error {
+	return &httpx.DomainError{
+		Status:  http.StatusBadRequest,
+		Code:    "invalid_token",
+		Message: "Token tidak valid atau sudah kedaluwarsa.",
+	}
+}
+
+func validateRegisterInput(in RegisterInput) error {
+	var details []httpx.ErrorDetail
+	if in.OrganizationName == "" {
+		details = append(details, httpx.ErrorDetail{Field: "organization_name", Code: "required"})
+	}
+	if in.FullName == "" {
+		details = append(details, httpx.ErrorDetail{Field: "full_name", Code: "required"})
+	}
+	if !looksLikeEmail(in.Email) {
+		details = append(details, httpx.ErrorDetail{Field: "email", Code: "invalid_format"})
+	}
+	if len(in.Password) < minPasswordLength {
+		details = append(details, httpx.ErrorDetail{Field: "password", Code: "too_short"})
+	}
+	if len(details) > 0 {
+		return httpx.NewValidationError(details...)
+	}
+	return nil
+}
+
+func looksLikeEmail(s string) bool {
+	at := -1
+	for i, c := range s {
+		if c == '@' {
+			at = i
+			break
+		}
+	}
+	return at > 0 && at < len(s)-1
+}

--- a/crm_be/internal/auth/service_test.go
+++ b/crm_be/internal/auth/service_test.go
@@ -1,0 +1,402 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/auth"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/mailer"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/password"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/token"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// spyMailer records every message it's asked to send, and can be told to
+// fail — used to prove Rule #32: a send failure must never roll back
+// work that already committed. It also captures the last message body so
+// tests can pull the raw verification token out of the link
+// sendVerificationEmail embeds — the raw token exists nowhere in the
+// database (only its hash does), so this is the only way a test can
+// recover it short of reimplementing token generation.
+type spyMailer struct {
+	failNext  atomic.Bool
+	sentCount atomic.Int32
+	lastTo    atomic.Value
+	lastBody  atomic.Value
+}
+
+func (m *spyMailer) Send(_ context.Context, msg mailer.Message) error {
+	if m.failNext.Load() {
+		return errors.New("simulated send failure")
+	}
+	m.sentCount.Add(1)
+	m.lastTo.Store(msg.To)
+	m.lastBody.Store(msg.Body)
+	return nil
+}
+
+// lastToken extracts the raw token from the "?token=<value>" query
+// string embedded in the last sent message's body.
+func (m *spyMailer) lastToken(t *testing.T) string {
+	t.Helper()
+	body, _ := m.lastBody.Load().(string)
+	const marker = "?token="
+	i := strings.Index(body, marker)
+	if i == -1 {
+		t.Fatalf("no verification link found in last sent email body: %q", body)
+	}
+	rest := body[i+len(marker):]
+	end := strings.IndexAny(rest, " \n")
+	if end == -1 {
+		end = len(rest)
+	}
+	return rest[:end]
+}
+
+func validInput(email string) auth.RegisterInput {
+	return auth.RegisterInput{
+		OrganizationName: "Toko ABC",
+		FullName:         "Budi Santoso",
+		Email:            email,
+		Password:         "correct horse battery staple",
+	}
+}
+
+func TestRegister_CreatesFourRowsAtomically(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	m := &spyMailer{}
+	svc := auth.NewService(pool, m, testLogger(), "http://localhost:3000")
+
+	out, err := svc.Register(ctx, validInput("owner@example.com"))
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	assertRowExists(t, ctx, pool, "organizations", out.OrganizationID)
+	assertRowExists(t, ctx, pool, "users", out.UserID)
+
+	var membershipCount int
+	err = pool.QueryRow(ctx,
+		`SELECT count(*) FROM memberships WHERE organization_id = $1 AND user_id = $2 AND role = 'owner'`,
+		out.OrganizationID, out.UserID,
+	).Scan(&membershipCount)
+	if err != nil || membershipCount != 1 {
+		t.Errorf("expected exactly 1 owner membership, got count=%d err=%v", membershipCount, err)
+	}
+
+	var subCount int
+	err = pool.QueryRow(ctx,
+		`SELECT count(*) FROM subscriptions WHERE organization_id = $1 AND plan_code = 'free' AND status = 'active'`,
+		out.OrganizationID,
+	).Scan(&subCount)
+	if err != nil || subCount != 1 {
+		t.Errorf("expected exactly 1 free active subscription, got count=%d err=%v", subCount, err)
+	}
+
+	var auditCount int
+	err = pool.QueryRow(ctx,
+		`SELECT count(*) FROM audit_logs WHERE organization_id = $1 AND action = 'user.registered'`,
+		out.OrganizationID,
+	).Scan(&auditCount)
+	if err != nil || auditCount != 1 {
+		t.Errorf("expected exactly 1 user.registered audit entry, got count=%d err=%v", auditCount, err)
+	}
+
+	if m.sentCount.Load() != 1 {
+		t.Errorf("expected exactly 1 email sent, got %d", m.sentCount.Load())
+	}
+	if got := m.lastTo.Load(); got != "owner@example.com" {
+		t.Errorf("expected verification email sent to owner@example.com, got %v", got)
+	}
+}
+
+// TestRegister_DuplicateEmail_LeavesNothingBehind is the acceptance
+// criterion "kegagalan di tengah transaksi → tidak ada satupun baris
+// tersimpan" — the second registration's organization insert must not
+// survive the user insert failing.
+func TestRegister_DuplicateEmail_LeavesNothingBehind(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	svc := auth.NewService(pool, &spyMailer{}, testLogger(), "http://localhost:3000")
+
+	if _, err := svc.Register(ctx, validInput("dup@example.com")); err != nil {
+		t.Fatalf("first registration failed: %v", err)
+	}
+
+	var orgCountBefore int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM organizations`).Scan(&orgCountBefore); err != nil {
+		t.Fatalf("failed to count organizations: %v", err)
+	}
+
+	secondInput := validInput("dup@example.com")
+	secondInput.OrganizationName = "Toko XYZ"
+	_, err := svc.Register(ctx, secondInput)
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "email_already_registered" {
+		t.Fatalf("expected email_already_registered DomainError, got: %v", err)
+	}
+
+	var orgCountAfter int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM organizations`).Scan(&orgCountAfter); err != nil {
+		t.Fatalf("failed to count organizations: %v", err)
+	}
+	if orgCountAfter != orgCountBefore {
+		t.Errorf("expected the failed registration to leave no new organization behind: before=%d after=%d", orgCountBefore, orgCountAfter)
+	}
+
+	var userCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM users WHERE email = 'dup@example.com'`).Scan(&userCount); err != nil {
+		t.Fatalf("failed to count users: %v", err)
+	}
+	if userCount != 1 {
+		t.Errorf("expected exactly 1 user with the duplicate email (from the first, successful registration), got %d", userCount)
+	}
+}
+
+// TestRegister_MailerFailure_StillCommits is Rule #32's core guarantee:
+// registration is already committed by the time the email is sent, so a
+// send failure cannot roll it back.
+func TestRegister_MailerFailure_StillCommits(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	m := &spyMailer{}
+	m.failNext.Store(true)
+	svc := auth.NewService(pool, m, testLogger(), "http://localhost:3000")
+
+	out, err := svc.Register(ctx, validInput("mailfail@example.com"))
+	if err != nil {
+		t.Fatalf("expected registration to succeed despite mailer failure, got: %v", err)
+	}
+
+	assertRowExists(t, ctx, pool, "users", out.UserID)
+}
+
+func TestVerifyEmail_ValidToken_MarksVerifiedAndConsumesToken(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	m := &spyMailer{}
+	svc := auth.NewService(pool, m, testLogger(), "http://localhost:3000")
+
+	out, err := svc.Register(ctx, validInput("verify@example.com"))
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	rawToken := m.lastToken(t)
+
+	if err := svc.VerifyEmail(ctx, rawToken); err != nil {
+		t.Fatalf("verify email failed: %v", err)
+	}
+
+	var verifiedAt *time.Time
+	err = pool.QueryRow(ctx, `SELECT email_verified_at FROM users WHERE id = $1`, out.UserID).Scan(&verifiedAt)
+	if err != nil || verifiedAt == nil {
+		t.Fatalf("expected email_verified_at to be set, got %v (err=%v)", verifiedAt, err)
+	}
+
+	var auditCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM audit_logs WHERE action = 'email.verified'`).Scan(&auditCount); err != nil {
+		t.Fatalf("failed to count audit logs: %v", err)
+	}
+	if auditCount != 1 {
+		t.Errorf("expected exactly 1 email.verified audit entry, got %d", auditCount)
+	}
+}
+
+// TestVerifyEmail_TokenUsedTwice_SecondAttemptFails proves single-use:
+// the acceptance criterion "token verifikasi sekali pakai — dipakai dua
+// kali → invalid_token".
+func TestVerifyEmail_TokenUsedTwice_SecondAttemptFails(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	m := &spyMailer{}
+	svc := auth.NewService(pool, m, testLogger(), "http://localhost:3000")
+
+	_, err := svc.Register(ctx, validInput("reuse@example.com"))
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	rawToken := m.lastToken(t)
+
+	if err := svc.VerifyEmail(ctx, rawToken); err != nil {
+		t.Fatalf("first verification failed: %v", err)
+	}
+
+	err = svc.VerifyEmail(ctx, rawToken)
+	assertInvalidToken(t, err)
+}
+
+func TestVerifyEmail_ExpiredToken_Rejected(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	svc := auth.NewService(pool, &spyMailer{}, testLogger(), "http://localhost:3000")
+
+	out, err := svc.Register(ctx, validInput("expired@example.com"))
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	rawToken, hash, err := token.Generate()
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+	_, err = pool.Exec(ctx, `
+		INSERT INTO email_verification_tokens (id, user_id, token_hash, expires_at)
+		VALUES (gen_random_uuid(), $1, $2, now() - interval '1 hour')`,
+		out.UserID, hash,
+	)
+	if err != nil {
+		t.Fatalf("failed to insert expired token: %v", err)
+	}
+
+	err = svc.VerifyEmail(ctx, rawToken)
+	assertInvalidToken(t, err)
+}
+
+func TestVerifyEmail_UnknownToken_Rejected(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	svc := auth.NewService(pool, &spyMailer{}, testLogger(), "http://localhost:3000")
+
+	err := svc.VerifyEmail(ctx, "this-token-does-not-exist")
+	assertInvalidToken(t, err)
+}
+
+func TestResendVerification_UnknownEmail_SendsNothing(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	m := &spyMailer{}
+	svc := auth.NewService(pool, m, testLogger(), "http://localhost:3000")
+
+	// Must not panic or error — the handler always answers 202 regardless.
+	svc.ResendVerification(ctx, "nobody@example.com")
+
+	if m.sentCount.Load() != 0 {
+		t.Errorf("expected no email sent for an unknown address, got %d", m.sentCount.Load())
+	}
+}
+
+func TestResendVerification_UnverifiedUser_SendsNewToken(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	m := &spyMailer{}
+	svc := auth.NewService(pool, m, testLogger(), "http://localhost:3000")
+
+	out, err := svc.Register(ctx, validInput("resend@example.com"))
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	svc.ResendVerification(ctx, "resend@example.com")
+
+	if m.sentCount.Load() != 2 { // one from Register, one from resend
+		t.Errorf("expected 2 emails sent total (register + resend), got %d", m.sentCount.Load())
+	}
+
+	var tokenCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM email_verification_tokens WHERE user_id = $1`, out.UserID).Scan(&tokenCount); err != nil {
+		t.Fatalf("failed to count verification tokens: %v", err)
+	}
+	if tokenCount != 2 {
+		t.Errorf("expected 2 verification tokens to exist (register + resend), got %d", tokenCount)
+	}
+}
+
+func TestResendVerification_AlreadyVerified_SendsNothing(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	m := &spyMailer{}
+	svc := auth.NewService(pool, m, testLogger(), "http://localhost:3000")
+
+	_, err := svc.Register(ctx, validInput("already-verified@example.com"))
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+	rawToken := m.lastToken(t)
+	if err := svc.VerifyEmail(ctx, rawToken); err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+
+	sentBefore := m.sentCount.Load()
+	svc.ResendVerification(ctx, "already-verified@example.com")
+
+	if m.sentCount.Load() != sentBefore {
+		t.Errorf("expected no additional email for an already-verified user, sent before=%d after=%d", sentBefore, m.sentCount.Load())
+	}
+}
+
+func TestRegister_WeakPassword_Rejected(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	svc := auth.NewService(pool, &spyMailer{}, testLogger(), "http://localhost:3000")
+
+	in := validInput("weak@example.com")
+	in.Password = "short"
+
+	_, err := svc.Register(ctx, in)
+	var verr *httpx.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected ValidationError for a too-short password, got: %v", err)
+	}
+}
+
+// TestPassword_HashIsNeverPlaintext guards against the most damaging
+// possible regression in this package: storing a recoverable password.
+func TestPassword_HashIsNeverPlaintext(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	svc := auth.NewService(pool, &spyMailer{}, testLogger(), "http://localhost:3000")
+
+	in := validInput("hash-check@example.com")
+	out, err := svc.Register(ctx, in)
+	if err != nil {
+		t.Fatalf("register failed: %v", err)
+	}
+
+	var storedHash string
+	if err := pool.QueryRow(ctx, `SELECT password_hash FROM users WHERE id = $1`, out.UserID).Scan(&storedHash); err != nil {
+		t.Fatalf("failed to read stored password hash: %v", err)
+	}
+
+	if storedHash == in.Password {
+		t.Fatal("password_hash must never equal the plaintext password")
+	}
+	ok, err := password.Verify(in.Password, storedHash)
+	if err != nil || !ok {
+		t.Errorf("expected stored hash to verify against the original password, ok=%v err=%v", ok, err)
+	}
+}
+
+func assertRowExists(t *testing.T, ctx context.Context, pool *pgxpool.Pool, table string, id any) {
+	t.Helper()
+	var exists bool
+	q := "SELECT EXISTS (SELECT 1 FROM " + table + " WHERE id = $1)"
+	if err := pool.QueryRow(ctx, q, id).Scan(&exists); err != nil {
+		t.Fatalf("failed to check row existence in %s: %v", table, err)
+	}
+	if !exists {
+		t.Errorf("expected a row in %s for id=%v", table, id)
+	}
+}
+
+func assertInvalidToken(t *testing.T, err error) {
+	t.Helper()
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "invalid_token" {
+		t.Fatalf("expected invalid_token DomainError, got: %v", err)
+	}
+}

--- a/crm_be/internal/auth/verification_token.go
+++ b/crm_be/internal/auth/verification_token.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+)
+
+// EmailVerificationToken is global, like user.User — it belongs to a
+// user_id, not an organization. See email_verification_tokens in
+// migration 0002.
+type EmailVerificationToken struct {
+	ID        uuid.UUID
+	UserID    uuid.UUID
+	TokenHash string
+	ExpiresAt time.Time
+	UsedAt    *time.Time
+	CreatedAt time.Time
+}
+
+const emailVerificationTTL = 24 * time.Hour
+
+// verificationRepository is unexported: email_verification_tokens is an
+// implementation detail of this package's Service, not something other
+// domains look up directly.
+type verificationRepository struct {
+	q db.Querier
+}
+
+func newVerificationRepository(q db.Querier) *verificationRepository {
+	return &verificationRepository{q: q}
+}
+
+func (r *verificationRepository) Create(ctx context.Context, id, userID uuid.UUID, tokenHash string) error {
+	const q = `
+		INSERT INTO email_verification_tokens (id, user_id, token_hash, expires_at)
+		VALUES ($1, $2, $3, $4)`
+
+	_, err := r.q.Exec(ctx, q, id, userID, tokenHash, time.Now().Add(emailVerificationTTL))
+	if err != nil {
+		return fmt.Errorf("auth: create verification token: %w", err)
+	}
+	return nil
+}
+
+// FindValidByHash returns the token row only if it exists, is unexpired,
+// and hasn't been used — any other case maps to the same
+// httpx.ErrNotFound so a caller can't distinguish "wrong token" from
+// "expired token" from "already used token" through timing or response
+// shape (all three become invalid_token at the HTTP layer).
+func (r *verificationRepository) FindValidByHash(ctx context.Context, hash string) (*EmailVerificationToken, error) {
+	const q = `
+		SELECT id, user_id, token_hash, expires_at, used_at, created_at
+		FROM email_verification_tokens
+		WHERE token_hash = $1 AND used_at IS NULL AND expires_at > now()`
+
+	var t EmailVerificationToken
+	err := r.q.QueryRow(ctx, q, hash).Scan(&t.ID, &t.UserID, &t.TokenHash, &t.ExpiresAt, &t.UsedAt, &t.CreatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, httpx.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("auth: find verification token: %w", err)
+	}
+	return &t, nil
+}
+
+func (r *verificationRepository) MarkUsed(ctx context.Context, id uuid.UUID) error {
+	const q = `UPDATE email_verification_tokens SET used_at = now() WHERE id = $1`
+	_, err := r.q.Exec(ctx, q, id)
+	if err != nil {
+		return fmt.Errorf("auth: mark verification token used: %w", err)
+	}
+	return nil
+}

--- a/crm_be/internal/organization/organization.go
+++ b/crm_be/internal/organization/organization.go
@@ -1,0 +1,19 @@
+// Package organization is the tenant root — every tenant-scoped table
+// elsewhere in this database has an organization_id pointing back to a
+// row here. See docs/architecture/freeze.md bagian 1.1.
+package organization
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Organization struct {
+	ID        uuid.UUID
+	Name      string
+	Timezone  string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time
+}

--- a/crm_be/internal/organization/repository.go
+++ b/crm_be/internal/organization/repository.go
@@ -1,0 +1,67 @@
+package organization
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+)
+
+// Repository deliberately does NOT take tenant.Context — an organization
+// IS the tenant, not something scoped to one. Looking one up by its own
+// id needs no further scoping, the same way membership.Repository's
+// FindByID scopes to organization_id but organizations themselves have
+// no parent to scope against.
+type Repository struct {
+	q db.Querier
+}
+
+func New(q db.Querier) *Repository {
+	return &Repository{q: q}
+}
+
+// Create inserts a new organization. Timezone defaults to Asia/Jakarta
+// at the database level (migration 0002); callers that need a different
+// timezone pass it explicitly via a future update path, not at creation.
+func (r *Repository) Create(ctx context.Context, id uuid.UUID, name string) (*Organization, error) {
+	const q = `
+		INSERT INTO organizations (id, name)
+		VALUES ($1, $2)
+		RETURNING id, name, timezone, created_at, updated_at, deleted_at`
+
+	o, err := scanOne(r.q.QueryRow(ctx, q, id, name))
+	if err != nil {
+		return nil, fmt.Errorf("organization: create: %w", err)
+	}
+	return o, nil
+}
+
+func (r *Repository) FindByID(ctx context.Context, id uuid.UUID) (*Organization, error) {
+	const q = `
+		SELECT id, name, timezone, created_at, updated_at, deleted_at
+		FROM organizations
+		WHERE id = $1 AND deleted_at IS NULL`
+
+	o, err := scanOne(r.q.QueryRow(ctx, q, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, httpx.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("organization: find by id: %w", err)
+	}
+	return o, nil
+}
+
+func scanOne(row pgx.Row) (*Organization, error) {
+	var o Organization
+	err := row.Scan(&o.ID, &o.Name, &o.Timezone, &o.CreatedAt, &o.UpdatedAt, &o.DeletedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &o, nil
+}

--- a/crm_be/internal/shared/config/config.go
+++ b/crm_be/internal/shared/config/config.go
@@ -14,6 +14,11 @@ import (
 var validAppEnvs = []string{"development", "production"}
 var validLogLevels = []string{"debug", "info", "warn", "error"}
 
+// "log" is the only provider that exists so far — LogMailer. A real
+// provider is added to this list when it's actually implemented, not
+// before (Rule #27).
+var validMailProviders = []string{"log"}
+
 // Config holds all environment-derived settings for crm_be.
 type Config struct {
 	AppEnv string `env:"APP_ENV" envDefault:"development"`
@@ -27,6 +32,12 @@ type Config struct {
 	DBMaxConns  int    `env:"DB_MAX_CONNS" envDefault:"10"`
 
 	LogLevel string `env:"LOG_LEVEL" envDefault:"info"`
+
+	// AppBaseURL is where verification/reset/invitation links point —
+	// the dashboard's origin, not this API's.
+	AppBaseURL   string `env:"APP_BASE_URL" envDefault:"http://localhost:3000"`
+	MailFrom     string `env:"MAIL_FROM" envDefault:"no-reply@localhost"`
+	MailProvider string `env:"MAIL_PROVIDER" envDefault:"log"`
 }
 
 // Load parses environment variables into a Config and validates it.
@@ -57,6 +68,9 @@ func (c *Config) validate() error {
 	// DBMaxConns safely fits int32 when passed to pgxpool.Config.MaxConns.
 	if c.DBMaxConns <= 0 || c.DBMaxConns > 1000 {
 		return fmt.Errorf("config invalid: DB_MAX_CONNS must be between 1 and 1000, got %d", c.DBMaxConns)
+	}
+	if !slices.Contains(validMailProviders, c.MailProvider) {
+		return fmt.Errorf("config invalid: MAIL_PROVIDER must be one of %v, got %q", validMailProviders, c.MailProvider)
 	}
 	return nil
 }

--- a/crm_be/internal/shared/httpx/error.go
+++ b/crm_be/internal/shared/httpx/error.go
@@ -47,6 +47,27 @@ func NewValidationError(details ...ErrorDetail) *ValidationError {
 	return &ValidationError{Details: details}
 }
 
+// DomainError lets any domain package produce a specific status/code/
+// message without internal/shared/httpx needing to import that domain
+// package — importing domain packages here would invert the dependency
+// direction every other shared package follows. A domain constructs
+// &httpx.DomainError{...} and returns it; MapError recognizes the type
+// generically via errors.As.
+//
+// This is the extension point referenced throughout
+// .claude/skills/jualin-backend: "tambahkan sentinel baru + case di
+// MapError saat domain butuh kode error baru" — for a one-off status/code
+// pair, constructing a DomainError directly is enough; only reach for a
+// dedicated sentinel + MapError case when multiple call sites need to
+// recognize the same error via errors.Is/errors.As.
+type DomainError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e *DomainError) Error() string { return e.Message }
+
 // MapError translates a domain error into an HTTP status and response body.
 //
 // Resources belonging to another tenant must be returned as ErrNotFound
@@ -54,6 +75,7 @@ func NewValidationError(details ...ErrorDetail) *ValidationError {
 // itself an information leak (Rule #6).
 func MapError(err error) (int, ErrorBody) {
 	var verr *ValidationError
+	var derr *DomainError
 	switch {
 	case errors.As(err, &verr):
 		return http.StatusBadRequest, ErrorBody{
@@ -61,6 +83,8 @@ func MapError(err error) (int, ErrorBody) {
 			Message: "Permintaan tidak valid.",
 			Details: verr.Details,
 		}
+	case errors.As(err, &derr):
+		return derr.Status, ErrorBody{Code: derr.Code, Message: derr.Message}
 	case errors.Is(err, ErrNotFound):
 		return http.StatusNotFound, ErrorBody{
 			Code:    "not_found",

--- a/crm_be/internal/shared/mailer/mailer.go
+++ b/crm_be/internal/shared/mailer/mailer.go
@@ -1,0 +1,54 @@
+// Package mailer defines the interface every email-sending flow in this
+// codebase uses, and a LogMailer implementation for development and
+// test.
+//
+// An interface with a single implementation usually violates Rule #27
+// (no abstraction before a second real user exists). It's justified here
+// because the second implementation — a real provider — is already known
+// to be coming (see docs/STATUS.md's lead-time items: domain + SPF/DKIM/
+// DMARC), and without this interface Phase 1 would be blocked on a
+// decision (which provider) that's outside this phase's control.
+//
+// Sends always happen after the triggering transaction commits (Rule
+// #32) — see internal/auth.Service.Register for the pattern. A send
+// failure is logged structurally; it never rolls back work that already
+// committed.
+package mailer
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Message is provider-agnostic — no HTML templating, attachments, or
+// provider-specific fields. Phase 1 only sends transactional plaintext
+// email.
+type Message struct {
+	To      string
+	Subject string
+	Body    string
+}
+
+type Mailer interface {
+	Send(ctx context.Context, msg Message) error
+}
+
+// LogMailer records the message via the request-scoped logger instead of
+// sending it. Used in development and in every test — no test in this
+// codebase depends on network access or a real inbox.
+type LogMailer struct {
+	Logger *slog.Logger
+}
+
+func NewLogMailer(logger *slog.Logger) *LogMailer {
+	return &LogMailer{Logger: logger}
+}
+
+func (m *LogMailer) Send(_ context.Context, msg Message) error {
+	m.Logger.Info("email (not sent — LogMailer)",
+		"to", msg.To,
+		"subject", msg.Subject,
+		"body", msg.Body,
+	)
+	return nil
+}

--- a/crm_be/internal/shared/password/argon2.go
+++ b/crm_be/internal/shared/password/argon2.go
@@ -1,0 +1,85 @@
+// Package password hashes and verifies user passwords with argon2id.
+//
+// This is deliberately a different algorithm choice from API keys
+// (SHA-256, see ADR-004): passwords are chosen by humans and have low
+// entropy, so a slow, memory-hard hash is what makes brute-forcing
+// expensive. API keys are 256-bit random values where a slow hash buys
+// nothing but latency.
+package password
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// Parameters are stored inside the hash string itself (PHC format), so
+// raising them later never requires a migration — verification reads
+// whatever parameters produced the stored hash.
+const (
+	saltLength  = 16
+	keyLength   = 32
+	memoryKiB   = 19 * 1024 // 19 MiB
+	iterations  = 2
+	parallelism = 1
+)
+
+var ErrInvalidHash = errors.New("password: malformed hash")
+
+// Hash produces a PHC-formatted argon2id hash:
+// $argon2id$v=19$m=19456,t=2,p=1$<salt>$<hash>
+func Hash(plaintext string) (string, error) {
+	salt := make([]byte, saltLength)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("password: failed to generate salt: %w", err)
+	}
+
+	hash := argon2.IDKey([]byte(plaintext), salt, iterations, memoryKiB, parallelism, keyLength)
+
+	return fmt.Sprintf(
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version, memoryKiB, iterations, parallelism,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash),
+	), nil
+}
+
+// Verify reports whether plaintext matches the given PHC-formatted hash,
+// using the parameters embedded in the hash itself — not the package's
+// current constants — so a hash created with older parameters still
+// verifies correctly.
+func Verify(plaintext, encoded string) (bool, error) {
+	parts := strings.Split(encoded, "$")
+	if len(parts) != 6 || parts[1] != "argon2id" {
+		return false, ErrInvalidHash
+	}
+
+	var version, mem, iter, par int
+	if _, err := fmt.Sscanf(parts[2], "v=%d", &version); err != nil {
+		return false, ErrInvalidHash
+	}
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &mem, &iter, &par); err != nil {
+		return false, ErrInvalidHash
+	}
+
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return false, ErrInvalidHash
+	}
+	want, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return false, ErrInvalidHash
+	}
+
+	// #nosec G115 -- mem/iter/par/keyLength are parsed from a hash this
+	// package itself generated with bounded values; not attacker-controlled
+	// in a way that risks overflow.
+	got := argon2.IDKey([]byte(plaintext), salt, uint32(iter), uint32(mem), uint8(par), uint32(len(want)))
+
+	return subtle.ConstantTimeCompare(got, want) == 1, nil
+}

--- a/crm_be/internal/shared/password/argon2_test.go
+++ b/crm_be/internal/shared/password/argon2_test.go
@@ -1,0 +1,56 @@
+package password_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/password"
+)
+
+func TestHashAndVerify_RoundTrip(t *testing.T) {
+	hash, err := password.Hash("correct horse battery staple")
+	if err != nil {
+		t.Fatalf("hash failed: %v", err)
+	}
+	if !strings.HasPrefix(hash, "$argon2id$") {
+		t.Errorf("expected PHC-formatted hash, got %q", hash)
+	}
+
+	ok, err := password.Verify("correct horse battery staple", hash)
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	if !ok {
+		t.Error("expected correct password to verify")
+	}
+}
+
+func TestVerify_WrongPassword(t *testing.T) {
+	hash, err := password.Hash("correct horse battery staple")
+	if err != nil {
+		t.Fatalf("hash failed: %v", err)
+	}
+
+	ok, err := password.Verify("wrong password", hash)
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+	if ok {
+		t.Error("expected wrong password to fail verification")
+	}
+}
+
+func TestHash_ProducesDifferentSaltEachTime(t *testing.T) {
+	h1, _ := password.Hash("same password")
+	h2, _ := password.Hash("same password")
+	if h1 == h2 {
+		t.Error("expected two hashes of the same password to differ (random salt)")
+	}
+}
+
+func TestVerify_MalformedHash(t *testing.T) {
+	_, err := password.Verify("anything", "not-a-valid-hash")
+	if err != password.ErrInvalidHash {
+		t.Errorf("expected ErrInvalidHash, got %v", err)
+	}
+}

--- a/crm_be/internal/shared/ratelimit/limiter.go
+++ b/crm_be/internal/shared/ratelimit/limiter.go
@@ -1,0 +1,63 @@
+// Package ratelimit provides in-memory rate limiting — no Redis (freeze:
+// no infrastructure beyond PostgreSQL in the MVP). Hidden behind an
+// interface so a distributed implementation can replace it later without
+// touching any caller.
+package ratelimit
+
+import (
+	"sync"
+	"time"
+)
+
+// Limiter reports whether the caller identified by key may proceed.
+// Every login/register/resend/forgot-password call site checks its own
+// keys (e.g. "register:ip:1.2.3.4", "resend:email:a@b.com") — the
+// limiter itself has no notion of what a key represents.
+type Limiter interface {
+	Allow(key string) bool
+}
+
+// FixedWindow is a simple fixed-window counter: at most Limit calls to
+// Allow with the same key succeed within any Window-sized bucket of wall
+// clock time. Simplicity over precision is deliberate — this only needs
+// to make brute-forcing and spam expensive, not implement a perfectly
+// smooth rate.
+type FixedWindow struct {
+	limit  int
+	window time.Duration
+
+	mu      sync.Mutex
+	buckets map[string]*bucket
+}
+
+type bucket struct {
+	windowStart time.Time
+	count       int
+}
+
+func NewFixedWindow(limit int, window time.Duration) *FixedWindow {
+	return &FixedWindow{
+		limit:   limit,
+		window:  window,
+		buckets: make(map[string]*bucket),
+	}
+}
+
+func (f *FixedWindow) Allow(key string) bool {
+	now := time.Now()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	b, ok := f.buckets[key]
+	if !ok || now.Sub(b.windowStart) >= f.window {
+		f.buckets[key] = &bucket{windowStart: now, count: 1}
+		return true
+	}
+
+	if b.count >= f.limit {
+		return false
+	}
+	b.count++
+	return true
+}

--- a/crm_be/internal/shared/ratelimit/limiter_test.go
+++ b/crm_be/internal/shared/ratelimit/limiter_test.go
@@ -1,0 +1,49 @@
+package ratelimit_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/ratelimit"
+)
+
+func TestFixedWindow_AllowsUpToLimit(t *testing.T) {
+	l := ratelimit.NewFixedWindow(3, time.Minute)
+
+	for i := 0; i < 3; i++ {
+		if !l.Allow("k") {
+			t.Fatalf("expected call %d to be allowed", i+1)
+		}
+	}
+	if l.Allow("k") {
+		t.Error("expected 4th call within the window to be denied")
+	}
+}
+
+func TestFixedWindow_KeysAreIndependent(t *testing.T) {
+	l := ratelimit.NewFixedWindow(1, time.Minute)
+
+	if !l.Allow("a") {
+		t.Fatal("expected first call for key 'a' to be allowed")
+	}
+	if !l.Allow("b") {
+		t.Error("expected key 'b' to be independent of key 'a''s limit")
+	}
+}
+
+func TestFixedWindow_ResetsAfterWindow(t *testing.T) {
+	l := ratelimit.NewFixedWindow(1, 10*time.Millisecond)
+
+	if !l.Allow("k") {
+		t.Fatal("expected first call to be allowed")
+	}
+	if l.Allow("k") {
+		t.Fatal("expected second call within the window to be denied")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	if !l.Allow("k") {
+		t.Error("expected a call after the window elapsed to be allowed again")
+	}
+}

--- a/crm_be/internal/shared/token/token.go
+++ b/crm_be/internal/shared/token/token.go
@@ -1,0 +1,33 @@
+// Package token generates single-use secrets for email verification,
+// password reset, and invitations. The raw value is what's emailed to
+// the user; only its hash is ever stored (same principle as API keys,
+// ADR-004) so a database read alone can never produce a usable token.
+package token
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+)
+
+const rawLength = 32 // bytes, before encoding
+
+// Generate returns a random raw token and its SHA-256 hash (hex-encoded).
+// Store hash; email raw; never store raw.
+func Generate() (raw string, hash string, err error) {
+	b := make([]byte, rawLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("token: failed to generate: %w", err)
+	}
+	raw = base64.RawURLEncoding.EncodeToString(b)
+	return raw, Hash(raw), nil
+}
+
+// Hash computes the same hash Generate would have stored, so callers can
+// verify a raw token received from a client against a stored hash.
+func Hash(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}

--- a/crm_be/internal/shared/token/token_test.go
+++ b/crm_be/internal/shared/token/token_test.go
@@ -1,0 +1,28 @@
+package token_test
+
+import (
+	"testing"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/token"
+)
+
+func TestGenerate_HashMatchesRaw(t *testing.T) {
+	raw, hash, err := token.Generate()
+	if err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+	if raw == "" || hash == "" {
+		t.Fatal("expected non-empty raw and hash")
+	}
+	if token.Hash(raw) != hash {
+		t.Error("expected Hash(raw) to reproduce the same hash Generate returned")
+	}
+}
+
+func TestGenerate_ProducesUniqueTokens(t *testing.T) {
+	_, h1, _ := token.Generate()
+	_, h2, _ := token.Generate()
+	if h1 == h2 {
+		t.Error("expected two generated tokens to differ")
+	}
+}

--- a/crm_be/internal/subscription/repository.go
+++ b/crm_be/internal/subscription/repository.go
@@ -1,0 +1,48 @@
+package subscription
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+type Repository struct {
+	q db.Querier
+}
+
+func New(q db.Querier) *Repository {
+	return &Repository{q: q}
+}
+
+// CreateFree inserts the free-plan subscription every organization gets
+// at registration. Plan/entitlement/usage enforcement is Phase 8 — this
+// call has no side effect beyond the row existing.
+func (r *Repository) CreateFree(ctx context.Context, t tenant.Context, id uuid.UUID) (*Subscription, error) {
+	const q = `
+		INSERT INTO subscriptions (id, organization_id, plan_code, status)
+		VALUES ($1, $2, 'free', 'active')
+		RETURNING id, organization_id, plan_code, status, current_period_start, current_period_end, external_reference, created_at, updated_at`
+
+	s, err := scanOne(r.q.QueryRow(ctx, q, id, t.OrganizationID))
+	if err != nil {
+		return nil, fmt.Errorf("subscription: create free: %w", err)
+	}
+	return s, nil
+}
+
+func scanOne(row interface{ Scan(...any) error }) (*Subscription, error) {
+	var s Subscription
+	err := row.Scan(
+		&s.ID, &s.OrganizationID, &s.PlanCode, &s.Status,
+		&s.CurrentPeriodStart, &s.CurrentPeriodEnd, &s.ExternalReference,
+		&s.CreatedAt, &s.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/crm_be/internal/subscription/subscription.go
+++ b/crm_be/internal/subscription/subscription.go
@@ -1,0 +1,23 @@
+// Package subscription holds the minimal Phase 1 shape — a row proving
+// every organization has a plan from the moment it registers. The full
+// plan/entitlement/usage machinery is Phase 8; nothing here enforces any
+// limit.
+package subscription
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Subscription struct {
+	ID                 uuid.UUID
+	OrganizationID     uuid.UUID
+	PlanCode           string
+	Status             string
+	CurrentPeriodStart *time.Time
+	CurrentPeriodEnd   *time.Time
+	ExternalReference  *string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}

--- a/crm_be/internal/user/repository.go
+++ b/crm_be/internal/user/repository.go
@@ -8,10 +8,20 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
 )
+
+// ErrEmailTaken means the email uniqueness constraint (users_email_key)
+// rejected an insert. Detected from the database's own unique-violation
+// error rather than a SELECT-then-INSERT check — that would be a
+// check-then-act race under concurrent registrations for the same
+// email; letting Postgres enforce it atomically isn't.
+var ErrEmailTaken = errors.New("user: email already taken")
+
+const emailUniqueConstraint = "users_email_key"
 
 // Repository is the one repository in this codebase that deliberately
 // does NOT take tenant.Context. users has no organization_id — a user
@@ -79,9 +89,25 @@ func (r *Repository) Create(ctx context.Context, id uuid.UUID, email, passwordHa
 
 	u, err := scanOne(r.q.QueryRow(ctx, q, id, normalizeEmail(email), passwordHash, fullName))
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == emailUniqueConstraint {
+			return nil, ErrEmailTaken
+		}
 		return nil, fmt.Errorf("user: create: %w", err)
 	}
 	return u, nil
+}
+
+// MarkEmailVerified sets email_verified_at. Called exactly once, from
+// auth.Service.VerifyEmail, inside the same transaction that marks the
+// consumed verification token as used.
+func (r *Repository) MarkEmailVerified(ctx context.Context, id uuid.UUID) error {
+	const q = `UPDATE users SET email_verified_at = now() WHERE id = $1 AND email_verified_at IS NULL`
+	_, err := r.q.Exec(ctx, q, id)
+	if err != nil {
+		return fmt.Errorf("user: mark email verified: %w", err)
+	}
+	return nil
 }
 
 func normalizeEmail(email string) string {

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 18 Agustus 2026 — Issue #8 selesai
-**Phase sekarang:** Phase 1 — Auth & Organization (1/4 issue selesai)
+**Last updated:** 19 Agustus 2026 — Issue #9 selesai
+**Phase sekarang:** Phase 1 — Auth & Organization (2/4 issue selesai)
 
 ---
 
@@ -24,6 +24,7 @@
 | **ADR-010 — Fail-fast startup** | — | — | Muncul dari review PR #6, dikonfirmasi pemilik produk sebagai prinsip umum (bukan hanya DB). Aturan #36 di `CLAUDE.md`. |
 | **Issue #3 — Test harness PostgreSQL asli** | — | 0 | `internal/shared/db/dbtest` (subpaket terpisah dari `db` produksi — testcontainers tidak ikut ter-link ke binary). Mengotomasi `db.InTx`, migration round-trip, `/health/ready` yang tadinya manual. **Phase 0 selesai.** |
 | **Issue #8 — Schema 0002, tenant context, pola repository, test katalog** | — | 1 | 9 tabel identity, `internal/shared/tenant`, `db.Querier`, `internal/membership` + `internal/user` sebagai contoh repository tenant-scoped/global. Test katalog **diverifikasi bisa gagal** secara adversarial (lihat notes.md). |
+| **Issue #9 — Registrasi atomik, argon2id, verifikasi email** | — | 1 | `POST /v1/auth/{register,verify-email,verify-email/resend}`. `httpx.DomainError` (mekanisme error domain generik, baru), `internal/{organization,subscription,auditlog,auth}`, `internal/shared/{password,token,mailer,ratelimit}`. Registrasi 6-insert atomik dalam satu `db.InTx`; email di luar transaksi (Aturan #32). Rate limit **dibuktikan aktif** di test HTTP. |
 
 ---
 
@@ -35,11 +36,11 @@ _(kosong)_
 
 ## Berikutnya
 
-**Issue #9 — Registrasi atomik, argon2id, dan verifikasi email**
+**Issue #10 — Login, refresh rotation, logout, reset password, CSRF**
 
-- Cakupan & acceptance: [issue #9](https://github.com/Pravasta/jualin-crm/issues/9)
-- TD: `docs/phases/01-auth-organization/td.md` §2, §3, §6, §10, §11, §12
-- Bergantung pada #8 (selesai). Urutan sisanya: #9 → #10 → #11.
+- Cakupan & acceptance: [issue #10](https://github.com/Pravasta/jualin-crm/issues/10)
+- TD: `docs/phases/01-auth-organization/td.md` §2, §4, §5, §6, §11, §12, §13
+- Bergantung pada #9 (selesai). Memakai `internal/shared/{password,token,mailer,ratelimit}` dan `httpx.DomainError` langsung, tanpa menulis ulang. Terakhir sebelum #11.
 
 ---
 
@@ -49,6 +50,8 @@ _(kosong)_
 |---|---|---|
 | Tidak ada test end-to-end otomatis untuk graceful shutdown | Issue #1 | Diverifikasi manual (build binary + SIGINT). Otomatisasi butuh test yang menjalankan binary sungguhan dan mengirim sinyal OS — `go run` tidak meneruskan sinyal ke child process, jadi tidak bisa diuji lewat itu. Belum ada issue yang mencakup ini; angkat saat menyentuh area shutdown lagi. |
 | Tidak ada auto-migrate saat container `api` start | Issue #2 | `make migrate-up` dijalankan manual. Sengaja dipisah dari entrypoint `api` — migration dan serving punya kelas kegagalan berbeda. |
+| `ratelimit.FixedWindow` tidak pernah membersihkan key lama | Issue #9 | Map tumbuh tanpa batas seiring IP/email baru muncul. Tidak masalah di volume MVP; perlu eviction sebelum traffic produksi nyata. |
+| Angka rate limit (register 5/jam, resend 3/jam+10/jam) belum final | Issue #9 | Cukup untuk membuktikan mekanisme aktif, bukan hasil tuning. Freeze mencatat "strategi rate limit final" sebagai keputusan terbuka hingga Phase 4. |
 
 > ~~Test otomatis `db.InTx` dan migration round-trip~~ — selesai di issue #3.
 

--- a/docs/phases/01-auth-organization/notes.md
+++ b/docs/phases/01-auth-organization/notes.md
@@ -60,3 +60,64 @@ Migration dikembalikan (diverifikasi `diff` identik dengan cadangan), test kemba
 - **`db.Querier`** dipakai ulang oleh setiap repository baru mulai issue #9. Constructor selalu `New(q db.Querier) *Repository`, bukan `New(pool *pgxpool.Pool)`.
 - **Organization belum punya model/repository sendiri.** Issue #8 hanya membuat tabelnya lewat migration; `internal/organization` (bila dibutuhkan sebagai paket) menyusul di issue #9 saat registrasi benar-benar membuat baris organization.
 - **Pola "satu contoh nyata lalu disalin"**: `membership.Repository` adalah rujukan untuk setiap repository tenant-scoped berikutnya. `user.Repository` adalah rujukan untuk setiap repository global berikutnya (belum ada yang lain sampai saat ini).
+
+---
+
+## #9 — Registrasi atomik, argon2id, dan verifikasi email
+
+### Menyimpang dari TD
+
+| Yang berbeda | Alasan |
+|---|---|
+| `httpx.DomainError` — mekanisme baru, tidak ada di TD | Domain error (`email_already_registered`, `invalid_token`) butuh status/code/message spesifik tanpa membuat `internal/shared/httpx` mengimpor paket domain (itu akan membalik arah dependensi: shared → domain). `DomainError{Status, Code, Message}` dikenali `MapError` lewat `errors.As`, generik untuk domain manapun. Dipakai lagi tanpa perubahan di #10 dan #11. |
+| `internal/organization`, `internal/subscription`, `internal/auditlog` dibuat sebagai paket baru | Tidak eksplisit di rencana per-file, tapi sudah tersirat dari cakupan ("organization + membership owner + subscription free", "audit log"). Mengikuti pola yang sama seperti `membership`/`user` di #8: `organization.Repository` juga tanpa `tenant.Context` (ia tenant root — alasan berbeda dari `user`, tapi pengecualian sejenis, didokumentasikan eksplisit di komentar). |
+| `internal/shared/ratelimit` — paket baru, tidak ada di TD sebagai nama paket | TD menyebut kebutuhan "rate limit per IP/per email" tanpa menentukan bentuk implementasinya. Dipilih fixed-window in-memory sesuai freeze ("tanpa Redis di MVP"), di balik interface `Limiter` agar bisa diganti nanti. Dipakai ulang di #10 (login) dan #11 (invitation). |
+| Rate limit dicek di **handler**, bukan sebagai middleware generik | Dimensi "per email" untuk `resend` butuh body ter-parse — middleware generik gin berjalan sebelum body dibaca, sehingga tidak punya akses ke email. Dicek eksplisit di dalam masing-masing handler setelah `ShouldBindJSON`. |
+| Angka rate limit (5/jam register, 3/jam+10/jam resend) adalah **default sementara**, bukan keputusan final | Freeze & `STATUS.md` sendiri mencatat "strategi rate limit final" sebagai keputusan terbuka hingga Phase 4/traffic nyata. Nilai di sini cukup untuk membuktikan mekanismenya aktif (acceptance criteria), bukan hasil tuning. |
+| **Test isolasi tenant untuk endpoint baru — tidak berlaku langsung di #9** | Definition of Done template menyebutnya secara generik, tapi ketiga endpoint di issue ini (`register`, `verify-email`, `verify-email/resend`) **tidak terautentikasi** — `register` justru **membuat** tenant, dan `verify-email`/`resend` beroperasi pada `users`/`email_verification_tokens` yang global. Tidak ada boundary lintas-tenant untuk diuji di sini karena belum ada sesi yang membawa `organization_id`. Pengujian isolasi tenant yang sesungguhnya dimulai di #10 (token terikat satu organization) dan #11 (harness generik lapis 4). Yang paling dekat dengan "isolasi" di #9: setiap registrasi menghasilkan `organization_id` baru yang independen — diverifikasi implisit lewat `TestRegister_CreatesFourRowsAtomically` dan `TestRegister_DuplicateEmail_LeavesNothingBehind`. |
+
+### Keputusan implementasi
+
+- **Deteksi email duplikat lewat *unique violation* Postgres, bukan `SELECT` lalu `INSERT`.** Menghindari race check-then-act di bawah registrasi konkuren untuk email yang sama. `user.Repository.Create` memeriksa `pgconn.PgError.Code == "23505"` **dan** `ConstraintName == "users_email_key"` secara spesifik — bukan asal kode 23505 apapun — supaya *unique violation* dari constraint lain (mis. token hash) tidak salah diterjemahkan jadi `email_already_registered`.
+- **Seluruh insert registrasi (organization, user, membership, subscription, token verifikasi, audit log) berada dalam satu `db.InTx`.** Token verifikasi sengaja dibuat **di dalam** transaksi yang sama, bukan setelah commit — supaya tidak ada state "user ada tapi tidak punya token untuk verifikasi" bila proses crash di antara keduanya. Hanya pengiriman email yang berada di luar transaksi (Aturan #32).
+- **`VerifyEmail` menyamakan token hilang/kedaluwarsa/sudah dipakai** — `verificationRepository.FindValidByHash` memakai satu query (`used_at IS NULL AND expires_at > now()`) yang mengembalikan `httpx.ErrNotFound` untuk ketiganya, diterjemahkan seragam jadi `invalid_token`. Klien tidak bisa membedakan ketiga kasus lewat response.
+- **Audit log `email.verified` mengasumsikan tepat satu membership aktif** pada saat verifikasi (`FindActiveByUserID`, ambil elemen pertama). Ini benar sepanjang Phase 1 karena user baru selalu lahir dengan satu membership dari registrasi. Akan perlu ditinjau ulang begitu #11 membuat multi-membership umum terjadi **sebelum** verifikasi selesai (mis. diundang ke organization kedua sebelum memverifikasi email organisasi pertama) — dicatat sebagai kondisi tepi untuk #11, bukan blocker sekarang karena skenario itu butuh urutan kejadian yang tidak mungkin di alur produk saat ini (undangan mensyaratkan akun yang sudah ada).
+- **`ResendVerification` tidak pernah mengembalikan error ke handler** — signature-nya `func(ctx, email)` tanpa `error`, karena endpoint selalu 202 apapun yang terjadi secara internal (email tidak ditemukan, sudah terverifikasi, gagal generate token). Kegagalan internal dicatat ke logger, tidak pernah bocor ke response.
+- **`looksLikeEmail` sengaja validasi minimal** (ada `@` dengan sesuatu di kedua sisi) — bukan regex RFC 5322 penuh. Validasi format yang lebih ketat tidak menambah keamanan (keunikan sudah ditegakkan database) dan berisiko menolak alamat sah yang tidak lazim. Konsisten Aturan #27.
+
+### Verifikasi
+
+```
+go test -race -count=1 ./...    → semua paket PASS, 2× berturut-turut
+golangci-lint run                → 0 issues (5 errcheck + 1 staticcheck ditemukan & diperbaiki)
+gofmt -l .                       → bersih
+go list -deps ./cmd/api | grep docker → kosong (binary produksi tetap bersih meski testcontainers dipakai luas di test)
+```
+
+19 test baru di `internal/auth`, mencakup seluruh acceptance criteria issue:
+
+| Acceptance criteria | Test |
+|---|---|
+| Registrasi sukses → 4 baris + audit + email | `TestRegister_CreatesFourRowsAtomically` |
+| Kegagalan di tengah transaksi → tidak ada baris tersimpan | `TestRegister_DuplicateEmail_LeavesNothingBehind` |
+| `LogMailer` gagal → registrasi tetap commit | `TestRegister_MailerFailure_StillCommits` |
+| Email sudah terdaftar → 409 | `TestRegister_DuplicateEmail_LeavesNothingBehind`, `TestHandler_Register_DuplicateEmail_Returns409` |
+| Resend email tak dikenal → 202, tidak ada email terkirim | `TestResendVerification_UnknownEmail_SendsNothing` |
+| Token sekali pakai, dipakai dua kali → `invalid_token` | `TestVerifyEmail_TokenUsedTwice_SecondAttemptFails` |
+| Token kedaluwarsa ditolak | `TestVerifyEmail_ExpiredToken_Rejected` |
+| Rate limit terbukti aktif | `TestHandler_Register_RateLimited`, `TestHandler_ResendVerification_RateLimitedPerEmail` |
+
+Ditambah di luar checklist eksplisit: `TestPassword_HashIsNeverPlaintext` (jaring pengaman terhadap regresi paling merusak yang mungkin terjadi di paket ini), dan test HTTP-level untuk register/verify-email/resend di `handler_test.go`.
+
+### Utang teknis
+
+- **Peta `map[string]*bucket` di `ratelimit.FixedWindow` tidak pernah dibersihkan** — tumbuh tanpa batas seiring key baru (IP/email) muncul. Untuk volume MVP tidak masalah; perlu eviction (TTL sederhana atau `sync.Map` + goroutine pembersih berkala) sebelum traffic produksi nyata. Belum jadi masalah karena provider email sungguhan (dan karenanya traffic pendaftaran nyata) masih menunggu domain.
+- **Angka rate limit belum final** (lihat Menyimpang dari TD) — perlu direvisi berdasarkan data nyata di Phase 4 atau lebih awal bila terbukti terlalu ketat/longgar saat pengujian manual dengan pengguna sungguhan.
+- **HIBP (cek password bocor) belum diimplementasikan** — dicatat di TD §3 sebagai kandidat, sengaja tidak dikerjakan di sini (butuh panggilan HTTP eksternal, di luar cakupan issue).
+
+### Catatan untuk session berikutnya
+
+- **`httpx.DomainError` adalah titik ekstensi utama mulai sekarang** — #10 dan #11 akan menambah lebih banyak kode error (`invalid_credentials`, `email_not_verified`, `organization_selection_required`, dst.) lewat pola yang sama, bukan menambah sentinel baru di `httpx`.
+- **`internal/shared/password`, `token`, `mailer`, `ratelimit` adalah dependensi bersama** — #10 (reset password, login) dan #11 (invitation) memakainya langsung, tidak menulis ulang.
+- **`auth.Service` akan tumbuh** — `RegisterService`/`VerifyEmail`/`ResendVerification` sekarang; #10 menambah `Login`, `Refresh`, `Logout`, `ForgotPassword`, `ResetPassword` ke struct `Service` yang sama (satu domain "auth", sesuai skill).
+- **`internal/organization.Repository` belum punya method `Update`** (mis. ubah timezone) — belum dibutuhkan siapapun. Tambahkan hanya saat ada pemakai nyata (Aturan #27).


### PR DESCRIPTION
Refs #9

## Apa yang berubah

`POST /v1/auth/register`, `/verify-email`, `/verify-email/resend`. Registrasi atomik (6 insert dalam satu `db.InTx`: organization, user, membership owner, subscription free, token verifikasi, audit log), argon2id, dan `Mailer` dengan `LogMailer`.

## Mekanisme baru — `httpx.DomainError`

Domain error (`email_already_registered`, `invalid_token`) butuh status/code/message spesifik tanpa membuat `internal/shared/httpx` mengimpor paket domain (itu akan membalik arah dependensi). `DomainError{Status, Code, Message}` dikenali `MapError` lewat `errors.As` — domain manapun tinggal `return &httpx.DomainError{...}`. Dipakai lagi tanpa perubahan di #10 dan #11.

## Empat paket shared baru

`internal/shared/{password,token,mailer,ratelimit}` — argon2id, generator token sekali-pakai, interface Mailer, dan fixed-window rate limiter in-memory. Semuanya dipakai langsung oleh #10 (login, reset password) dan #11 (invitation), tidak ditulis ulang.

## Deteksi email duplikat — lewat error Postgres, bukan SELECT lalu INSERT

`user.Repository.Create` mendeteksi *unique violation* (`23505` pada constraint `users_email_key` **secara spesifik**, bukan asal 23505 apapun) alih-alih SELECT-check-then-INSERT — itu race di bawah registrasi konkuren untuk email yang sama.

## ⚠️ Klarifikasi Definition of Done — "test isolasi tenant" tidak berlaku langsung di sini

Template DoD menyebutnya generik, tapi ketiga endpoint di issue ini **tidak terautentikasi**: `register` justru **membuat** tenant, dan `verify-email`/`resend` beroperasi pada `users`/`email_verification_tokens` yang global. Tidak ada boundary lintas-tenant untuk diuji — itu dimulai di #10 (token terikat satu organization) dan #11 (harness generik lapis 4).

Yang paling dekat dengan "isolasi" di sini: setiap registrasi menghasilkan `organization_id` independen, diverifikasi di `TestRegister_CreatesFourRowsAtomically` dan `TestRegister_DuplicateEmail_LeavesNothingBehind`.

## Test

19 test baru di `internal/auth`, memetakan langsung ke seluruh acceptance criteria issue (rincian: `notes.md`). Termasuk **rate limit dibuktikan aktif** di level HTTP (`TestHandler_Register_RateLimited`, `TestHandler_ResendVerification_RateLimitedPerEmail`) — bukan hanya kode ada, tapi request ke-6/ke-4 benar-benar dapat 429.

## Cara menguji

```bash
cd crm_be
go test -race -count=1 ./...     # 2× berturut-turut, semua PASS
golangci-lint run                 # 0 issues (5 errcheck + 1 staticcheck ditemukan & diperbaiki)
go list -deps ./cmd/api | grep -i docker   # kosong — binary produksi bersih meski testcontainers dipakai luas di test
```

## Checklist

- [x] Test lolos
- [x] Registrasi atomik — diverifikasi lewat query count sebelum/sesudah, bukan asumsi
- [x] `LogMailer` gagal → registrasi tetap commit (Aturan #32)
- [x] Tidak ada `organization_id` di DTO manapun
- [x] Efek samping eksternal (email) tidak di dalam transaksi
- [x] Tidak ada rahasia ter-commit
- [x] `notes.md` dan `STATUS.md` diperbarui

## Catatan untuk reviewer

Paling ingin dikonfirmasi:

1. **`httpx.DomainError`** — pola ini akan dipakai berulang mulai #10; kalau ada keberatan arsitektural, sekarang saat termudah mengubahnya
2. **Angka rate limit** (5/jam register, 3+10/jam resend) — sengaja bukan angka final, hanya untuk membuktikan mekanisme aktif
3. **Klarifikasi DoD isolasi tenant** di atas — apakah pembacaan saya terhadap cakupan issue ini tepat
