### PR TITLE
docs(phase-2): PRD, TD, dan indeks issue untuk CRM Core

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 21 Agustus 2026 — Issue #11 selesai, **Phase 1 selesai**
-**Phase sekarang:** Phase 2 — CRM Core (belum dimulai — PRD+TD berikutnya)
+**Last updated:** 21 Agustus 2026 — PRD + TD Phase 2 dibuka, B6–B9 ditutup
+**Phase sekarang:** Phase 2 — CRM Core (0/5 issue selesai — implementasi dimulai di #19)
 
 ---
 
@@ -40,12 +40,12 @@ _(kosong)_
 
 ## Berikutnya
 
-**Phase 2 — CRM Core**
+**Issue #19 — Schema 0003, repository lead, alokasi `lead_number`, optimistic locking**
 
-- Phase 1 (Auth & Organization) selesai — #8, #9, #10, #11, #15, plus ADR-011.
-- Sesuai `docs/workflow.md`/ADR-008: mulai dengan PRD + TD Phase 2, **bukan** langsung issue implementasi. Cakupan Phase 2 per freeze bagian 3.1/4: Lead (CRUD, status + transisi, source, filter, pagination, idempotency, `lead_number`, `version`), Assignment manual ke membership, Activity append-only, Task, Customer (konversi dari Lead), Notification.
-- `cmd/api/tenant_isolation_test.go`'s `[]isolationCase` sudah siap menerima entri `lead` begitu endpoint-nya ada — lihat notes.md `## #11`.
-- `internal/shared/authz`'s matriks baru mencakup Membership; Phase 2 menambah `Action` untuk Lead/Customer/dst mengikuti `architecture_product_review.md` §6.2.
+- Cakupan & acceptance: [issue #19](https://github.com/Pravasta/jualin-crm/issues/19)
+- TD: `docs/phases/02-crm-core/td.md` §1, §3, §4, §9, §16
+- Issue pertama Phase 2, **tanpa endpoint sama sekali** — menetapkan dua mekanisme paling halus di phase ini (serialisasi `lead_number` per organization, optimistic locking `version`) yang keduanya hanya bisa dipercaya bila diuji di bawah konkurensi nyata.
+- Berurutan: #19 → #20 → #21 → #22 → #23. Rincian di `docs/phases/02-crm-core/issues.md`.
 
 ---
 
@@ -70,10 +70,6 @@ Tidak ada yang memblokir. Semuanya diputuskan saat fitur terkait dikerjakan.
 
 | Kode | Keputusan | Diputuskan sebelum |
 |---|---|---|
-| B6 | Daftar `lost_reason` final | Phase 2 |
-| B7 | Boleh mengubah status lead mundur? | Phase 2 |
-| B8 | Task boleh berdiri tanpa Lead? | Phase 2 |
-| B9 | Konversi ke Customer otomatis saat `won`? | Phase 2 |
 | — | Email provider (Resend / Postmark / SES) | Phase 1 — ⏳ *lead time, lihat bawah* |
 | — | Domain final & branding | Phase 1 — ⏳ *lead time, lihat bawah* |
 | — | Hosting & managed PostgreSQL | Phase 0 akhir |
@@ -84,6 +80,8 @@ Tidak ada yang memblokir. Semuanya diputuskan saat fitur terkait dikerjakan.
 | — | Kontrak integrasi payment service | Sebelum Phase 8 |
 
 Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 dan `docs/brainstorming/architecture_product_review.md` bagian 12.
+
+> **B6–B9 ditutup** saat PRD Phase 2 dibuka (21 Agustus 2026), seluruhnya mengikuti rekomendasi freeze: `lost_reason` 6 nilai · mundur satu langkah · `tasks.lead_id NOT NULL` · konversi ke Customer adalah aksi eksplisit. Alasan tiap keputusan ada di `docs/phases/02-crm-core/prd.md` bagian *Keputusan yang ditutup di phase ini*.
 
 ---
 
@@ -121,7 +119,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 |---|---|---|---|---|---|
 | 0 | Foundation | ✅ | ✅ | ✅ #1–#3 | ✅ |
 | 1 | Auth & Organization | ✅ | ✅ | ✅ #8–#11, #15 | ✅ |
-| 2 | CRM Core | ⬜ | ⬜ | ⬜ | ⬜ |
+| 2 | CRM Core | ✅ | ✅ | ✅ #19–#23 | ⬜ |
 | 3 | Owner Dashboard | ⬜ | ⬜ | ⬜ | ⬜ |
 | 4 | Public API | ⬜ | ⬜ | ⬜ | ⬜ |
 | 5 | Employee Mobile | ⬜ | ⬜ | ⬜ | ⬜ |

--- a/docs/phases/02-crm-core/issues.md
+++ b/docs/phases/02-crm-core/issues.md
@@ -1,0 +1,73 @@
+# Phase 2 — CRM Core · Issues
+
+> Indeks pekerjaan. **Tanpa kolom status** — status hidup di GitHub ([ADR-008](../../decisions/ADR-008-delivery-workflow.md)).
+>
+> Status terkini: `gh issue list --milestone "Phase 2 — CRM Core"`
+
+**Milestone:** [Phase 2 — CRM Core](https://github.com/Pravasta/jualin-crm/milestone/3)
+
+---
+
+## Daftar
+
+| # | Judul | Cakupan | TD |
+|---|---|---|---|
+| [19](https://github.com/Pravasta/jualin-crm/issues/19) | Schema 0003, repository lead, alokasi `lead_number`, optimistic locking | 4 tabel + `ALTER organizations`, repository lead + visibilitas employee, serialisasi nomor, `version` | §1, §3, §4, §9 |
+| [20](https://github.com/Pravasta/jualin-crm/issues/20) | Lead CRUD, transisi status, filter, pagination, idempotency, E.164 | Usecase + HTTP lead, validasi transisi, `Idempotency-Key`, `phone.ToE164` | §4, §5, §6, §7, §8, §8.1, §9 |
+| [21](https://github.com/Pravasta/jualin-crm/issues/21) | Activity append-only + auto-log, dan Task | Timeline otomatis dalam transaksi yang sama, task `lead_id NOT NULL` | §1.3, §1.4, §8, §10 |
+| [22](https://github.com/Pravasta/jualin-crm/issues/22) | Assignment, notification (`0004`), penutupan kewajiban penonaktifan membership | Assignment + notification atomik, **kewajiban warisan Phase 1** | §2, §8, §11, §13 |
+| [23](https://github.com/Pravasta/jualin-crm/issues/23) | Customer, konversi dari lead, kasus `lead` pada harness isolasi | Konversi eksplisit (B9), CRUD customer, **penutup phase** | §1.2, §8, §12, §16, §18 |
+
+---
+
+## Urutan
+
+Kelimanya **berurutan**, tidak bisa diparalelkan:
+
+```
+#19 schema & konkurensi ──► #20 lead ──► #21 activity & task ──► #22 assignment & notification ──► #23 customer & harness
+```
+
+| Dependensi | Alasan |
+|---|---|
+| #20 → #19 | Butuh tabel, repository, alokasi nomor, dan optimistic locking |
+| #21 → #20 | Activity otomatis dipicu peristiwa lead; task menempel pada lead |
+| #22 → #21 | Assignment menghasilkan activity **dan** notification sekaligus |
+| #23 → #21 | Konversi menghasilkan activity `lead_converted` |
+
+**Harness isolasi sengaja ditutup di #23**, bukan dimulai di #19 — supaya ia mencakup seluruh endpoint phase ini sekaligus, bukan ditambal empat kali.
+
+---
+
+## Batas per issue
+
+| Issue | Berhenti di |
+|---|---|
+| #19 | **Tidak ada endpoint sama sekali.** Hanya schema, repository, dan test konkurensi. |
+| #20 | Lead berdiri sendiri — belum ada timeline, belum ada task, belum bisa di-assign. |
+| #21 | Task ada dan lead punya timeline, tapi assignment belum menghasilkan notification. |
+| #22 | Belum ada customer — lead `won` berhenti di situ. |
+| #23 | Phase 2 tutup. Dashboard, API publik, dan mobile **tidak** disentuh. |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Dua issue yang perlu perhatian ekstra saat review
+
+**#19 — tidak menghasilkan perilaku yang bisa dilihat.** Nilainya seluruhnya ada di test konkurensi: N goroutine membuat lead bersamaan, dan `lead_number` harus 1..N tanpa lubang. Test berurutan akan hijau bahkan bila locking-nya dihapus total — jadi yang layak direview di PR itu adalah **apakah test-nya benar-benar konkuren**, bukan apakah kodenya rapi.
+
+**#22 — menutup kewajiban yang sudah menunggu sejak Phase 1.** Penonaktifan membership dengan lead terbuka **harus menolak secara default**. Diam-diam melepas assignment saat seseorang resign adalah persis kegagalan senyap yang aturan ini ada untuk mencegahnya (freeze 2.3): lead tetap ter-assign ke orang yang tidak bisa login lagi, tidak muncul di "My Leads" siapapun, dan tidak tertangkap filter "belum ter-assign".
+
+---
+
+## Setelah kelimanya selesai
+
+Phase 2 tutup bila **14 acceptance criteria** di [`prd.md`](./prd.md) terpenuhi. Lalu:
+
+1. `authorization.md` diperbarui — matriks Lead/Task/Activity/Customer jadi nyata, aturan #1 terwujud
+2. `multi-tenancy.md` — tabel lapis 4: kasus #1 dan #4 dari "belum ada kasus nyata" menjadi ✅
+3. `docs/STATUS.md` — Phase 2 ✅, utang teknis (retensi `idempotency_key`) dicatat
+4. Buka **Phase 3 — Owner Dashboard**: PRD + TD, pecah issue
+
+> Phase 3 adalah **demo pertama** (freeze bagian 4) — produk bisa dipakai tanpa `curl`. Ia juga phase pertama di luar `crm_be`, sehingga PRD-nya perlu membahas hal yang belum pernah dibahas: setup Next.js, penyimpanan token di sisi client, dan bentuk error yang ditampilkan ke pengguna.

--- a/docs/phases/02-crm-core/prd.md
+++ b/docs/phases/02-crm-core/prd.md
@@ -1,0 +1,132 @@
+# Phase 2 — CRM Core · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md).
+> Sumber: [`architecture/freeze.md`](../../architecture/freeze.md) bagian 4 (Phase 2), 2.3 (keputusan modeling), 2.4 (lead status), 2.5 (activity type), 8.4 (migration `0003`/`0004`), A3 (notification) · [ADR-006](../../decisions/ADR-006-lead-status-as-pipeline.md)
+
+---
+
+## Tujuan
+
+Membangun **produk yang sebenarnya**: siklus hidup lead dari masuk sampai menjadi pelanggan.
+
+Phase 0 menyiapkan lantai, Phase 1 menyiapkan dinding tenancy. Phase 2 adalah yang pertama menghasilkan sesuatu yang bisa disebut CRM — dan yang pertama menyimpan **data pelanggan milik pelanggan Anda**.
+
+> Ini juga phase yang membuktikan bahwa fondasi Phase 1 benar. Harness isolasi tenant sampai sekarang hanya bisa menguji membership dan invitation; begitu `leads` ada, ia akhirnya bisa menguji apa yang sebenarnya dijaga — data bisnis, dan aturan "employee hanya melihat lead miliknya".
+
+---
+
+## Kebutuhan
+
+| # | Sebagai… | Saya butuh… | Supaya… |
+|---|---|---|---|
+| 1 | Owner | Mencatat lead yang masuk lewat jalur apapun | Tidak ada calon pembeli yang hilang di WhatsApp atau catatan kertas |
+| 2 | Owner | Menyebut lead dengan nomor yang bisa diucapkan (`#1024`) | Bisa membahasnya di telepon dan grup tanpa membacakan UUID |
+| 3 | Owner | Menugaskan lead ke sales tertentu | Setiap lead punya penanggung jawab yang jelas |
+| 4 | Employee | Melihat **hanya** lead yang ditugaskan ke saya | Tidak tenggelam dalam daftar seluruh organisasi |
+| 5 | Employee | Diberi tahu saat ada lead baru untuk saya | Bisa merespons cepat, tanpa harus memantau layar |
+| 6 | Siapa pun | Melihat riwayat lengkap apa yang sudah terjadi pada sebuah lead | Bisa melanjutkan pekerjaan orang lain tanpa bertanya |
+| 7 | Employee | Mencatat tindak lanjut yang harus dilakukan, dengan tenggat | Tidak lupa menelepon balik |
+| 8 | Owner | Mengubah status lead mengikuti kemajuan nyata | Bisa melihat funnel yang mencerminkan keadaan sebenarnya |
+| 9 | Owner | Mengubah lead yang berhasil menjadi pelanggan | Relasi jangka panjang tercatat terpisah dari proses penjualannya |
+| 10 | Owner | Menyaring lead (status, pemilik, sumber, periode, kata kunci) | Bisa menjawab "mana yang belum ditangani" dalam hitungan detik |
+| 11 | Sistem pengirim (Phase 4) | Mengirim ulang request yang timeout tanpa membuat lead ganda | Retry tidak merusak data pelanggan |
+
+---
+
+## Acceptance Criteria
+
+Phase 2 selesai bila **semuanya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | Lead bisa dibuat, dibaca, diubah, dan di-soft-delete lewat API internal, seluruhnya tenant-scoped |
+| 2 | `lead_number` dialokasikan **berurutan per organization mulai dari 1**, tanpa lubang dan tanpa duplikat, **dibuktikan di bawah pembuatan bersamaan** |
+| 3 | Perubahan bersamaan pada lead/task yang sama → tepat satu berhasil, sisanya **409** dengan keadaan terkini — tidak pernah menimpa diam-diam |
+| 4 | Transisi status divalidasi di usecase: mundur satu langkah diizinkan, melompat maju ditolak, `lost` wajib disertai `lost_reason` |
+| 5 | `spam` dan `unqualified` **dikecualikan** dari perhitungan konversi |
+| 6 | Nomor telepon dinormalisasi ke E.164; nomor yang tidak bisa diurai **tetap diterima** dan tersimpan apa adanya |
+| 7 | `Idempotency-Key` yang diulang mengembalikan **response asli**, bukan lead kedua dan bukan error |
+| 8 | Setiap peristiwa penting pada lead menghasilkan activity **otomatis**, dalam transaksi yang sama — timeline tidak pernah bercerai dari kejadiannya |
+| 9 | Activity **append-only**: tidak ada endpoint edit maupun hapus, dan tidak ada kolom `updated_at`/`deleted_at` |
+| 10 | Assignment menghasilkan notification untuk employee yang ditugaskan, dalam transaksi yang sama |
+| 11 | **Employee hanya bisa membaca lead yang di-assign kepadanya** — ditegakkan di **repository**, dan lead milik employee lain → **404**, bukan 403 |
+| 12 | Konversi ke Customer adalah **aksi eksplisit**; masuk status `won` tidak mengonversi apapun secara otomatis |
+| 13 | Menonaktifkan membership **menolak berjalan** bila masih ada lead terbuka miliknya, kecuali disertai keputusan eksplisit (reassign / lepas assignment) — kewajiban yang diteruskan Phase 1 |
+| 14 | Harness isolasi tenant bertambah kasus `lead` dan **tetap terbukti bisa gagal** |
+
+---
+
+## Keputusan yang ditutup di phase ini
+
+Empat keputusan yang `STATUS.md` tandai *"diputuskan sebelum Phase 2"* — ditutup di sini, bukan diserahkan ke tengah implementasi:
+
+| # | Pertanyaan | Keputusan | Alasan |
+|---|---|---|---|
+| **B6** | Daftar `lost_reason` final | `price` · `competitor` · `timing` · `no_response` · `not_interested` · `other` | Menutup alasan kalah yang lazim, `other` sebagai katup pengaman. Teks bebas ditolak: *"kemahalan"*, *"harga"*, dan *"mahal"* akan menjadi tiga kategori berbeda dan laporan kalah-menang kehilangan artinya. |
+| **B7** | Boleh mengubah status mundur? | **Ya, satu langkah.** Melompat maju ditolak. | Salah klik adalah kejadian normal; membuatnya permanen berarti butuh jalur koreksi tersendiri. Mundur bebas ditolak karena membuat funnel tidak bermakna — lead bisa "lahir kembali" berkali-kali. |
+| **B8** | Task boleh berdiri tanpa Lead? | **Tidak** — `lead_id NOT NULL` | Melonggarkan `NOT NULL` nanti adalah satu `ALTER`; mengetatkannya berarti membersihkan baris yatim lebih dulu. Task pribadi tanpa lead belum ada di core flow. |
+| **B9** | Konversi otomatis saat `won`? | **Tidak** — aksi eksplisit | Sudah ditetapkan freeze 2.4 aturan 5. `won` berarti kesepakatan tercapai; konversi berarti relasi pelanggan dibuat. Keduanya kejadian berbeda dan tidak selalu terjadi bersamaan. |
+
+---
+
+## Di luar cakupan
+
+| Tidak dikerjakan | Ke |
+|---|---|
+| Dashboard UI apapun | Phase 3 |
+| API Key, `POST /v1/leads` publik, dokumentasi integrator | Phase 4 |
+| Mobile app, push notification, `device_tokens` | Phase 5 |
+| Embedded form, `forms`, `source_form_id` | Phase 6 |
+| Webhook masuk & keluar | Phase 7 |
+| Penegakan limit / usage / quota | Phase 8 |
+| Deal, Pipeline sebagai entity, automation, reports lanjutan | Phase 9 |
+| Dedup bisnis (`possible_duplicate_of`) | Belum dijadwalkan — lihat catatan di bawah |
+| Attribution channel (Website, Facebook, Referral, …) | Belum dijadwalkan — berbeda dimensi dari `source` |
+| Round robin / assignment rule otomatis | Setelah assignment manual terbukti dipakai |
+| Custom field, Contact, Team | Saat diminta |
+| Import/export CSV | **Naikkan prioritas bila calon pelanggan datang dari spreadsheet** |
+
+### Tiga hal yang sengaja tertahan
+
+**Dedup bisnis.** `architecture_product_review.md` §4 menganjurkan menandai lead dengan telepon/email sama dalam 30 hari sebagai `possible_duplicate_of`. Yang dikerjakan Phase 2 hanya **idempotency teknis** (`Idempotency-Key`) — retry yang menghasilkan lead ganda. Keduanya sering dikira satu hal; keduanya berbeda. Dedup bisnis butuh keputusan produk yang belum diambil (ambang waktu, apakah ditampilkan sebagai peringatan atau blokir), dan menebaknya sekarang berarti membangun perilaku yang mungkin dibatalkan.
+
+**Attribution channel.** `source` menjawab *"lewat pintu mana lead masuk"* (`manual` · `api` · `form` · `webhook`), bukan *"dari kampanye mana"*. Menggabungkan keduanya ke satu enum mencampur dua dimensi dan membuat laporan mustahil dibaca (freeze 2.3).
+
+**`source_api_key_id` dan `source_form_id`.** `leads` dibuat **tanpa** kedua kolom itu; keduanya menyusul bersama tabel tujuannya di `0005` dan `0007` (freeze 8.4). Nilai enum `api` dan `form` sudah diterima `leads.source` sejak `0003` — nilai enum boleh mendahului FK-nya, dan menambah kolom nullable ke tabel yang sudah ada bersifat instan.
+
+---
+
+## Dependensi
+
+Phase 1 selesai — tenancy, `tenant.Context`, pola repository tenant-scoped, `Store`/`Repos`, `authn`, `authz`, audit log, dan harness isolasi tenant semuanya sudah ada.
+
+**Satu kewajiban diwarisi dari Phase 1** ([`01-auth-organization/td.md`](../01-auth-organization/td.md) §17): penonaktifan membership harus menolak berjalan bila masih ada lead terbuka. Di Phase 1 aturan itu belum bisa ditegakkan karena `leads` belum ada — Phase 2 wajib menutupnya, dan ia masuk sebagai acceptance criterion #13, bukan sebagai catatan.
+
+**Tidak ada keputusan yang memblokir.** B6–B9 ditutup di atas.
+
+---
+
+## Pembagian issue
+
+Freeze memetakan Phase 2 sebagai **empat** session. Setelah melihat isinya — 5 tabel, dua migration, ~15 endpoint, alokasi nomor di bawah konkurensi, optimistic locking, idempotency, dan aturan visibilitas employee yang ditegakkan di repository — saya pecah menjadi **lima**, dengan memisahkan lapisan schema/konkurensi dari lapisan HTTP:
+
+| Urut | Issue | Kenapa dipisah |
+|---|---|---|
+| 1 | Schema `0003` + repository lead + alokasi `lead_number` + optimistic locking | Dua mekanisme paling halus di seluruh phase ini — serialisasi nomor per organization dan deteksi konflik tulis — dan keduanya hanya bisa dipercaya bila diuji **di bawah konkurensi nyata**. Menumpuk HTTP di atasnya sebelum keduanya terbukti berarti mereview keduanya sekaligus. |
+| 2 | Lead CRUD, transisi status, filter, pagination, idempotency, E.164 | Lapisan HTTP + aturan bisnis lead di atas fondasi yang sudah terbukti |
+| 3 | Activity (append-only + auto-log) + Task | Timeline dan tindak lanjut; keduanya bergantung pada peristiwa lead dari #2 |
+| 4 | Assignment + Notification (`0004`) + **penutupan kewajiban Phase 1** | Assignment memicu activity (#3) **dan** notification sekaligus; kewajiban "tolak nonaktifkan bila ada lead terbuka" jatuh di sini karena baru di sini semua bahannya ada |
+| 5 | Customer + konversi + kasus `lead` pada harness isolasi | Konversi butuh lead di status `won` (#2) dan menghasilkan activity (#3). Harness ditutup terakhir supaya mencakup seluruh endpoint phase ini. |
+
+Ini **penyimpangan dari peta session di freeze**, dicatat di sini agar terlihat — pola yang sama dipakai Phase 1 (3 → 4). Bila Anda lebih memilih empat PR, katakan saat review: #1 dan #2 tinggal digabung.
+
+Rincian: [`issues.md`](./issues.md)
+
+---
+
+## Bukan tujuan phase ini
+
+- **Bukan** membangun UI apapun — seluruh verifikasi lewat test dan `curl`
+- **Bukan** membekukan bentuk API publik — itu Phase 4, dan justru phase inilah yang memvalidasi bentuknya lebih dulu lewat pemakaian internal
+- **Bukan** mengoptimasi query — index dipasang mengikuti Aturan #16, tapi belum ada volume untuk diukur
+- **Bukan** menyiapkan struktur untuk Deal, Form, atau Webhook yang "sudah pasti datang" (Aturan #27, #28)

--- a/docs/phases/02-crm-core/td.md
+++ b/docs/phases/02-crm-core/td.md
@@ -1,0 +1,691 @@
+# Phase 2 — CRM Core · Technical Design
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+>
+> Memuat **delta** untuk Phase 2. Yang sudah ada di [`freeze.md`](../../architecture/freeze.md), [`multi-tenancy.md`](../../architecture/multi-tenancy.md), [`api.md`](../../architecture/api.md), [`authentication.md`](../../architecture/authentication.md), [`authorization.md`](../../architecture/authorization.md), dan `.claude/skills/jualin-backend/` **tidak diulang** — hanya dirujuk.
+
+---
+
+## 1. Schema — migration `0003_crm_core`
+
+Freeze bagian 8.4 menetapkan isinya; bentuk kolom **tidak** ditetapkan di sana (freeze 8.3 hanya merinci `0002`), sehingga diputuskan di dokumen ini.
+
+| Tabel | Kelas | Catatan |
+|---|---|---|
+| `leads` | tenant-scoped | Domain inti. `lead_number` + `version` + `idempotency_key` |
+| `customers` | tenant-scoped | Hasil konversi Lead, entity terpisah |
+| `activities` | tenant-scoped | **Append-only** — tanpa `updated_at`, tanpa `deleted_at` |
+| `tasks` | tenant-scoped | `lead_id NOT NULL` (B8), `version` |
+| `organizations` | — | `ALTER ADD next_lead_number integer NOT NULL DEFAULT 1` |
+
+### 1.1 `leads`
+
+```sql
+CREATE TABLE leads (
+    id                        uuid PRIMARY KEY,
+    organization_id           uuid NOT NULL REFERENCES organizations (id),
+    lead_number               integer NOT NULL,
+
+    name                      text NOT NULL,
+    email                     text,
+    phone                     text,
+    phone_e164                text,
+    company                   text,
+    notes                     text,
+
+    status                    text NOT NULL DEFAULT 'new',
+    lost_reason               text,
+    source                    text NOT NULL,
+    assigned_to_membership_id uuid,
+
+    raw_payload               jsonb,
+    idempotency_key           text,
+    version                   integer NOT NULL DEFAULT 1,
+
+    created_by_membership_id  uuid,
+    created_at                timestamptz NOT NULL DEFAULT now(),
+    updated_at                timestamptz NOT NULL DEFAULT now(),
+    deleted_at                timestamptz,
+
+    CONSTRAINT ck_leads_status CHECK (status IN
+        ('new','contacted','qualified','proposal','won','lost','unqualified','spam')),
+    CONSTRAINT ck_leads_source CHECK (source IN ('manual','api','form','webhook')),
+    CONSTRAINT ck_leads_lost_reason CHECK (lost_reason IS NULL OR lost_reason IN
+        ('price','competitor','timing','no_response','not_interested','other')),
+    CONSTRAINT ck_leads_lost_requires_reason CHECK (status <> 'lost' OR lost_reason IS NOT NULL),
+    CONSTRAINT ck_leads_email_lowercase CHECK (email IS NULL OR email = lower(email)),
+
+    CONSTRAINT uq_leads_id_org UNIQUE (id, organization_id),
+    CONSTRAINT uq_leads_org_number UNIQUE (organization_id, lead_number),
+
+    CONSTRAINT fk_leads_assignee
+        FOREIGN KEY (assigned_to_membership_id, organization_id)
+        REFERENCES memberships (id, organization_id),
+    CONSTRAINT fk_leads_creator
+        FOREIGN KEY (created_by_membership_id, organization_id)
+        REFERENCES memberships (id, organization_id)
+);
+```
+
+| Keputusan | Alasan |
+|---|---|
+| **Tidak ada `CHECK` yang mewajibkan email atau telepon** | Menolak lead di titik ingest berarti membuang data pelanggan — kerusakan yang tidak bisa dibatalkan (freeze 2.3). Lead tanpa kontak diterima; UI menandainya tidak dapat ditindaklanjuti. |
+| `created_by_membership_id` **nullable** | Lead dari `api`/`form`/`webhook` tidak punya pembuat manusia. `NOT NULL` akan memaksa membuat membership palsu untuk sistem. |
+| `ck_leads_lost_requires_reason` di **database**, bukan hanya usecase | Aturan #4 acceptance criteria. Validasi usecase memberi pesan error yang baik; constraint database memastikan tidak ada jalur lain (migration, perbaikan manual) yang bisa melanggarnya. |
+| Tidak ada kolom nilai/revenue | Deal ditunda pasca-Phase 5; freeze 3.2 menyatakan Phase 3 **tanpa** angka revenue. Menambah kolom uang sekarang berarti kolom mati yang mengundang pengisian tidak konsisten. |
+| `raw_payload jsonb` — **alasan tertulis wajib (Aturan #17)** | Payload dari sumber eksternal (`api`, `form`, `webhook`) berbentuk sembarang dan **tidak boleh dibuang**: field tak dikenal tetap tersimpan supaya lead bisa direkonstruksi saat integrator melapor "data saya hilang". Tidak pernah di-query isinya di Phase 2 — hanya disimpan dan ditampilkan apa adanya. |
+
+**Index** (Aturan #16 — selalu berawalan `organization_id`):
+
+```sql
+CREATE INDEX ix_leads_org_status    ON leads (organization_id, status)      WHERE deleted_at IS NULL;
+CREATE INDEX ix_leads_org_assignee  ON leads (organization_id, assigned_to_membership_id) WHERE deleted_at IS NULL;
+CREATE INDEX ix_leads_org_created   ON leads (organization_id, created_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX ix_leads_org_phone     ON leads (organization_id, phone_e164)  WHERE deleted_at IS NULL AND phone_e164 IS NOT NULL;
+
+CREATE UNIQUE INDEX uq_leads_org_idempotency
+    ON leads (organization_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+```
+
+`ix_leads_org_assignee` adalah index yang menopang aturan visibilitas employee (§9) — ia dipakai di **setiap** request employee, bukan sesekali.
+
+### 1.2 `customers`
+
+```sql
+CREATE TABLE customers (
+    id                         uuid PRIMARY KEY,
+    organization_id            uuid NOT NULL REFERENCES organizations (id),
+
+    name                       text NOT NULL,
+    email                      text,
+    phone                      text,
+    phone_e164                 text,
+    company                    text,
+    notes                      text,
+
+    converted_from_lead_id     uuid NOT NULL,
+    converted_by_membership_id uuid,
+    converted_at               timestamptz NOT NULL DEFAULT now(),
+
+    created_at                 timestamptz NOT NULL DEFAULT now(),
+    updated_at                 timestamptz NOT NULL DEFAULT now(),
+    deleted_at                 timestamptz,
+
+    CONSTRAINT ck_customers_email_lowercase CHECK (email IS NULL OR email = lower(email)),
+    CONSTRAINT uq_customers_id_org UNIQUE (id, organization_id),
+
+    CONSTRAINT fk_customers_lead
+        FOREIGN KEY (converted_from_lead_id, organization_id)
+        REFERENCES leads (id, organization_id),
+    CONSTRAINT fk_customers_converter
+        FOREIGN KEY (converted_by_membership_id, organization_id)
+        REFERENCES memberships (id, organization_id)
+);
+
+CREATE UNIQUE INDEX uq_customers_org_lead ON customers (organization_id, converted_from_lead_id);
+```
+
+`converted_from_lead_id` **NOT NULL**: di MVP setiap customer berasal dari lead — tidak ada endpoint "buat customer langsung". `uq_customers_org_lead` menjamin satu lead hanya menghasilkan satu customer, sehingga konversi ganda ditolak **database**, bukan sekadar dicek usecase.
+
+> Melonggarkan `NOT NULL` nanti (saat customer boleh dibuat langsung) adalah satu `ALTER`; alasan yang sama dengan B8.
+
+### 1.3 `activities` — append-only
+
+```sql
+CREATE TABLE activities (
+    id                  uuid PRIMARY KEY,
+    organization_id     uuid NOT NULL REFERENCES organizations (id),
+    lead_id             uuid NOT NULL,
+    type                text NOT NULL,
+    actor_membership_id uuid,
+    body                text,
+    metadata            jsonb,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT ck_activities_type CHECK (type IN (
+        'lead_created','lead_assigned','lead_unassigned','status_changed','lead_converted',
+        'note_added','call_logged','whatsapp_opened','task_created','task_completed')),
+    CONSTRAINT uq_activities_id_org UNIQUE (id, organization_id),
+
+    CONSTRAINT fk_activities_lead
+        FOREIGN KEY (lead_id, organization_id) REFERENCES leads (id, organization_id),
+    CONSTRAINT fk_activities_actor
+        FOREIGN KEY (actor_membership_id, organization_id) REFERENCES memberships (id, organization_id)
+);
+
+CREATE INDEX ix_activities_org_lead ON activities (organization_id, lead_id, created_at DESC);
+```
+
+**Tanpa `updated_at`, tanpa `deleted_at`, tanpa trigger `set_updated_at`** — persis seperti `audit_logs` (Aturan #18). Ketiadaan kolom itu adalah penegakannya: tidak ada endpoint edit/hapus yang *bisa* ditulis tanpa mengubah schema lebih dulu.
+
+`actor_membership_id` nullable — activity bertipe sistem (`lead_created` dari API, `status_changed` oleh automation kelak) tidak punya aktor manusia.
+
+`metadata jsonb` — **alasan tertulis (Aturan #17)**: bentuknya berbeda per `type` (`lead_assigned` menyimpan `{from, to}`, `status_changed` menyimpan `{from, to}`, `call_logged` menyimpan durasi). Kolom terpisah untuk tiap tipe berarti belasan kolom yang mayoritas selalu `NULL`. Tidak pernah di-query isinya di Phase 2 — hanya dirender di timeline.
+
+### 1.4 `tasks`
+
+```sql
+CREATE TABLE tasks (
+    id                         uuid PRIMARY KEY,
+    organization_id            uuid NOT NULL REFERENCES organizations (id),
+    lead_id                    uuid NOT NULL,
+
+    title                      text NOT NULL,
+    description                text,
+    due_at                     timestamptz,
+    status                     text NOT NULL DEFAULT 'open',
+
+    assigned_to_membership_id  uuid,
+    completed_at               timestamptz,
+    completed_by_membership_id uuid,
+
+    version                    integer NOT NULL DEFAULT 1,
+    created_by_membership_id   uuid,
+    created_at                 timestamptz NOT NULL DEFAULT now(),
+    updated_at                 timestamptz NOT NULL DEFAULT now(),
+    deleted_at                 timestamptz,
+
+    CONSTRAINT ck_tasks_status CHECK (status IN ('open','done')),
+    CONSTRAINT ck_tasks_done_requires_completed_at CHECK (status <> 'done' OR completed_at IS NOT NULL),
+    CONSTRAINT uq_tasks_id_org UNIQUE (id, organization_id),
+
+    CONSTRAINT fk_tasks_lead     FOREIGN KEY (lead_id, organization_id) REFERENCES leads (id, organization_id),
+    CONSTRAINT fk_tasks_assignee FOREIGN KEY (assigned_to_membership_id, organization_id) REFERENCES memberships (id, organization_id),
+    CONSTRAINT fk_tasks_creator  FOREIGN KEY (created_by_membership_id, organization_id)  REFERENCES memberships (id, organization_id),
+    CONSTRAINT fk_tasks_completer FOREIGN KEY (completed_by_membership_id, organization_id) REFERENCES memberships (id, organization_id)
+);
+
+CREATE INDEX ix_tasks_org_assignee_due ON tasks (organization_id, assigned_to_membership_id, due_at)
+    WHERE deleted_at IS NULL AND status = 'open';
+CREATE INDEX ix_tasks_org_lead ON tasks (organization_id, lead_id) WHERE deleted_at IS NULL;
+```
+
+**Status hanya `open` dan `done`.** Tidak ada `cancelled`: task yang tidak jadi dikerjakan **dihapus** (soft delete), dan `deleted_at` sudah membedakannya dari task yang selesai. Menambah status ketiga yang artinya "diabaikan" berarti dua mekanisme untuk satu maksud.
+
+### 1.5 `ALTER organizations`
+
+```sql
+ALTER TABLE organizations ADD COLUMN next_lead_number integer NOT NULL DEFAULT 1;
+```
+
+Sengaja di `0003`, bukan `0002` — di `0002` belum ada `leads`, sehingga kolom itu akan menjadi schema mati (freeze 8.4). `ADD COLUMN` dengan `DEFAULT` konstan bersifat instan pada PostgreSQL modern.
+
+### Larangan yang berlaku pada migration ini
+
+- **Tidak ada** `source_api_key_id` maupun `source_form_id` — menyusul bersama tabel tujuannya di `0005`/`0007` (freeze 8.4)
+- **Tidak ada** kolom uang di manapun — Deal ditunda
+- **Tidak ada** `updated_at`/`deleted_at` pada `activities`
+- Setiap FK ke tabel tenant-scoped **wajib composite** (Aturan #3) — termasuk FK antar tabel baru
+
+---
+
+## 2. Migration `0004_notifications`
+
+```sql
+CREATE TABLE notifications (
+    id                      uuid PRIMARY KEY,
+    organization_id         uuid NOT NULL REFERENCES organizations (id),
+    recipient_membership_id uuid NOT NULL,
+    type                    text NOT NULL,
+    lead_id                 uuid,
+    task_id                 uuid,
+    title                   text NOT NULL,
+    body                    text,
+    read_at                 timestamptz,
+    created_at              timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT ck_notifications_type CHECK (type IN ('lead_assigned','task_assigned')),
+    CONSTRAINT uq_notifications_id_org UNIQUE (id, organization_id),
+
+    CONSTRAINT fk_notifications_recipient
+        FOREIGN KEY (recipient_membership_id, organization_id) REFERENCES memberships (id, organization_id),
+    CONSTRAINT fk_notifications_lead FOREIGN KEY (lead_id, organization_id) REFERENCES leads (id, organization_id),
+    CONSTRAINT fk_notifications_task FOREIGN KEY (task_id, organization_id) REFERENCES tasks (id, organization_id)
+);
+
+CREATE INDEX ix_notifications_recipient_unread
+    ON notifications (organization_id, recipient_membership_id, created_at DESC)
+    WHERE read_at IS NULL;
+```
+
+Dipisah dari `0003` mengikuti freeze 8.4. **`task_assigned` adalah perluasan kecil yang disengaja** terhadap freeze A3 (yang menyebut "pembuatan record saat assignment" tanpa membatasi ke lead): menugaskan task ke seseorang tanpa memberitahunya adalah fitur setengah jadi, dan biayanya satu nilai enum plus satu call site yang mekanismenya sudah identik.
+
+`notifications` **tanpa `deleted_at`** — notifikasi dibaca (`read_at`), tidak dihapus. Ia bukan entity bisnis yang dikelola pengguna.
+
+---
+
+## 3. `lead_number` — alokasi berurutan per organization
+
+```sql
+UPDATE organizations
+SET next_lead_number = next_lead_number + 1
+WHERE id = $1
+RETURNING next_lead_number - 1;
+```
+
+Dijalankan **di dalam transaksi pembuatan lead yang sama**, sebelum `INSERT INTO leads`.
+
+> **Penyimpangan tercatat dari freeze 2.3.** Freeze menyebut `SELECT … FOR UPDATE`. Satu `UPDATE … RETURNING` mengambil row lock yang **sama persis** dan menahannya sampai commit, tetapi dalam satu statement, bukan dua — menghilangkan celah antara membaca dan menulis yang harus diingat untuk dijaga. Efek serialisasinya identik; yang berbeda hanya jumlah statement.
+
+Konsekuensi yang diterima: pembuatan lead terserialisasi **per organization**. Pada volume MVP tidak terasa. `uq_leads_org_number` adalah jaring pengaman terakhir — bila serialisasi ini pernah bocor, database menolak, bukan diam-diam menerima nomor ganda.
+
+**Wajib diuji di bawah konkurensi** (§16), bukan hanya secara berurutan. Test yang membuat lead satu per satu akan hijau bahkan bila locking-nya salah total.
+
+---
+
+## 4. Optimistic locking — `version`
+
+Berlaku pada `leads` dan `tasks` (Aturan #35).
+
+```sql
+UPDATE leads
+SET <kolom> = …, version = version + 1, updated_at = now()
+WHERE id = $1 AND organization_id = $2 AND version = $3 AND deleted_at IS NULL;
+```
+
+| Hasil | Respons |
+|---|---|
+| 1 baris terpengaruh | 200, body memuat `version` baru |
+| 0 baris, dan baris **tidak ada** dalam tenant ini | **404** (Aturan #6) |
+| 0 baris, dan baris **ada** tapi `version` berbeda | **409 `version_conflict`**, body memuat **keadaan terkini** |
+
+Membedakan dua kasus terakhir memerlukan satu `SELECT` lanjutan setelah `UPDATE` mengembalikan 0 baris. Itu disengaja: mengembalikan 404 untuk konflik versi akan membuat client menghapus lead dari cache lokalnya, dan pada Phase 5 (antrian offline) itu berarti **kehilangan data pengguna**.
+
+**Client tidak pernah menimpa otomatis.** Body 409 memuat keadaan terkini justru supaya client bisa menampilkan konflik, bukan menyelesaikannya sendiri.
+
+---
+
+## 5. Status lead & validasi transisi
+
+Diagram, arti tiap status, dan aturan pengecualian metrik: freeze 2.4. Yang ditetapkan di sini adalah **cara menegakkannya**.
+
+```
+new ──► contacted ──► qualified ──► proposal ──► won
+ │          │             │             │
+ └──────────┴─────────────┴─────────────┴──────► lost        (wajib lost_reason)
+ │
+ ├──────────────────────────────────────────────► unqualified
+ └──────────────────────────────────────────────► spam
+```
+
+| Aturan | Ketentuan |
+|---|---|
+| Maju | Hanya **satu langkah** pada jalur utama `new → contacted → qualified → proposal → won` |
+| Mundur | **Satu langkah** (B7) — `qualified → contacted` boleh, `proposal → new` tidak |
+| Terminal samping | `lost`, `unqualified`, `spam` dapat dicapai dari status manapun di jalur utama |
+| Keluar dari terminal | `lost` → status jalur utama **diizinkan satu langkah** kembali ke status sebelum kalah (lead hidup lagi); `unqualified` dan `spam` **final** |
+| `lost` | **Wajib** `lost_reason` ∈ B6 |
+| Keluar dari `lost` | `lost_reason` di-`NULL`-kan kembali |
+| `won` | **Tidak** mengonversi apapun secara otomatis (B9) |
+
+Ditegakkan di **usecase**, bukan handler dan bukan repository — ia aturan bisnis, dan usecase adalah satu-satunya lapis yang tahu status lama *dan* status baru sekaligus. Transisi tidak sah → **422 `invalid_status_transition`** (sudah ada di katalog `api.md`).
+
+`spam` dan `unqualified` dikecualikan dari metrik konversi. Di Phase 2 belum ada endpoint metrik (itu Phase 3); yang wajib sekarang hanyalah **kedua status itu ada dan terpisah**, sehingga Phase 3 bisa mengecualikannya tanpa migration.
+
+---
+
+## 6. Normalisasi telepon — E.164
+
+Paket baru `internal/shared/phone`, satu fungsi:
+
+```go
+func ToE164(raw string) (string, bool)   // "" , false bila tidak bisa diurai
+```
+
+| Masukan | Hasil |
+|---|---|
+| `0812-3456-7890` | `+6281234567890` |
+| `+62 812 3456 7890` | `+6281234567890` |
+| `62812 3456 7890` | `+6281234567890` |
+| `812 3456 7890` | `+6281234567890` |
+| `1234` | `""`, `false` |
+
+**Indonesia-first, disengaja.** Bukan implementasi E.164 umum: memakai port libphonenumber berarti dependensi besar dengan tabel metadata seluruh dunia untuk satu negara. Ditulis tangan, ~40 baris, dengan asumsi yang **ditulis di doc comment paket**, bukan disembunyikan.
+
+**Nomor yang tidak bisa diurai tetap diterima.** `phone` menyimpan apa yang diketik pengguna; `phone_e164` `NULL`. Menolak lead karena format telepon adalah membuang data pelanggan — alasan yang sama dengan tidak mewajibkan kontak sama sekali (§1.1).
+
+Jalur upgrade tercatat: begitu ada pelanggan dengan nomor non-Indonesia, ganti isi `ToE164` dengan libphonenumber. Signature-nya sudah benar; yang berubah hanya implementasinya.
+
+---
+
+## 7. Idempotency
+
+Freeze memutuskan penyimpanannya: **kolom di `leads`, bukan tabel tersendiri** — resource-nya **adalah** response-nya.
+
+```
+POST /v1/leads
+Idempotency-Key: <uuid dari client>
+```
+
+| Keadaan | Perilaku |
+|---|---|
+| Header tidak ada | Lead dibuat biasa, `idempotency_key` `NULL` |
+| Key baru | Lead dibuat, key tersimpan → **201** |
+| Key sudah ada di organization ini | Lead **yang sama** dikembalikan → **200**, bukan 201, bukan error |
+
+Deteksi lewat pelanggaran `uq_leads_org_idempotency` (unique violation `23505`), bukan `SELECT`-lalu-`INSERT` — pola yang sama dengan `user.ErrEmailTaken` di Phase 1, dan karena alasan yang sama: cek-lalu-tulis adalah race di bawah retry bersamaan, yang justru **persis situasi** yang memicu pemakaian idempotency key.
+
+**Retensi ditunda, tercatat sebagai utang.** `api.md` menyebut retensi 24–48 jam. Phase 2 tidak punya scheduler (tanpa message broker, tanpa cron), sehingga key disimpan selamanya. Konsekuensinya: key yang dipakai ulang setahun kemudian mengembalikan lead lama. Tidak berbahaya, tetapi salah — dan baru benar-benar relevan di Phase 4, saat integrator sungguhan mulai mengirim key. Dicatat di `STATUS.md` bagian Utang Teknis.
+
+---
+
+## 8. Endpoint
+
+Seluruhnya berprefix `/v1` (Aturan #33), di belakang `authn.Middleware`.
+
+### Lead
+
+| Method | Path | Isi |
+|---|---|---|
+| `POST` | `/v1/leads` | `{name, email?, phone?, company?, notes?, source?, assigned_to_membership_id?}` → 201 (atau 200 bila idempotent replay) |
+| `GET` | `/v1/leads` | Filter + pagination (§8.1) |
+| `GET` | `/v1/leads/{id}` | Detail |
+| `PATCH` | `/v1/leads/{id}` | `{version, name?, email?, phone?, company?, notes?}` → 200 / 409 |
+| `PATCH` | `/v1/leads/{id}/status` | `{version, status, lost_reason?}` → 200 / 409 / 422 |
+| `PATCH` | `/v1/leads/{id}/assignment` | `{version, assigned_to_membership_id \| null}` → 200 / 409 |
+| `DELETE` | `/v1/leads/{id}` | Soft delete → 204 |
+
+`status` dan `assignment` dipisah dari `PATCH` umum karena keduanya punya aturan sendiri (validasi transisi, pembuatan notification) dan menghasilkan activity bertipe berbeda. Menggabungkannya berarti satu handler yang harus menebak maksud dari kombinasi field yang terisi.
+
+### 8.1 Filter & pagination lead
+
+```
+GET /v1/leads?status=new,contacted&assigned_to=<membership_id>&source=manual
+             &q=budi&created_from=2026-08-01&created_to=2026-08-31
+             &page=1&per_page=25
+```
+
+| Parameter | Ketentuan |
+|---|---|
+| `status` | Daftar dipisah koma |
+| `assigned_to` | `membership_id`, atau **`none`** untuk "belum ter-assign" |
+| `source` | Daftar dipisah koma |
+| `q` | Cocok pada `name`, `email`, `phone_e164` — `ILIKE` sederhana, **bukan** full-text |
+| `created_from` / `created_to` | ISO 8601 |
+| Pagination | Offset (`api.md`): `page`, `per_page` (default 25, maks 100), `meta` memuat `page`/`per_page`/`total` |
+
+`q` memakai `ILIKE '%…%'` tanpa index pendukung. Disengaja: search engine dilarang freeze, dan pada volume MVP sequential scan per organization tidak terasa. Bila suatu saat terasa, jawabannya `pg_trgm`, bukan Elasticsearch — dicatat di sini agar tidak dibahas ulang dari nol.
+
+### Activity
+
+| Method | Path | Isi |
+|---|---|---|
+| `GET` | `/v1/leads/{id}/activities` | Timeline, terbaru dulu |
+| `POST` | `/v1/leads/{id}/activities` | `{type, body?, metadata?}` — **hanya** tipe buatan pengguna |
+
+`type` pada `POST` dibatasi ke `note_added`, `call_logged`, `whatsapp_opened`. Tipe sistem (`lead_created`, `status_changed`, `lead_assigned`, `lead_unassigned`, `lead_converted`, `task_created`, `task_completed`) **ditolak 422** bila dikirim client — activity sistem hanya lahir dari peristiwa yang sebenarnya (§10), dan mengizinkan client memalsukannya berarti timeline berhenti bisa dipercaya.
+
+**Tidak ada** `PATCH` maupun `DELETE`. Append-only.
+
+### Task
+
+| Method | Path | Isi |
+|---|---|---|
+| `POST` | `/v1/leads/{id}/tasks` | `{title, description?, due_at?, assigned_to_membership_id?}` → 201 |
+| `GET` | `/v1/tasks` | Task saya / filter (`assigned_to`, `status`, `due_before`) |
+| `GET` | `/v1/leads/{id}/tasks` | Task pada satu lead |
+| `PATCH` | `/v1/tasks/{id}` | `{version, title?, description?, due_at?, assigned_to_membership_id?}` |
+| `POST` | `/v1/tasks/{id}/complete` | `{version}` → 200, menyetel `status`, `completed_at`, `completed_by` |
+| `DELETE` | `/v1/tasks/{id}` | Soft delete → 204 |
+
+`complete` sebagai endpoint tersendiri, bukan `PATCH status=done`: ia menyetel tiga kolom sekaligus dan menghasilkan activity — sama alasannya dengan pemisahan `PATCH /status` pada lead.
+
+### Customer
+
+| Method | Path | Isi |
+|---|---|---|
+| `POST` | `/v1/leads/{id}/convert` | `{}` → 201 customer. Menolak bila lead bukan `won`, atau sudah pernah dikonversi |
+| `GET` | `/v1/customers` | Daftar + pagination |
+| `GET` | `/v1/customers/{id}` | Detail |
+| `PATCH` | `/v1/customers/{id}` | `{name?, email?, phone?, company?, notes?}` |
+| `DELETE` | `/v1/customers/{id}` | Soft delete → 204 |
+
+Konversi berada di bawah `/v1/leads/{id}` karena ia **aksi pada lead**, bukan pembuatan customer dari ketiadaan. `customers` tidak punya `version` — ia tidak diubah dari mobile offline, sehingga tidak ada konflik tulis untuk dideteksi (Aturan #35 menyebut `leads` dan `tasks` secara spesifik).
+
+### Notification
+
+| Method | Path | Isi |
+|---|---|---|
+| `GET` | `/v1/notifications` | Milik **saya** saja, `?unread=true` opsional |
+| `POST` | `/v1/notifications/{id}/read` | → 204 |
+| `POST` | `/v1/notifications/read-all` | → 204 |
+
+Notification selalu di-scope ke `recipient_membership_id = t.MembershipID` di **repository**, bukan handler — pola yang sama dengan visibilitas employee (§9). Tidak ada endpoint yang bisa membaca notifikasi orang lain, terlepas dari role.
+
+---
+
+## 9. Visibilitas employee — ditegakkan di repository
+
+Aturan #1 dari empat aturan di [`authorization.md`](../../architecture/authorization.md). Phase 1 belum bisa menegakkannya karena belum ada resource milik employee; Phase 2 adalah tempatnya.
+
+| Role | Lead yang terlihat |
+|---|---|
+| Owner, Admin | Seluruh organization |
+| Manager | Seluruh organization (baca) — freeze 6.3 opsi A, tanpa konsep Team |
+| **Employee** | **Hanya `assigned_to_membership_id = t.MembershipID`** |
+
+Ditegakkan di **repository**, bukan handler dan bukan usecase:
+
+```go
+func (r *postgresRepository) FindByID(ctx context.Context, t tenant.Context, id uuid.UUID) (*Lead, error) {
+    // organization_id SELALU; assigned_to SELALU bila t.Role == employee.
+}
+```
+
+**Lead employee lain → `httpx.ErrNotFound` (404), bukan 403** — alasan identik Aturan #6: 403 mengonfirmasi bahwa lead dengan id itu ada.
+
+> Ini permukaan kebocoran paling mungkin di mobile app (`architecture_product_review.md` §6). Menegakkannya di usecase berarti setiap usecase baru harus mengingatnya; menegakkannya di repository berarti tidak ada jalur query yang bisa melewatkannya.
+
+Pembagian tugas dengan `authz` tetap seperti [`authorization.md`](../../architecture/authorization.md): `authz.Require` menjawab *"boleh melakukan kelas aksi ini?"*, repository menjawab *"atas baris yang mana?"*.
+
+**`Action` baru** di `internal/shared/authz`:
+
+| Action | Owner | Admin | Manager | Employee |
+|---|---|---|---|---|
+| `lead.create` | ✅ | ✅ | ✅ | — |
+| `lead.list` / `lead.read` | ✅ | ✅ | ✅ | ✅¹ |
+| `lead.update` | ✅ | ✅ | ✅ | ✅¹ |
+| `lead.delete` | ✅ | ✅ | — | — |
+| `lead.assign` | ✅ | ✅ | ✅ | — |
+| `lead.convert` | ✅ | ✅ | — | — |
+| `activity.create` / `activity.list` | ✅ | ✅ | ✅ | ✅¹ |
+| `task.create` / `task.update` / `task.complete` | ✅ | ✅ | ✅ | ✅¹ |
+| `task.delete` | ✅ | ✅ | ✅ | — |
+| `customer.list` / `customer.read` | ✅ | ✅ | ✅ | ✅¹ |
+| `customer.update` / `customer.delete` | ✅ | ✅ | — | — |
+
+¹ **Dibatasi repository** ke lead yang di-assign kepadanya (dan turunannya: activity, task, customer dari lead itu).
+
+---
+
+## 10. Activity otomatis — dalam transaksi yang sama
+
+| Peristiwa | Activity |
+|---|---|
+| Lead dibuat | `lead_created` |
+| Assignment ditetapkan/diubah | `lead_assigned`, `metadata = {from, to}` |
+| Assignment dilepas | `lead_unassigned`, `metadata = {from}` |
+| Status berubah | `status_changed`, `metadata = {from, to}` |
+| Konversi | `lead_converted`, `metadata = {customer_id}` |
+| Task dibuat | `task_created`, `metadata = {task_id, title}` |
+| Task diselesaikan | `task_completed`, `metadata = {task_id}` |
+
+Seluruhnya ditulis **di dalam `Store.InTx` yang sama** dengan perubahan yang memicunya. Keduanya adalah tulis database — tidak ada efek samping eksternal — sehingga Aturan #32 tidak menghalangi, dan atomisitas justru wajib: timeline yang bercerai dari kejadiannya lebih buruk daripada tidak ada timeline, karena ia terlihat lengkap padahal bohong.
+
+> Bandingkan dengan email di Phase 1, yang justru **wajib di luar** transaksi. Perbedaannya bukan selera — email adalah panggilan jaringan yang bisa menggantung; `INSERT` ke tabel yang sama tidak.
+
+---
+
+## 11. Assignment & notification
+
+`PATCH /v1/leads/{id}/assignment` di dalam **satu** transaksi:
+
+```
+1. UPDATE leads … version = version + 1     (optimistic locking, §4)
+2. INSERT activities (lead_assigned | lead_unassigned)
+3. INSERT notifications                      (hanya bila di-assign ke seseorang)
+```
+
+`assigned_to_membership_id` divalidasi milik organization yang sama — dan karena FK-nya composite `(assigned_to_membership_id, organization_id)`, **database menolak** meski usecase lalai. Itu lapis 2 `multi-tenancy.md` bekerja sebagaimana dirancang.
+
+Assign ke diri sendiri **tidak** menghasilkan notification — memberi tahu seseorang tentang tindakannya sendiri hanya menambah bising.
+
+---
+
+## 12. Konversi ke Customer
+
+```
+POST /v1/leads/{id}/convert
+```
+
+| Prasyarat | Kegagalan |
+|---|---|
+| Lead ada, dalam tenant, terlihat oleh pemanggil | 404 |
+| `authz.Require(t, ActionLeadConvert)` | 403 |
+| Status lead **`won`** | 422 `invalid_status_transition` |
+| Belum pernah dikonversi | 409 `lead_already_converted` (kode baru) |
+
+Dalam satu transaksi: `INSERT customers` (menyalin `name`/`email`/`phone`/`phone_e164`/`company`) + `INSERT activities (lead_converted)`.
+
+**Lead tidak dihapus dan statusnya tidak berubah.** Ia tetap `won` dan tetap menjadi jejak proses penjualannya; `customers.converted_from_lead_id` adalah tautannya. Menghapus lead setelah konversi berarti membuang seluruh timeline yang menjelaskan bagaimana pelanggan itu didapat.
+
+Data disalin, bukan dirujuk: customer boleh berubah nama atau telepon tanpa mengubah catatan historis lead-nya.
+
+---
+
+## 13. Kewajiban Phase 1 yang ditutup di sini
+
+[`01-auth-organization/td.md`](../01-auth-organization/td.md) §17 dan freeze 2.3:
+
+> Penonaktifan membership **wajib menolak berjalan** bila masih ada lead terbuka, kecuali disertai keputusan eksplisit.
+
+`DELETE /v1/memberships/{id}` bertambah parameter:
+
+```
+DELETE /v1/memberships/{id}?on_open_leads=reject|unassign|reassign&reassign_to=<membership_id>
+```
+
+| Nilai | Perilaku |
+|---|---|
+| tidak diisi / `reject` | **Default.** Bila ada lead terbuka → **409 `membership_has_open_leads`** (kode baru), body memuat jumlahnya |
+| `unassign` | `assigned_to_membership_id = NULL` untuk lead terbukanya, + activity `lead_unassigned` per lead |
+| `reassign` | Dipindah ke `reassign_to`, + activity `lead_assigned` per lead |
+
+"Lead terbuka" = status **bukan** `won`, `lost`, `unqualified`, `spam`, dan `deleted_at IS NULL`.
+
+Seluruhnya dalam **satu transaksi** dengan penonaktifan membership dan pencabutan refresh token yang sudah ada sejak #11. Default `reject` disengaja: diam-diam melepas assignment saat seseorang resign adalah persis kegagalan senyap yang aturan ini ada untuk mencegahnya.
+
+> `internal/membership` akan memerlukan akses ke lead untuk ini — lewat interface sempit yang **dideklarasikan `membership`** (`OpenLeadRepository`: hitung, lepas, pindahkan), diimplementasikan `internal/lead`, dirakit di composition root. Pola yang sama dengan `auth.RefreshTokenRevoker` di #11; `membership` tidak mengimpor `lead`.
+
+---
+
+## 14. Error code baru
+
+Ditambahkan ke katalog di [`api.md`](../../architecture/api.md):
+
+| HTTP | `code` |
+|---|---|
+| 409 | `lead_already_converted` |
+| 409 | `membership_has_open_leads` |
+
+Sudah ada dan dipakai ulang: `version_conflict` (409), `invalid_status_transition` (422), `not_found` (404), `forbidden` (403), `validation_failed` (400), `conflict` (409).
+
+---
+
+## 15. Paket baru
+
+```
+internal/lead/            entity · port · usecase · repository_postgres · handler_http
+internal/activity/        entity · port · usecase · repository_postgres · handler_http
+internal/task/            entity · port · usecase · repository_postgres · handler_http
+internal/customer/        entity · port · usecase · repository_postgres · handler_http
+internal/notification/    entity · port · usecase · repository_postgres · handler_http
+internal/shared/phone/    ToE164
+```
+
+Masing-masing dengan `Store`/`Repos` sendiri dan composition root `cmd/api/<domain>_store.go` — pola ADR-011, **bukan** satu `Store` raksasa lintas domain.
+
+`activity` sengaja menjadi paket tersendiri meski selalu ditulis bersama lead/task: ia punya aturan sendiri (append-only, tipe sistem vs pengguna) dan endpoint sendiri. Yang membuatnya bekerja lintas transaksi adalah interface `ActivityRecorder` yang **dideklarasikan konsumennya** (`lead`, `task`, `customer`) — sama seperti `AuditRepository` di Phase 1.
+
+---
+
+## 16. Rencana test
+
+### Wajib di bawah konkurensi
+
+| Test | Membuktikan |
+|---|---|
+| N goroutine membuat lead bersamaan di satu organization | `lead_number` = 1..N, **tanpa lubang, tanpa duplikat** |
+| N goroutine membuat lead di organization berbeda | Nomor per organization saling bebas, keduanya mulai dari 1 |
+| Dua `PATCH` bersamaan dengan `version` sama | Tepat **satu** 200, satunya **409** — tidak pernah dua-duanya sukses |
+| Dua `POST /v1/leads` bersamaan dengan `Idempotency-Key` sama | Tepat **satu** lead tercipta, keduanya menerima lead yang sama |
+
+Keempatnya **tidak bisa** dibuktikan oleh test berurutan. Test yang membuat lead satu per satu akan hijau bahkan bila locking-nya dihapus seluruhnya — itulah yang membuat keempatnya wajib, bukan opsional.
+
+### Test keamanan wajib
+
+| Skenario | Harapan |
+|---|---|
+| Employee membaca lead yang di-assign ke employee lain | **404** |
+| Employee membaca lead organization lain | **404** |
+| Employee membuat lead | **403** |
+| Employee membaca activity pada lead orang lain | **404** |
+| Employee membaca notification orang lain | **404** / tidak muncul di daftar |
+| Menugaskan lead ke membership organization lain | Ditolak **database** (composite FK) |
+| Client mengirim activity bertipe sistem (`status_changed`) | **422** |
+| Konversi lead yang belum `won` | **422** |
+| Konversi lead dua kali | **409** |
+| Nonaktifkan membership dengan lead terbuka, tanpa parameter | **409** |
+
+### Harness isolasi tenant
+
+`cmd/api/tenant_isolation_test.go`'s `[]isolationCase` bertambah entri `lead`, `task`, `customer`, `activity` — **menambah entri, bukan menulis harness baru** (itulah bentuk generiknya dirancang sejak #11).
+
+Ini juga yang **mengaktifkan kasus #1 dan #4** di tabel [`multi-tenancy.md`](../../architecture/multi-tenancy.md) lapis 4, yang sampai akhir Phase 1 masih kosong karena belum ada resource milik employee.
+
+**Kriteria kualitas tetap berlaku:** harness harus terbukti bisa gagal. Prosedurnya sudah dijalankan sekali di #11 dan dicatat di `notes.md`; ulangi untuk kasus `lead` — hapus filter `assigned_to` dari repository lead secara sengaja, pastikan merah.
+
+### Test lain
+
+- Transisi status: setiap pasangan sah dan tidak sah, termasuk `lost` tanpa `lost_reason` dan keluar dari `lost`
+- `ToE164`: tabel masukan/keluaran termasuk yang tidak bisa diurai
+- Activity append-only: tidak ada route `PATCH`/`DELETE` yang terdaftar (diperiksa lewat daftar route, bukan asumsi)
+- Setiap usecase punya test unit tanpa Docker (`TestUnit_*`, fake `Store`) — ADR-011
+
+---
+
+## 17. Risiko teknis
+
+| Risiko | Mitigasi |
+|---|---|
+| **Alokasi `lead_number` salah di bawah beban** — risiko terbesar phase ini; kegagalannya senyap dan datanya tidak bisa diperbaiki retroaktif | Test konkurensi wajib (§16) + `uq_leads_org_number` sebagai jaring pengaman database |
+| **Visibilitas employee bocor** karena ditegakkan di usecase, bukan repository | Ditegakkan di repository; harness isolasi + test keamanan tersendiri; review khusus setiap query lead baru |
+| **Optimistic locking dilewati** oleh endpoint baru yang lupa meminta `version` | Signature repository `Update(…, version int)` — endpoint yang lupa tidak akan bisa dikompilasi |
+| **Activity sistem dipalsukan client** | Allowlist tipe di handler `POST /activities`, ditolak 422; test tersendiri |
+| **`ILIKE '%…%'` menjadi lambat** | Diterima untuk MVP; jalur upgrade (`pg_trgm`) dicatat di §8.1 agar tidak jadi diskusi ulang |
+| **Idempotency key tanpa retensi** | Dicatat sebagai utang teknis, bukan diam-diam; baru relevan di Phase 4 |
+
+---
+
+## 18. Yang berubah pada dokumentasi
+
+| Berkas | Perubahan |
+|---|---|
+| [`api.md`](../../architecture/api.md) | Dua error code baru (§14); contoh filter & pagination lead |
+| [`authorization.md`](../../architecture/authorization.md) | Matriks bertambah baris Lead/Task/Activity/Customer yang **nyata**; aturan #1 berubah dari "belum berlaku" menjadi terwujud |
+| [`multi-tenancy.md`](../../architecture/multi-tenancy.md) | Tabel lapis 4: kasus #1 dan #4 dari "belum ada kasus nyata" menjadi ✅ |
+| `STATUS.md` | Phase 2 selesai; utang teknis (retensi idempotency) |
+| `phases/02-crm-core/notes.md` | Satu bagian per issue |
+
+---
+
+## 19. Kewajiban yang diteruskan ke phase berikutnya
+
+Ditulis di sini agar tidak bergantung pada ingatan:
+
+> **Phase 3 (Dashboard)** wajib menyediakan filter permanen **"lead tanpa pemilik aktif"** sebagai jaring pengaman terhadap membership yang dinonaktifkan (freeze 2.3 ketentuan #3). Query-nya sudah didukung Phase 2 lewat `assigned_to=none`; yang belum ada hanyalah layarnya.
+>
+> **Phase 4 (API Publik)** mewarisi retensi `idempotency_key` (§7) dan menambahkan `leads.source_api_key_id` di `0005`.
+>
+> **Phase 5 (Mobile)** adalah alasan `version` ada. Antrian offline wajib menampilkan 409 kepada pengguna, **tidak pernah** menimpa otomatis (§4).


### PR DESCRIPTION
## Ringkasan

Membuka **Phase 2 — CRM Core**: PRD, TD, dan indeks issue. Tidak ada kode.

- `docs/phases/02-crm-core/prd.md` — tujuan, 11 kebutuhan, 14 acceptance criteria, batas cakupan
- `docs/phases/02-crm-core/td.md` — schema `0003`/`0004`, alokasi `lead_number`, optimistic locking, transisi status, E.164, idempotency, endpoint, visibilitas employee, activity otomatis, konversi, rencana test
- `docs/phases/02-crm-core/issues.md` — indeks lima issue ([#19](https://github.com/Pravasta/jualin-crm/issues/19)–[#23](https://github.com/Pravasta/jualin-crm/issues/23)), berurutan
- `docs/STATUS.md` — B6–B9 ditutup, `Berikutnya` → #19

## Keputusan yang ditutup

B6–B9 — empat keputusan yang `STATUS.md` tandai *"diputuskan sebelum Phase 2"*. Seluruhnya mengikuti rekomendasi freeze:

| # | Keputusan |
|---|---|
| B6 | `lost_reason` = `price` · `competitor` · `timing` · `no_response` · `not_interested` · `other` |
| B7 | Mundur **satu langkah**; melompat maju ditolak |
| B8 | `tasks.lead_id` **NOT NULL** — task selalu menempel pada lead |
| B9 | Konversi ke Customer **aksi eksplisit**, bukan efek samping `won` (sudah ditetapkan freeze 2.4) |

Alasan tiap keputusan ada di PRD, supaya tidak dibahas ulang dari nol di session berikutnya.

## Pembagian issue — 5, bukan 4

Freeze memetakan Phase 2 sebagai empat session. Dipecah jadi lima dengan memisahkan lapisan schema/konkurensi dari lapisan HTTP.

**#19 sengaja tidak menghasilkan perilaku yang bisa dilihat.** Alokasi `lead_number` dan optimistic locking gagal secara **senyap**, dan test berurutan tetap hijau bahkan bila locking-nya dihapus total. Nilainya seluruhnya ada di test konkurensi — dan itulah yang layak direview di PR-nya.

Penyimpangan ini tercatat di PRD. Bila Anda lebih memilih empat PR, #19 dan #20 tinggal digabung.

## Dua penyimpangan dari freeze — dicatat, bukan diam-diam

1. **`lead_number`** memakai satu `UPDATE … RETURNING`, bukan `SELECT … FOR UPDATE` seperti tertulis di freeze 2.3. Row lock-nya sama persis dan ditahan sampai commit, tapi dalam satu statement — menghilangkan celah antara membaca dan menulis. (TD §3)
2. **`notifications`** membawa tipe `task_assigned` di samping `lead_assigned`. Freeze A3 hanya menyebut "pembuatan record saat assignment" tanpa membatasi ke lead; menugaskan task tanpa memberi tahu orangnya adalah fitur setengah jadi, dan biayanya satu nilai enum. (TD §2)

## Kewajiban warisan Phase 1

Phase 1 TD §17 menitipkan: penonaktifan membership **wajib menolak** bila masih ada lead terbuka. Belum bisa ditegakkan saat itu karena `leads` belum ada. Jatuh di **#22**, dan masuk sebagai acceptance criterion #13 di PRD — bukan sebagai catatan yang bergantung pada ingatan.

## Verifikasi

- Seluruh link relatif di ketiga dokumen dicek resolve
- Lima issue GitHub dibuat di milestone Phase 2, berurutan dengan dependensi tertulis

Refs #19, #20, #21, #22, #23