### PR TITLE
feat(be): CRM Core schema, lead repository, lead_number allocation, optimistic locking

### DIFF
--- a/crm_be/internal/lead/entity.go
+++ b/crm_be/internal/lead/entity.go
@@ -1,0 +1,76 @@
+// Package lead is CRM Core's domain entity — the shape every capture
+// source (manual, api, form, webhook) produces. This issue (#19) ships
+// only entity.go + repository_postgres.go: no usecase, no HTTP, same
+// shape internal/membership had before #11 gave it a real consumer.
+// See docs/phases/02-crm-core/td.md §1.1.
+package lead
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Lead struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+	LeadNumber     int
+
+	Name      string
+	Email     *string
+	Phone     *string
+	PhoneE164 *string
+	Company   *string
+	Notes     *string
+
+	Status                 string
+	LostReason             *string
+	Source                 string
+	AssignedToMembershipID *uuid.UUID
+
+	RawPayload     []byte
+	IdempotencyKey *string
+	Version        int
+
+	CreatedByMembershipID *uuid.UUID
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+	DeletedAt             *time.Time
+}
+
+// CreateInput is what Repository.Create persists — no validation here.
+// Field validation, status defaulting, and E.164 normalization belong to
+// the usecase issue #20 adds; this package only writes what it's given.
+type CreateInput struct {
+	Name                   string
+	Email                  *string
+	Phone                  *string
+	PhoneE164              *string
+	Company                *string
+	Notes                  *string
+	Source                 string
+	AssignedToMembershipID *uuid.UUID
+	CreatedByMembershipID  *uuid.UUID
+	RawPayload             []byte
+	IdempotencyKey         *string
+}
+
+// UpdateInput is the mutable-field subset PATCH /v1/leads/{id} will
+// expose (issue #20) — nil means "don't touch". Deliberately does not
+// cover status or assignment: those have their own transition rules and
+// land with #20/#22, not here.
+type UpdateInput struct {
+	Name    *string
+	Email   *string
+	Phone   *string
+	Company *string
+	Notes   *string
+}
+
+// ErrVersionConflict is what Update returns — alongside the row's
+// CURRENT state — when expectedVersion no longer matches. Returning the
+// current state here means the future usecase doesn't need a second
+// query to build the 409 body TD §4 requires ("body memuat keadaan
+// terkini").
+var ErrVersionConflict = errors.New("lead: version conflict")

--- a/crm_be/internal/lead/repository_concurrency_test.go
+++ b/crm_be/internal/lead/repository_concurrency_test.go
@@ -1,0 +1,168 @@
+package lead_test
+
+// These three tests are the actual point of issue #19 — lead_number
+// allocation and optimistic locking both fail SILENTLY under
+// concurrency. A sequential test (create leads one at a time, or run
+// updates one after another) stays green even with the row lock or the
+// version check removed entirely, because there's never two writers
+// racing on the same row. Only genuine concurrent goroutines prove
+// anything here — see docs/phases/02-crm-core/td.md §16.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const concurrentWriters = 20
+
+// TestConcurrency_LeadNumber_NoGapsNoDuplicates proves TD §3: N
+// goroutines racing Create for the same organization must land on
+// exactly {1..N}, no gaps, no duplicates — the row lock the
+// UPDATE ... RETURNING statement takes on organizations.next_lead_number
+// serializes concurrent allocation correctly.
+//
+// This test alone does NOT prove Create needs db.InTx — a single
+// UPDATE...RETURNING is atomic whether or not it's wrapped in an
+// explicit transaction, and this test never makes the following INSERT
+// fail. What db.InTx actually buys — rollback undoing the allocation
+// when the INSERT fails, so a rejected Create doesn't burn a number — is
+// proven separately by TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber
+// in repository_test.go. Checked by hand while writing this: temporarily
+// calling Create straight against the pool (no db.InTx at all) still
+// passes this exact test, which is why that second, more targeted test
+// exists.
+func TestConcurrency_LeadNumber_NoGapsNoDuplicates(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	org := seedOrganization(t, ctx, pool)
+
+	numbers := createConcurrently(t, ctx, pool, org, concurrentWriters)
+
+	assertExactSequence(t, numbers, concurrentWriters)
+}
+
+// TestConcurrency_LeadNumber_IndependentPerOrganization proves
+// allocation serializes per organization, not globally — both
+// organizations independently land on {1..N/2}.
+func TestConcurrency_LeadNumber_IndependentPerOrganization(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	orgA := seedOrganization(t, ctx, pool)
+	orgB := seedOrganization(t, ctx, pool)
+
+	const perOrg = concurrentWriters / 2
+	var wg sync.WaitGroup
+	numbersA := make([]int, perOrg)
+	numbersB := make([]int, perOrg)
+
+	wg.Add(2)
+	go func() { defer wg.Done(); copy(numbersA, createConcurrently(t, ctx, pool, orgA, perOrg)) }()
+	go func() { defer wg.Done(); copy(numbersB, createConcurrently(t, ctx, pool, orgB, perOrg)) }()
+	wg.Wait()
+
+	assertExactSequence(t, numbersA, perOrg)
+	assertExactSequence(t, numbersB, perOrg)
+}
+
+// TestConcurrency_VersionConflict_ExactlyOneWins proves TD §4: M
+// concurrent Update calls starting from the same version must produce
+// exactly one success — never zero, never more than one.
+func TestConcurrency_VersionConflict_ExactlyOneWins(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := lead.New(pool)
+	org := seedOrganization(t, ctx, pool)
+
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org}, minimalInput("Contested Lead"))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const writers = concurrentWriters
+	var wg sync.WaitGroup
+	var successes, conflicts int
+	var mu sync.Mutex
+
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			name := "Writer Name"
+			_, err := repo.Update(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, created.ID, created.Version, lead.UpdateInput{Name: &name})
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				successes++
+			case errors.Is(err, lead.ErrVersionConflict):
+				conflicts++
+			default:
+				t.Errorf("writer %d: unexpected error: %v", n, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if successes != 1 {
+		t.Errorf("expected exactly 1 successful update out of %d concurrent writers, got %d", writers, successes)
+	}
+	if conflicts != writers-1 {
+		t.Errorf("expected %d version conflicts, got %d", writers-1, conflicts)
+	}
+}
+
+// createConcurrently fires n goroutines, each in its own db.InTx, and
+// returns the resulting lead_numbers.
+func createConcurrently(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, n int) []int {
+	t.Helper()
+
+	numbers := make([]int, n)
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			err := db.InTx(ctx, pool, func(tx pgx.Tx) error {
+				repo := lead.New(tx)
+				created, err := repo.Create(ctx, tenant.Context{OrganizationID: org}, minimalInput("Concurrent Lead"))
+				if err != nil {
+					return err
+				}
+				numbers[idx] = created.LeadNumber
+				return nil
+			})
+			if err != nil {
+				t.Errorf("goroutine %d: create failed: %v", idx, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	return numbers
+}
+
+func assertExactSequence(t *testing.T, numbers []int, n int) {
+	t.Helper()
+	seen := make(map[int]bool, n)
+	for _, num := range numbers {
+		if seen[num] {
+			t.Errorf("duplicate lead_number %d", num)
+		}
+		seen[num] = true
+	}
+	for i := 1; i <= n; i++ {
+		if !seen[i] {
+			t.Errorf("missing lead_number %d — gap in sequence", i)
+		}
+	}
+}

--- a/crm_be/internal/lead/repository_postgres.go
+++ b/crm_be/internal/lead/repository_postgres.go
@@ -1,0 +1,173 @@
+package lead
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Repository is a plain concrete type — no interface — mirroring
+// internal/membership's shape before #11 gave it a real usecase.
+// Interface-at-consumer (ADR-011) only makes sense once a consumer
+// exists to declare it; #20 adds port.go + usecase.go and renames this
+// to postgresRepository at that point, same migration membership already
+// went through.
+type Repository struct {
+	q db.Querier
+}
+
+func New(q db.Querier) *Repository {
+	return &Repository{q: q}
+}
+
+// Create allocates the next lead_number for t.OrganizationID and inserts
+// the row using the SAME r.q for both statements. The allocating
+// UPDATE ... RETURNING is a single atomic statement, so concurrent
+// callers never collide or duplicate a number regardless of whether r.q
+// is a pool or a transaction (proven under real concurrency in
+// repository_concurrency_test.go). What DOES depend on r.q being a
+// pgx.Tx (via db.InTx) is what happens when the following INSERT
+// fails: wrapped in a transaction, the whole thing rolls back —
+// including the allocation — so a rejected Create doesn't burn a
+// number; called against a bare pool, the allocation already committed
+// on its own and the number is gone for good, a permanent gap. TD §3
+// requires the transactional form. See
+// TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber in
+// repository_test.go for the proof of that specific guarantee.
+func (r *Repository) Create(ctx context.Context, t tenant.Context, in CreateInput) (*Lead, error) {
+	const allocQ = `
+		UPDATE organizations SET next_lead_number = next_lead_number + 1
+		WHERE id = $1
+		RETURNING next_lead_number - 1`
+
+	var nextNumber int
+	if err := r.q.QueryRow(ctx, allocQ, t.OrganizationID).Scan(&nextNumber); err != nil {
+		return nil, fmt.Errorf("lead: allocate lead_number: %w", err)
+	}
+
+	const insertQ = `
+		INSERT INTO leads (
+			id, organization_id, lead_number, name, email, phone, phone_e164, company, notes,
+			source, assigned_to_membership_id, raw_payload, idempotency_key, created_by_membership_id
+		)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+		RETURNING ` + leadColumns
+
+	id := uuid.Must(uuid.NewV7())
+	row := r.q.QueryRow(ctx, insertQ,
+		id, t.OrganizationID, nextNumber, in.Name, in.Email, in.Phone, in.PhoneE164, in.Company, in.Notes,
+		in.Source, in.AssignedToMembershipID, in.RawPayload, in.IdempotencyKey, in.CreatedByMembershipID,
+	)
+	created, err := scanLead(row)
+	if err != nil {
+		return nil, fmt.Errorf("lead: create: %w", err)
+	}
+	return created, nil
+}
+
+// FindByID is tenant-scoped (Rule #6: cross-org → httpx.ErrNotFound) and,
+// when t.Role is employee, additionally scoped to leads assigned to
+// t.MembershipID (TD §9 — the PRD's core requirement for this issue,
+// enforced here once rather than in every future usecase method that
+// touches a single lead).
+func (r *Repository) FindByID(ctx context.Context, t tenant.Context, id uuid.UUID) (*Lead, error) {
+	const q = `
+		SELECT ` + leadColumns + `
+		FROM leads
+		WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
+		  AND (NOT $3 OR assigned_to_membership_id = $4)`
+
+	row := r.q.QueryRow(ctx, q, id, t.OrganizationID, isEmployee(t), membershipIDOrNil(t))
+	found, err := scanLead(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, httpx.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lead: find by id: %w", err)
+	}
+	return found, nil
+}
+
+// Update applies optimistic locking (TD §4): expectedVersion must match
+// the current row, and (like FindByID) an employee can only update a
+// lead assigned to them. Nullable fields in in use "nil means don't
+// touch" — this minimal Update has no way to clear a field to NULL;
+// that's a deliberate simplification for issue #19's repository-only
+// scope, revisited if #20's usecase needs it.
+//
+// Zero rows affected is ambiguous (wrong version vs. wrong tenant/scope
+// vs. missing) — resolved by re-running FindByID's exact scoping query:
+// row not visible in this scope → httpx.ErrNotFound; row visible but
+// version differs → (current state, ErrVersionConflict), so the future
+// usecase can build TD §4's 409 body without a second round trip.
+func (r *Repository) Update(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, in UpdateInput) (*Lead, error) {
+	const q = `
+		UPDATE leads
+		SET version = version + 1,
+		    name    = COALESCE($5, name),
+		    email   = COALESCE($6, email),
+		    phone   = COALESCE($7, phone),
+		    company = COALESCE($8, company),
+		    notes   = COALESCE($9, notes)
+		WHERE id = $1 AND organization_id = $2 AND version = $3 AND deleted_at IS NULL
+		  AND (NOT $4 OR assigned_to_membership_id = $10)
+		RETURNING ` + leadColumns
+
+	row := r.q.QueryRow(ctx, q,
+		id, t.OrganizationID, expectedVersion, isEmployee(t),
+		in.Name, in.Email, in.Phone, in.Company, in.Notes,
+		membershipIDOrNil(t),
+	)
+	updated, err := scanLead(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		current, findErr := r.FindByID(ctx, t, id)
+		if findErr != nil {
+			return nil, findErr
+		}
+		return current, ErrVersionConflict
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lead: update: %w", err)
+	}
+	return updated, nil
+}
+
+func isEmployee(t tenant.Context) bool {
+	return t.Role == tenant.RoleEmployee
+}
+
+func membershipIDOrNil(t tenant.Context) uuid.UUID {
+	if t.MembershipID == nil {
+		return uuid.UUID{}
+	}
+	return *t.MembershipID
+}
+
+const leadColumns = `
+	id, organization_id, lead_number, name, email, phone, phone_e164, company, notes,
+	status, lost_reason, source, assigned_to_membership_id, raw_payload, idempotency_key,
+	version, created_by_membership_id, created_at, updated_at, deleted_at`
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanLead(row rowScanner) (*Lead, error) {
+	var l Lead
+	err := row.Scan(
+		&l.ID, &l.OrganizationID, &l.LeadNumber, &l.Name, &l.Email, &l.Phone, &l.PhoneE164, &l.Company, &l.Notes,
+		&l.Status, &l.LostReason, &l.Source, &l.AssignedToMembershipID, &l.RawPayload, &l.IdempotencyKey,
+		&l.Version, &l.CreatedByMembershipID, &l.CreatedAt, &l.UpdatedAt, &l.DeletedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &l, nil
+}

--- a/crm_be/internal/lead/repository_test.go
+++ b/crm_be/internal/lead/repository_test.go
@@ -1,0 +1,241 @@
+package lead_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+func TestRepository_Create_FirstLeadInOrgGetsNumberOne(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := lead.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org}, minimalInput("Budi"))
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if created.LeadNumber != 1 {
+		t.Errorf("expected lead_number 1 for a fresh organization, got %d", created.LeadNumber)
+	}
+	if created.Version != 1 {
+		t.Errorf("expected initial version 1, got %d", created.Version)
+	}
+	if created.Status != "new" {
+		t.Errorf("expected default status 'new', got %q", created.Status)
+	}
+}
+
+// TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber is the actual
+// proof that Create must be called inside db.InTx (TD §3) — see the
+// doc comment on Create and on the concurrency tests in
+// repository_concurrency_test.go for why the concurrency tests alone
+// don't establish this: they never make the INSERT fail, so they'd
+// pass identically even if Create were called against a bare pool.
+func TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := lead.New(pool)
+	org := seedOrganization(t, ctx, pool)
+
+	first, err := repo.Create(ctx, tenant.Context{OrganizationID: org}, minimalInput("First"))
+	if err != nil {
+		t.Fatalf("seed create: %v", err)
+	}
+	if first.LeadNumber != 1 {
+		t.Fatalf("expected the seed lead to get number 1, got %d", first.LeadNumber)
+	}
+
+	// This Create is guaranteed to fail at the INSERT step: the FK on
+	// assigned_to_membership_id points at a membership that doesn't
+	// exist. Run inside db.InTx, so the whole attempt — including the
+	// next_lead_number allocation that happened first — rolls back.
+	bogusMembership := uuid.Must(uuid.NewV7())
+	failingInput := minimalInput("Will Fail")
+	failingInput.AssignedToMembershipID = &bogusMembership
+
+	txErr := db.InTx(ctx, pool, func(tx pgx.Tx) error {
+		_, err := lead.New(tx).Create(ctx, tenant.Context{OrganizationID: org}, failingInput)
+		return err
+	})
+	if txErr == nil {
+		t.Fatal("expected the create to fail on the FK violation")
+	}
+
+	// If the allocation had NOT been rolled back with it, this next
+	// create would land on number 3 (1 already burned by the failed
+	// attempt). It must land on 2.
+	second, err := repo.Create(ctx, tenant.Context{OrganizationID: org}, minimalInput("Second"))
+	if err != nil {
+		t.Fatalf("second create: %v", err)
+	}
+	if second.LeadNumber != 2 {
+		t.Errorf("expected lead_number 2 (rolled-back attempt should leave no gap), got %d", second.LeadNumber)
+	}
+}
+
+func TestRepository_FindByID_CrossTenant_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := lead.New(pool)
+
+	orgA := seedOrganization(t, ctx, pool)
+	orgB := seedOrganization(t, ctx, pool)
+
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: orgA}, minimalInput("Org A Lead"))
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	_, err = repo.FindByID(ctx, tenant.Context{OrganizationID: orgB, Role: tenant.RoleOwner}, created.ID)
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound for a lead in a different organization, got: %v", err)
+	}
+}
+
+// TestRepository_FindByID_Employee_OnlySeesOwnAssignedLead is the PRD's
+// core requirement for this issue (TD §9) — enforced in the repository,
+// not left to a future usecase to remember.
+func TestRepository_FindByID_Employee_OnlySeesOwnAssignedLead(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := lead.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	employeeA := seedMembership(t, ctx, pool, org, "employee-a@example.com", tenant.RoleEmployee)
+	employeeB := seedMembership(t, ctx, pool, org, "employee-b@example.com", tenant.RoleEmployee)
+
+	in := minimalInput("Assigned to A")
+	in.AssignedToMembershipID = &employeeA
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org}, in)
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	// Employee B must not see it.
+	_, err = repo.FindByID(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleEmployee, MembershipID: &employeeB}, created.ID)
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound for an employee reading someone else's lead, got: %v", err)
+	}
+
+	// Employee A (the assignee) must see it.
+	found, err := repo.FindByID(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleEmployee, MembershipID: &employeeA}, created.ID)
+	if err != nil {
+		t.Fatalf("expected the assignee to read their own lead, got: %v", err)
+	}
+	if found.ID != created.ID {
+		t.Errorf("expected the same lead back, got a different id")
+	}
+
+	// Owner sees everything regardless of assignment.
+	ownerID := seedMembership(t, ctx, pool, org, "owner@example.com", tenant.RoleOwner)
+	if _, err := repo.FindByID(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner, MembershipID: &ownerID}, created.ID); err != nil {
+		t.Errorf("expected owner to read any lead in their organization, got: %v", err)
+	}
+}
+
+func TestRepository_Update_CorrectVersion_Succeeds(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := lead.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org}, minimalInput("Original Name"))
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	newName := "Updated Name"
+	updated, err := repo.Update(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, created.ID, created.Version, lead.UpdateInput{Name: &newName})
+	if err != nil {
+		t.Fatalf("update failed: %v", err)
+	}
+	if updated.Name != newName {
+		t.Errorf("expected name %q, got %q", newName, updated.Name)
+	}
+	if updated.Version != created.Version+1 {
+		t.Errorf("expected version to increment from %d to %d, got %d", created.Version, created.Version+1, updated.Version)
+	}
+}
+
+// TestRepository_Update_StaleVersion_ReturnsConflictWithCurrentState is
+// TD §4's contract: the caller gets the current row back alongside
+// ErrVersionConflict, without a second query.
+func TestRepository_Update_StaleVersion_ReturnsConflictWithCurrentState(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := lead.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org}, minimalInput("Name"))
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+
+	staleVersion := created.Version - 1 // never a real version — always stale
+	newName := "Should Not Apply"
+	current, err := repo.Update(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, created.ID, staleVersion, lead.UpdateInput{Name: &newName})
+	if !errors.Is(err, lead.ErrVersionConflict) {
+		t.Fatalf("expected lead.ErrVersionConflict, got: %v", err)
+	}
+	if current == nil {
+		t.Fatal("expected the current lead state to be returned alongside the conflict")
+	}
+	if current.Name == newName {
+		t.Error("the stale update must not have applied")
+	}
+	if current.Version != created.Version {
+		t.Errorf("expected returned version to be the actual current version %d, got %d", created.Version, current.Version)
+	}
+}
+
+func TestRepository_Update_MissingLead_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := lead.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	newName := "Doesn't Matter"
+	_, err := repo.Update(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, uuid.Must(uuid.NewV7()), 1, lead.UpdateInput{Name: &newName})
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound for a nonexistent lead, got: %v", err)
+	}
+}
+
+func minimalInput(name string) lead.CreateInput {
+	return lead.CreateInput{Name: name, Source: "manual"}
+}
+
+func seedOrganization(t *testing.T, ctx context.Context, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, id); err != nil {
+		t.Fatalf("failed to seed organization: %v", err)
+	}
+	return id
+}
+
+func seedMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, email string, role tenant.Role) uuid.UUID {
+	t.Helper()
+	userID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Test User')`, userID, email); err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+	membershipID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, $4)`, membershipID, org, userID, role); err != nil {
+		t.Fatalf("failed to seed membership: %v", err)
+	}
+	return membershipID
+}

--- a/crm_be/internal/shared/db/migrate_test.go
+++ b/crm_be/internal/shared/db/migrate_test.go
@@ -89,11 +89,63 @@ func TestMigrationRoundTrip_0002Identity(t *testing.T) {
 	restoreLatest(t, sqlDB)
 }
 
+func TestMigrationRoundTrip_0003CrmCore(t *testing.T) {
+	sqlDB := openGooseDB(t)
+
+	// Land on exactly version 2 first, so UpTo(3) below is a real
+	// migration of 0003 alone rather than a no-op against an
+	// already-fully-migrated shared container.
+	if err := goose.DownTo(sqlDB, ".", 2); err != nil {
+		t.Fatalf("goose down to 2 failed: %v", err)
+	}
+	if columnExists(t, sqlDB, "organizations", "next_lead_number") {
+		t.Fatal("expected organizations.next_lead_number to be absent before migrating to version 3")
+	}
+
+	if err := goose.UpTo(sqlDB, ".", 3); err != nil {
+		t.Fatalf("goose up to 3 failed: %v", err)
+	}
+	for _, table := range crmCoreTables {
+		if !tableExists(t, sqlDB, table) {
+			t.Errorf("expected table %q to exist after migrating to version 3", table)
+		}
+	}
+	if !columnExists(t, sqlDB, "organizations", "next_lead_number") {
+		t.Error("expected organizations.next_lead_number to exist after migrating to version 3")
+	}
+
+	if err := goose.DownTo(sqlDB, ".", 2); err != nil {
+		t.Fatalf("goose down to 2 failed: %v", err)
+	}
+	for _, table := range crmCoreTables {
+		if tableExists(t, sqlDB, table) {
+			t.Errorf("expected table %q to be gone after rolling back to version 2 — nothing should be left behind", table)
+		}
+	}
+	if columnExists(t, sqlDB, "organizations", "next_lead_number") {
+		t.Error("expected organizations.next_lead_number to be gone after rolling back to version 2")
+	}
+	// 0001's function and 0002's tables must survive rolling back 0003 —
+	// down only undoes its own migration, not everything beneath it.
+	if !functionExists(t, sqlDB, "set_updated_at") {
+		t.Fatal("expected set_updated_at() (from 0001) to survive rolling back 0003")
+	}
+	for _, table := range identityTables {
+		if !tableExists(t, sqlDB, table) {
+			t.Errorf("expected table %q (from 0002) to survive rolling back 0003", table)
+		}
+	}
+
+	restoreLatest(t, sqlDB)
+}
+
 var identityTables = []string{
 	"organizations", "users", "memberships", "subscriptions",
 	"invitations", "email_verification_tokens", "password_reset_tokens",
 	"refresh_tokens", "audit_logs",
 }
+
+var crmCoreTables = []string{"leads", "customers", "activities", "tasks"}
 
 func openGooseDB(t *testing.T) *sql.DB {
 	t.Helper()
@@ -151,6 +203,19 @@ func tableExists(t *testing.T, db *sql.DB, name string) bool {
 	).Scan(&exists)
 	if err != nil {
 		t.Fatalf("failed to check table existence: %v", err)
+	}
+	return exists
+}
+
+func columnExists(t *testing.T, db *sql.DB, table, column string) bool {
+	t.Helper()
+	var exists bool
+	err := db.QueryRow(
+		`SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2)`,
+		table, column,
+	).Scan(&exists)
+	if err != nil {
+		t.Fatalf("failed to check column existence: %v", err)
 	}
 	return exists
 }

--- a/crm_be/migrations/0003_crm_core.sql
+++ b/crm_be/migrations/0003_crm_core.sql
@@ -1,0 +1,205 @@
+-- Phase 2 — CRM Core. First domain migration of the phase.
+-- Spec: docs/phases/02-crm-core/td.md §1. Column shapes below are copied
+-- from that spec, not re-derived.
+
+-- +goose Up
+
+-- leads — domain inti. No CHECK requiring email or phone: rejecting a
+-- lead at ingest time means discarding a customer's data, which is
+-- unrecoverable (freeze bagian 2.3).
+CREATE TABLE leads (
+    id                        uuid PRIMARY KEY,
+    organization_id           uuid NOT NULL REFERENCES organizations (id),
+    lead_number               integer NOT NULL,
+
+    name                      text NOT NULL,
+    email                     text,
+    phone                     text,
+    phone_e164                text,
+    company                   text,
+    notes                     text,
+
+    status                    text NOT NULL DEFAULT 'new',
+    lost_reason               text,
+    source                    text NOT NULL,
+    assigned_to_membership_id uuid,
+
+    -- Sumber capture eksternal (api/form/webhook) berbentuk sembarang dan
+    -- tidak boleh dibuang begitu field tak dikenal muncul — field itu
+    -- tetap tersimpan di sini supaya lead bisa direkonstruksi saat
+    -- integrator melapor "data saya hilang" (Aturan #17). Tidak pernah
+    -- di-query isinya; hanya disimpan dan ditampilkan apa adanya.
+    raw_payload               jsonb,
+    idempotency_key           text,
+    version                   integer NOT NULL DEFAULT 1,
+
+    created_by_membership_id  uuid,
+    created_at                timestamptz NOT NULL DEFAULT now(),
+    updated_at                timestamptz NOT NULL DEFAULT now(),
+    deleted_at                timestamptz,
+
+    CONSTRAINT ck_leads_status CHECK (status IN
+        ('new','contacted','qualified','proposal','won','lost','unqualified','spam')),
+    CONSTRAINT ck_leads_source CHECK (source IN ('manual','api','form','webhook')),
+    CONSTRAINT ck_leads_lost_reason CHECK (lost_reason IS NULL OR lost_reason IN
+        ('price','competitor','timing','no_response','not_interested','other')),
+    -- Aturan #4 acceptance criteria ditegakkan di database, bukan hanya
+    -- usecase — tidak ada jalur lain (migration, perbaikan manual) yang
+    -- bisa melanggarnya.
+    CONSTRAINT ck_leads_lost_requires_reason CHECK (status <> 'lost' OR lost_reason IS NOT NULL),
+    CONSTRAINT ck_leads_email_lowercase CHECK (email IS NULL OR email = lower(email)),
+
+    CONSTRAINT uq_leads_id_org UNIQUE (id, organization_id),
+    CONSTRAINT uq_leads_org_number UNIQUE (organization_id, lead_number),
+
+    -- created_by_membership_id nullable: lead dari api/form/webhook tidak
+    -- punya pembuat manusia.
+    CONSTRAINT fk_leads_assignee
+        FOREIGN KEY (assigned_to_membership_id, organization_id)
+        REFERENCES memberships (id, organization_id),
+    CONSTRAINT fk_leads_creator
+        FOREIGN KEY (created_by_membership_id, organization_id)
+        REFERENCES memberships (id, organization_id)
+);
+
+CREATE TRIGGER trg_leads_updated_at BEFORE UPDATE ON leads
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE INDEX ix_leads_org_status    ON leads (organization_id, status)      WHERE deleted_at IS NULL;
+CREATE INDEX ix_leads_org_assignee  ON leads (organization_id, assigned_to_membership_id) WHERE deleted_at IS NULL;
+CREATE INDEX ix_leads_org_created   ON leads (organization_id, created_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX ix_leads_org_phone     ON leads (organization_id, phone_e164)  WHERE deleted_at IS NULL AND phone_e164 IS NOT NULL;
+
+-- Kolom & constraint idempotency dibuat sekarang meski belum ada yang
+-- menulisnya — endpoint POST /v1/leads (issue #20) bergantung padanya.
+CREATE UNIQUE INDEX uq_leads_org_idempotency
+    ON leads (organization_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+-- customers — hasil konversi Lead, entity terpisah. converted_from_lead_id
+-- NOT NULL: di MVP setiap customer berasal dari lead, tidak ada endpoint
+-- "buat customer langsung".
+CREATE TABLE customers (
+    id                         uuid PRIMARY KEY,
+    organization_id            uuid NOT NULL REFERENCES organizations (id),
+
+    name                       text NOT NULL,
+    email                      text,
+    phone                      text,
+    phone_e164                 text,
+    company                    text,
+    notes                      text,
+
+    converted_from_lead_id     uuid NOT NULL,
+    converted_by_membership_id uuid,
+    converted_at               timestamptz NOT NULL DEFAULT now(),
+
+    created_at                 timestamptz NOT NULL DEFAULT now(),
+    updated_at                 timestamptz NOT NULL DEFAULT now(),
+    deleted_at                 timestamptz,
+
+    CONSTRAINT ck_customers_email_lowercase CHECK (email IS NULL OR email = lower(email)),
+    CONSTRAINT uq_customers_id_org UNIQUE (id, organization_id),
+
+    CONSTRAINT fk_customers_lead
+        FOREIGN KEY (converted_from_lead_id, organization_id)
+        REFERENCES leads (id, organization_id),
+    CONSTRAINT fk_customers_converter
+        FOREIGN KEY (converted_by_membership_id, organization_id)
+        REFERENCES memberships (id, organization_id)
+);
+
+CREATE TRIGGER trg_customers_updated_at BEFORE UPDATE ON customers
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Satu lead hanya boleh menghasilkan satu customer — ditegakkan database,
+-- bukan sekadar dicek usecase.
+CREATE UNIQUE INDEX uq_customers_org_lead ON customers (organization_id, converted_from_lead_id);
+
+-- activities — append-only, immutable. Tanpa updated_at, tanpa deleted_at,
+-- tanpa trigger set_updated_at: ketiadaan kolom itu SENDIRI adalah
+-- penegakannya — tidak ada endpoint edit/hapus yang bisa ditulis tanpa
+-- mengubah schema lebih dulu.
+CREATE TABLE activities (
+    id                  uuid PRIMARY KEY,
+    organization_id     uuid NOT NULL REFERENCES organizations (id),
+    lead_id             uuid NOT NULL,
+    type                text NOT NULL,
+    actor_membership_id uuid,
+    body                text,
+    -- Bentuk metadata berbeda per type (lead_assigned menyimpan {from,to},
+    -- status_changed menyimpan {from,to}, call_logged menyimpan durasi).
+    -- Kolom terpisah per tipe berarti belasan kolom yang mayoritas selalu
+    -- NULL (Aturan #17). Tidak pernah di-query isinya — hanya dirender di
+    -- timeline.
+    metadata            jsonb,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT ck_activities_type CHECK (type IN (
+        'lead_created','lead_assigned','lead_unassigned','status_changed','lead_converted',
+        'note_added','call_logged','whatsapp_opened','task_created','task_completed')),
+    CONSTRAINT uq_activities_id_org UNIQUE (id, organization_id),
+
+    CONSTRAINT fk_activities_lead
+        FOREIGN KEY (lead_id, organization_id) REFERENCES leads (id, organization_id),
+    CONSTRAINT fk_activities_actor
+        FOREIGN KEY (actor_membership_id, organization_id) REFERENCES memberships (id, organization_id)
+);
+
+CREATE INDEX ix_activities_org_lead ON activities (organization_id, lead_id, created_at DESC);
+
+-- tasks — lead_id NOT NULL (B8): task selalu menempel pada satu lead.
+-- Melonggarkan NOT NULL nanti adalah satu ALTER; mengetatkannya berarti
+-- membersihkan baris yatim lebih dulu.
+CREATE TABLE tasks (
+    id                         uuid PRIMARY KEY,
+    organization_id            uuid NOT NULL REFERENCES organizations (id),
+    lead_id                    uuid NOT NULL,
+
+    title                      text NOT NULL,
+    description                text,
+    due_at                     timestamptz,
+    status                     text NOT NULL DEFAULT 'open',
+
+    assigned_to_membership_id  uuid,
+    completed_at               timestamptz,
+    completed_by_membership_id uuid,
+
+    version                    integer NOT NULL DEFAULT 1,
+    created_by_membership_id   uuid,
+    created_at                 timestamptz NOT NULL DEFAULT now(),
+    updated_at                 timestamptz NOT NULL DEFAULT now(),
+    deleted_at                 timestamptz,
+
+    -- Hanya open/done. Tidak ada "cancelled" — task yang tidak jadi
+    -- dikerjakan dihapus (soft delete); deleted_at sudah membedakannya
+    -- dari yang selesai.
+    CONSTRAINT ck_tasks_status CHECK (status IN ('open','done')),
+    CONSTRAINT ck_tasks_done_requires_completed_at CHECK (status <> 'done' OR completed_at IS NOT NULL),
+    CONSTRAINT uq_tasks_id_org UNIQUE (id, organization_id),
+
+    CONSTRAINT fk_tasks_lead      FOREIGN KEY (lead_id, organization_id) REFERENCES leads (id, organization_id),
+    CONSTRAINT fk_tasks_assignee  FOREIGN KEY (assigned_to_membership_id, organization_id) REFERENCES memberships (id, organization_id),
+    CONSTRAINT fk_tasks_creator   FOREIGN KEY (created_by_membership_id, organization_id)  REFERENCES memberships (id, organization_id),
+    CONSTRAINT fk_tasks_completer FOREIGN KEY (completed_by_membership_id, organization_id) REFERENCES memberships (id, organization_id)
+);
+
+CREATE TRIGGER trg_tasks_updated_at BEFORE UPDATE ON tasks
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE INDEX ix_tasks_org_assignee_due ON tasks (organization_id, assigned_to_membership_id, due_at)
+    WHERE deleted_at IS NULL AND status = 'open';
+CREATE INDEX ix_tasks_org_lead ON tasks (organization_id, lead_id) WHERE deleted_at IS NULL;
+
+-- next_lead_number sengaja ditambahkan sekarang, bukan di 0002 — di 0002
+-- belum ada leads, sehingga kolom itu akan menjadi schema mati. ALTER
+-- TABLE ADD COLUMN dengan DEFAULT konstan bersifat instan pada PostgreSQL
+-- modern.
+ALTER TABLE organizations ADD COLUMN next_lead_number integer NOT NULL DEFAULT 1;
+
+-- +goose Down
+ALTER TABLE organizations DROP COLUMN IF EXISTS next_lead_number;
+DROP TABLE IF EXISTS tasks;
+DROP TABLE IF EXISTS activities;
+DROP TABLE IF EXISTS customers;
+DROP TABLE IF EXISTS leads;

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 21 Agustus 2026 — PRD + TD Phase 2 dibuka, B6–B9 ditutup
-**Phase sekarang:** Phase 2 — CRM Core (0/5 issue selesai — implementasi dimulai di #19)
+**Last updated:** 21 Agustus 2026 — Issue #19 selesai
+**Phase sekarang:** Phase 2 — CRM Core (1/5 issue selesai)
 
 ---
 
@@ -29,6 +29,7 @@
 | **Issue #15 — Refactor: layering, interface, Unit of Work** | — | 1 | `internal/auth` dipecah jadi `entity/port/usecase/repository_postgres/handler_http.go`. `Store`/`Repos` (Unit of Work) menggantikan `db.InTx` langsung di usecase. Composition root di `cmd/api/auth_store.go`. **7 unit test baru lolos tanpa Docker** (dibuktikan lewat `DOCKER_HOST` tak valid + inspeksi `go list -deps`). 33 test lama lolos tanpa perubahan asersi. |
 | **Issue #10 — Login, refresh rotation, logout, reset password, CSRF, GET /v1/me** | — | 1 | `POST /v1/auth/{login,refresh,logout,password/forgot,password/reset}`, `GET /v1/me`. Access token JWT (`internal/shared/accesstoken`) + refresh token opaque dengan rotasi & deteksi penggunaan ulang (`SELECT ... FOR UPDATE`, revoke seluruh `family_id`). Dashboard = cookie `HttpOnly`; Mobile = body — dibuktikan lewat test HTTP & smoke test manual. CSRF double-submit (`httpx.VerifyCSRF`) untuk request cookie non-GET. `LoginLimiter` (backoff progresif). `docs/architecture/authentication.md` baru. **12 test integrasi + 13 unit test baru** (plus 5 test `LoginLimiter`, 4 test `accesstoken`), semuanya lolos tanpa perubahan asersi lama. |
 | **Issue #11 — RBAC, invitation, penonaktifan membership, harness isolasi tenant** | — | 1 | `internal/shared/{authn,authz}` (session middleware diekstrak dari `auth`, RBAC baru). `internal/membership` naik jadi domain penuh (`port/usecase/handler_http.go`). `internal/invitation` baru — undangan dua cabang (B4), keduanya diuji termasuk test keamanan wajib. `POST/GET/DELETE /v1/invitations`, `GET/PATCH/DELETE /v1/memberships`. Penonaktifan membership mencabut refresh token dalam transaksi yang sama — **dibuktikan lewat smoke test end-to-end**. `docs/architecture/authorization.md` baru. **Harness isolasi tenant (`cmd/api/tenant_isolation_test.go`) dibangun & dibuktikan bisa gagal** (lapis 4, blocking CI). Satu bug nyata (email tidak terverifikasi otomatis saat accept undangan) ditemukan lewat smoke test manual, diperbaiki, dan mendapat test regresi di kedua level. **Phase 1 selesai.** |
+| **Issue #19 — Schema 0003, repository lead, alokasi `lead_number`, optimistic locking** | — | 2 | Migration `0003_crm_core` (`leads`, `customers`, `activities`, `tasks` + `organizations.next_lead_number`). `internal/lead` — repository murni (`entity.go`+`repository_postgres.go`, tanpa `port.go`/usecase — pola `membership` pra-#11). Alokasi `lead_number` berurutan per organization dan optimistic locking `version`, **dibuktikan di bawah konkurensi nyata** (20 goroutine bersamaan). Visibilitas employee ditegakkan di repository. Klaim awal soal kebutuhan `db.InTx` sempat berlebihan di komentar kode — diuji langsung sebelum commit, ternyata test konkurensi tidak membuktikannya; ditulis test terpisah (`TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber`) yang benar-benar membuktikan. Test katalog (dari #8) otomatis mencakup keempat tabel baru **tanpa perubahan**. |
 
 ---
 
@@ -40,12 +41,12 @@ _(kosong)_
 
 ## Berikutnya
 
-**Issue #19 — Schema 0003, repository lead, alokasi `lead_number`, optimistic locking**
+**Issue #20 — Lead CRUD, transisi status, filter, pagination, idempotency, E.164**
 
-- Cakupan & acceptance: [issue #19](https://github.com/Pravasta/jualin-crm/issues/19)
-- TD: `docs/phases/02-crm-core/td.md` §1, §3, §4, §9, §16
-- Issue pertama Phase 2, **tanpa endpoint sama sekali** — menetapkan dua mekanisme paling halus di phase ini (serialisasi `lead_number` per organization, optimistic locking `version`) yang keduanya hanya bisa dipercaya bila diuji di bawah konkurensi nyata.
-- Berurutan: #19 → #20 → #21 → #22 → #23. Rincian di `docs/phases/02-crm-core/issues.md`.
+- Cakupan & acceptance: [issue #20](https://github.com/Pravasta/jualin-crm/issues/20)
+- TD: `docs/phases/02-crm-core/td.md` §4, §5, §6, §7, §8, §8.1, §9
+- Menambahkan `port.go` + `usecase.go` ke `internal/lead` — pada titik ini `Repository` di `repository_postgres.go` berganti jadi interface dan struct konkretnya berganti nama `postgresRepository`, persis migrasi `membership` di #11 (lihat notes.md `## #19`).
+- Berurutan: #19 (selesai) → #20 → #21 → #22 → #23. Rincian di `docs/phases/02-crm-core/issues.md`.
 
 ---
 

--- a/docs/phases/02-crm-core/notes.md
+++ b/docs/phases/02-crm-core/notes.md
@@ -1,0 +1,60 @@
+# Phase 2 — CRM Core · Notes
+
+One section per issue, appended as each is implemented.
+
+---
+
+## #19 — Schema 0003, repository lead, alokasi lead_number, optimistic locking
+
+### Menyimpang dari rencana issue
+
+| Yang berbeda | Alasan |
+|---|---|
+| `internal/lead` **tidak** mendapat `port.go` — hanya `entity.go` + `repository_postgres.go`, dengan `Repository` sebagai struct konkret (bukan interface) | Issue #19 checklist menyebut `port.go`, tapi itu tidak konsisten dengan konvensi yang sudah dua kali ditetapkan codebase ini (`user`, `organization`, dan `membership` sebelum #11): paket "repository murni" tanpa usecase mengekspor struct konkret; `port.go` (interface) baru muncul saat consumer sungguhan (`Usecase`) ada untuk mendeklarasikannya (ADR-011). #20 menambah `port.go` + `usecase.go` saat consumer itu ada, dan `Repository` berubah jadi interface — migrasi yang sama persis dengan yang `membership` alami di #11. |
+
+### Keputusan implementasi
+
+- **Klaim awal di komentar kode terbukti berlebihan, ditemukan sebelum commit.** Draf pertama `Create`'s doc comment menyatakan "callers MUST wrap Create in db.InTx, dibuktikan di repository_concurrency_test.go". Sebelum menulis ini di notes.md, saya uji klaim itu secara langsung: memodifikasi `createConcurrently` sementara untuk memanggil `Create` langsung ke pool (tanpa `db.InTx` sama sekali) dan menjalankan `TestConcurrency_LeadNumber_NoGapsNoDuplicates` lima kali dengan `-race`. **Tetap hijau seluruhnya.** Alasannya: `UPDATE … RETURNING` tunggal sudah atomik dan mengambil row lock terlepas dari apakah ia dibungkus transaksi eksplisit — yang dibuktikan test konkurensi hanyalah alokasi nomor tidak pernah tabrakan, bukan kebutuhan `db.InTx`.
+
+  Yang **sungguh** bergantung pada `db.InTx` adalah skenario berbeda: `INSERT INTO leads` gagal **setelah** `next_lead_number` berhasil dialokasikan (mis. pelanggaran FK). Tanpa transaksi, alokasi itu sudah ter-commit sendiri — nomor itu hilang permanen, sebuah lubang. Di dalam `db.InTx`, kegagalan `INSERT` me-rollback **seluruh** percobaan termasuk alokasinya, sehingga percobaan berikutnya mendapat nomor yang sama, bukan nomor berikutnya.
+
+  Ditulis test baru yang secara langsung membuktikan skenario itu — `TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber` (`repository_test.go`): buat lead pertama (nomor 1), coba `Create` kedua yang **sengaja** melanggar FK `assigned_to_membership_id` di dalam `db.InTx`, pastikan gagal, lalu `Create` ketiga (di luar transaksi manapun, seperti biasa) harus mendapat nomor **2**, bukan 3. Ini benar-benar membuktikan kebutuhan transaksi; tiga test konkurensi tidak.
+
+  Komentar kode (`Create`'s doc comment dan `repository_concurrency_test.go`'s doc comment) ditulis ulang supaya tidak mengklaim lebih dari yang benar-benar dibuktikan test yang menyertainya — kesalahan kecil, ditangkap sebelum commit, tapi dicatat di sini karena persis jenis overclaim yang mudah lolos review kalau tidak diuji langsung.
+
+- **`Update`'s field nullable (`Email`, `Phone`, `Company`, `Notes`) tidak bisa di-set ke `NULL` lewat `UpdateInput`** — `nil` berarti "jangan sentuh", direpresentasikan lewat `COALESCE($n, kolom)`. Tidak ada cara membedakan "jangan sentuh" dari "kosongkan" dengan `*string` tunggal. Disengaja untuk cakupan repository-only issue ini; `#20` menambah mekanisme tri-state (mis. `**string` atau flag terpisah) bila usecase-nya benar-benar butuh mengosongkan field, bukan ditebak sekarang.
+
+- **`ck_leads_lost_requires_reason` dan `uq_customers_org_lead` ditegakkan database**, persis seperti TD — bukan hanya usecase (yang belum ada di issue ini). Terverifikasi lewat schema migration, bukan test Go (belum ada usecase untuk memicunya lewat kode aplikasi).
+
+### Verifikasi
+
+```
+go build ./...                              → bersih
+go vet ./...                                → bersih
+golangci-lint run                           → 0 issues
+gofmt -l .                                  → bersih
+go test -race -count=1 ./... (2x)           → semua PASS
+
+go test ./internal/lead/... -race -count=1  → 10/10 PASS
+  TestConcurrency_LeadNumber_NoGapsNoDuplicates          — 20 goroutine, {1..20} tepat
+  TestConcurrency_LeadNumber_IndependentPerOrganization  — dua org paralel, {1..10} masing-masing
+  TestConcurrency_VersionConflict_ExactlyOneWins         — 20 update bersamaan, tepat 1 sukses
+  TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber — lihat di atas
+
+goose up/down round-trip (0003)             → bersih, tabel 0002 & fungsi 0001 tetap ada setelah rollback 0003
+TestCatalog_TenantScopedTables*             → leads/customers/activities/tasks otomatis lolos TANPA perubahan test (dari #8)
+
+go list -deps ./cmd/api | grep docker       → kosong
+```
+
+Seluruh acceptance criteria issue #19 terpenuhi.
+
+### Utang teknis
+
+- Tidak ada item baru dari issue ini sendiri.
+
+### Catatan untuk session berikutnya
+
+- **`internal/lead` mengikuti pola `entity.go`+`repository_postgres.go` murni.** #20 menambah `port.go` (interface `Repository` + `Store`/`Repos`) dan `usecase.go` — pada titik itu, struct `Repository` di `repository_postgres.go` berganti nama jadi `postgresRepository` (unexported), persis migrasi `membership` di #11. Jangan kaget saat rename itu terjadi — sudah direncanakan, bukan refactor darurat.
+- **`Update` di repository ini hanya field umum** (`name`, `email`, `phone`, `company`, `notes`). Transisi status (`PATCH /status`) dan assignment (`PATCH /assignment`) di TD adalah endpoint terpisah dengan aturan sendiri — `#20` kemungkinan menambah method `Repository` baru untuk itu (`UpdateStatus`, atau usecase memanggil `Update` plus logic tambahan), bukan memperluas `UpdateInput` yang ada.
+- **Uji klaim atomisitas secara langsung sebelum menuliskannya di komentar kode**, bukan berasumsi dari desain. Pengalaman di atas (klaim `db.InTx` yang ternyata tidak dibuktikan test konkurensi) adalah contoh konkret kenapa ini penting — desain yang *terlihat* benar bisa salah soal *test mana* yang sebenarnya membuktikannya.


### PR DESCRIPTION
## Ringkasan

Issue pertama Phase 2. Migration `0003_crm_core` (`leads`, `customers`, `activities`, `tasks`, `organizations.next_lead_number`) + `internal/lead` — repository murni, **tanpa usecase/HTTP** (pola `membership` sebelum #11).

- Alokasi `lead_number` berurutan per organization
- Optimistic locking lewat `version`
- Visibilitas employee ditegakkan di repository (`FindByID`/`Update` hanya melihat lead miliknya)
- **Tanpa endpoint HTTP sama sekali** — nilainya seluruhnya ada di test konkurensi

## Klaim yang diuji dan ternyata berlebihan — diperbaiki sebelum commit

Draf pertama komentar `Create` menyatakan test konkurensi membuktikan kebutuhan `db.InTx`. Sebelum menulis ini di notes.md, saya uji klaim itu langsung: memanggil `Create` tanpa `db.InTx` sama sekali, jalankan `TestConcurrency_LeadNumber_NoGapsNoDuplicates` 5x dengan `-race` — **tetap hijau**. `UPDATE ... RETURNING` tunggal sudah atomik terlepas dari transaksi.

Yang *sungguh* butuh `db.InTx`: `INSERT` gagal **setelah** nomor teralokasi (mis. pelanggaran FK) — tanpa transaksi, nomor itu hilang permanen (lubang). Ditulis test baru yang membuktikan ini secara langsung: `TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber`. Detail lengkap di `notes.md`.

## Verifikasi

- `go build/vet/gofmt/golangci-lint` → bersih, 0 issues
- `go test -race -count=1 ./...` → semua PASS, dijalankan 2x
- `go test ./internal/lead/... -race -count=1` → 10/10 PASS, termasuk 4 test konkurensi/atomisitas
- Migration round-trip (`0003`) bersih — tabel `0002` dan fungsi `0001` tetap ada setelah rollback `0003`
- Test katalog (dari #8) otomatis mencakup `leads`/`customers`/`activities`/`tasks` **tanpa perubahan test**
- `go list -deps ./cmd/api | grep docker` → kosong

Detail lengkap di `docs/phases/02-crm-core/notes.md` bagian `## #19`.

Refs #19