### PR TITLE
feat(lead): add CRUD, status transitions, filtering, and idempotency

### DIFF
--- a/crm_be/cmd/api/lead_store.go
+++ b/crm_be/cmd/api/lead_store.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+)
+
+// leadStore is the composition root's implementation of lead.Store —
+// same wiring pattern as auth_store.go/membership_store.go/
+// invitation_store.go. internal/lead has no cross-package dependency
+// yet, so reposFor here is the simplest of the four so far.
+type leadStore struct {
+	pool *pgxpool.Pool
+}
+
+func newLeadStore(pool *pgxpool.Pool) lead.Store {
+	return &leadStore{pool: pool}
+}
+
+func (s *leadStore) InTx(ctx context.Context, fn func(lead.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(leadReposFor(tx))
+	})
+}
+
+func (s *leadStore) Repos() lead.Repos {
+	return leadReposFor(s.pool)
+}
+
+func leadReposFor(q db.Querier) lead.Repos {
+	return lead.Repos{
+		Lead: lead.New(q),
+	}
+}

--- a/crm_be/cmd/api/main.go
+++ b/crm_be/cmd/api/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Pravasta/jualin-crm/crm_be/internal/auth"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/invitation"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/membership"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/config"
@@ -103,6 +104,9 @@ func newRouter(log *slog.Logger, pool *pgxpool.Pool, cfg *config.Config) *gin.En
 
 	invitationUsecase := invitation.NewUsecase(newInvitationStore(pool), mail, log, cfg.AppBaseURL)
 	invitation.NewHandler(invitationUsecase).RegisterRoutes(r, authMW, optionalAuthMW)
+
+	leadUsecase := lead.NewUsecase(newLeadStore(pool))
+	lead.NewHandler(leadUsecase).RegisterRoutes(r, authMW)
 
 	r.NoRoute(func(c *gin.Context) {
 		httpx.RespondError(c, http.StatusNotFound, "not_found", "Route tidak ditemukan.")

--- a/crm_be/internal/lead/entity.go
+++ b/crm_be/internal/lead/entity.go
@@ -1,8 +1,8 @@
 // Package lead is CRM Core's domain entity — the shape every capture
-// source (manual, api, form, webhook) produces. This issue (#19) ships
-// only entity.go + repository_postgres.go: no usecase, no HTTP, same
-// shape internal/membership had before #11 gave it a real consumer.
-// See docs/phases/02-crm-core/td.md §1.1.
+// source (manual, api, form, webhook) produces. As of #20 this is a full
+// domain package (entity/port/usecase/repository_postgres/handler_http),
+// having started in #19 as a pure repository. See
+// docs/phases/02-crm-core/td.md §1.1.
 package lead
 
 import (
@@ -74,3 +74,92 @@ type UpdateInput struct {
 // query to build the 409 body TD §4 requires ("body memuat keadaan
 // terkini").
 var ErrVersionConflict = errors.New("lead: version conflict")
+
+// ErrIdempotencyKeyExists is Create's signal that the (organization,
+// idempotency_key) pair already exists — detected via the
+// uq_leads_org_idempotency unique-violation, never a SELECT-then-INSERT
+// (that would race under exactly the concurrent-retry conditions
+// idempotency keys exist to handle). The usecase reacts by looking up
+// and returning the existing lead instead of erroring.
+var ErrIdempotencyKeyExists = errors.New("lead: idempotency key already used")
+
+// ErrAssigneeNotFound is Create's signal that
+// CreateInput.AssignedToMembershipID doesn't reference a real
+// membership in this organization — detected via the fk_leads_assignee
+// foreign-key violation, same database-constraint-as-source-of-truth
+// pattern as ErrIdempotencyKeyExists. Found during #20's own testing: a
+// bad assignee id used to surface as a bare 500.
+var ErrAssigneeNotFound = errors.New("lead: assignee not found")
+
+// mainPath is TD §5's primary funnel — index order matters, it's what
+// "maju satu langkah" / "mundur satu langkah" measure against.
+var mainPath = []string{"new", "contacted", "qualified", "proposal", "won"}
+
+const (
+	StatusLost        = "lost"
+	StatusUnqualified = "unqualified"
+	StatusSpam        = "spam"
+)
+
+// ListFilter is FindAllByOrg's argument — every field is optional
+// (zero value = don't filter on it), except AssignedToNone which is a
+// separate flag from AssignedTo since "filter to unassigned leads" and
+// "don't filter on assignment" are different requests that both leave
+// AssignedTo nil.
+type ListFilter struct {
+	Status         []string
+	Source         []string
+	AssignedTo     *uuid.UUID
+	AssignedToNone bool
+	Query          string
+	CreatedFrom    *time.Time
+	CreatedTo      *time.Time
+	Page           int
+	PerPage        int
+}
+
+// CreateLeadInput is Usecase.Create's argument — pre-normalization
+// (unlike port.go's CreateInput, which is what Repository.Create
+// persists once the usecase has already validated/normalized
+// everything). Deliberately distinct types: the repository layer must
+// never need to know what "not yet validated" looks like.
+type CreateLeadInput struct {
+	Name                   string
+	Email                  *string
+	Phone                  *string
+	Company                *string
+	Notes                  *string
+	Source                 string
+	AssignedToMembershipID *uuid.UUID
+	IdempotencyKey         *string
+}
+
+// UpdateLeadInput is Usecase.Update's argument — same
+// pre-normalization relationship to port.go's UpdateInput that
+// CreateLeadInput has to CreateInput.
+type UpdateLeadInput struct {
+	Version int
+	Name    *string
+	Email   *string
+	Phone   *string
+	Company *string
+	Notes   *string
+}
+
+// UpdateStatusInput is Usecase.UpdateStatus's argument.
+type UpdateStatusInput struct {
+	Version    int
+	Status     string
+	LostReason *string
+}
+
+// VersionConflictError carries the row's current state — TD §4's 409
+// body requirement ("body memuat keadaan terkini"). Same pattern as
+// auth.OrganizationSelectionError: a documented, narrow extension of the
+// error envelope for the one case that genuinely needs it, not license
+// for arbitrary error payloads.
+type VersionConflictError struct {
+	Current *Lead
+}
+
+func (e *VersionConflictError) Error() string { return "version conflict" }

--- a/crm_be/internal/lead/handler_http.go
+++ b/crm_be/internal/lead/handler_http.go
@@ -1,0 +1,273 @@
+package lead
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+)
+
+type Handler struct {
+	usecase *Usecase
+}
+
+func NewHandler(usecase *Usecase) *Handler {
+	return &Handler{usecase: usecase}
+}
+
+// RegisterRoutes mounts /v1/leads behind authMW — built once at the
+// composition root and shared across every domain (internal/shared/authn).
+func (h *Handler) RegisterRoutes(r gin.IRouter, authMW gin.HandlerFunc) {
+	g := r.Group("/v1/leads")
+	g.Use(authMW)
+	g.POST("", h.create)
+	g.GET("", h.list)
+	g.GET("/:id", h.get)
+	g.PATCH("/:id", h.update)
+	g.PATCH("/:id/status", h.updateStatus)
+	g.DELETE("/:id", h.delete)
+}
+
+type createRequest struct {
+	Name                   string  `json:"name"`
+	Email                  *string `json:"email"`
+	Phone                  *string `json:"phone"`
+	Company                *string `json:"company"`
+	Notes                  *string `json:"notes"`
+	Source                 string  `json:"source"`
+	AssignedToMembershipID *string `json:"assigned_to_membership_id"`
+}
+
+// create honors Idempotency-Key (Aturan #34-adjacent convention, TD §7):
+// a repeated key returns the ORIGINAL lead with 200, never a second
+// lead and never an error.
+func (h *Handler) create(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	var req createRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	in := CreateLeadInput{
+		Name: req.Name, Email: req.Email, Phone: req.Phone, Company: req.Company, Notes: req.Notes,
+		Source: req.Source,
+	}
+	if assignee, err := parseUUIDPtr(req.AssignedToMembershipID); err == nil {
+		in.AssignedToMembershipID = assignee
+	}
+	if key := c.GetHeader("Idempotency-Key"); key != "" {
+		in.IdempotencyKey = &key
+	}
+
+	created, isNew, err := h.usecase.Create(c.Request.Context(), t, in)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+
+	status := http.StatusOK
+	if isNew {
+		status = http.StatusCreated
+	}
+	httpx.OK(c, status, leadJSON(created))
+}
+
+func (h *Handler) get(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	found, err := h.usecase.Get(c.Request.Context(), t, id)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusOK, leadJSON(found))
+}
+
+func (h *Handler) list(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	in := ListInput{
+		Status: splitCSV(c.Query("status")),
+		Source: splitCSV(c.Query("source")),
+		Query:  c.Query("q"),
+	}
+	if assignedTo := c.Query("assigned_to"); assignedTo == "none" {
+		in.AssignedToNone = true
+	} else if assignedTo != "" {
+		if id, err := uuid.Parse(assignedTo); err == nil {
+			in.AssignedTo = &id
+		}
+	}
+	if from, err := time.Parse(time.RFC3339, c.Query("created_from")); err == nil {
+		in.CreatedFrom = &from
+	}
+	if to, err := time.Parse(time.RFC3339, c.Query("created_to")); err == nil {
+		in.CreatedTo = &to
+	}
+	if page, err := strconv.Atoi(c.Query("page")); err == nil {
+		in.Page = page
+	}
+	if perPage, err := strconv.Atoi(c.Query("per_page")); err == nil {
+		in.PerPage = perPage
+	}
+
+	leads, meta, err := h.usecase.List(c.Request.Context(), t, in)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+
+	out := make([]gin.H, 0, len(leads))
+	for _, l := range leads {
+		out = append(out, leadJSON(l))
+	}
+	httpx.List(c, out, meta)
+}
+
+type updateRequest struct {
+	Version int     `json:"version"`
+	Name    *string `json:"name"`
+	Email   *string `json:"email"`
+	Phone   *string `json:"phone"`
+	Company *string `json:"company"`
+	Notes   *string `json:"notes"`
+}
+
+func (h *Handler) update(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	var req updateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	updated, err := h.usecase.Update(c.Request.Context(), t, id, UpdateLeadInput(req))
+	if err != nil {
+		respondLeadError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusOK, leadJSON(updated))
+}
+
+type updateStatusRequest struct {
+	Version    int     `json:"version"`
+	Status     string  `json:"status"`
+	LostReason *string `json:"lost_reason"`
+}
+
+func (h *Handler) updateStatus(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	var req updateStatusRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	updated, err := h.usecase.UpdateStatus(c.Request.Context(), t, id, UpdateStatusInput(req))
+	if err != nil {
+		respondLeadError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusOK, leadJSON(updated))
+}
+
+func (h *Handler) delete(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	if err := h.usecase.Delete(c.Request.Context(), t, id); err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// respondLeadError type-switches for *VersionConflictError before
+// falling through to the generic mapper — TD §4's 409 body carries the
+// current row, which httpx.DomainError can't express (same pattern as
+// auth's organization_selection_required).
+func respondLeadError(c *gin.Context, err error) {
+	var conflict *VersionConflictError
+	if errors.As(err, &conflict) {
+		c.JSON(http.StatusConflict, gin.H{"error": gin.H{
+			"code":    "version_conflict",
+			"message": "Data sudah diubah oleh orang lain. Muat ulang dan coba lagi.",
+			"current": leadJSON(conflict.Current),
+		}})
+		return
+	}
+	httpx.WriteError(c, err)
+}
+
+func leadJSON(l *Lead) gin.H {
+	return gin.H{
+		"id":                        l.ID,
+		"lead_number":               l.LeadNumber,
+		"name":                      l.Name,
+		"email":                     l.Email,
+		"phone":                     l.Phone,
+		"phone_e164":                l.PhoneE164,
+		"company":                   l.Company,
+		"notes":                     l.Notes,
+		"status":                    l.Status,
+		"lost_reason":               l.LostReason,
+		"source":                    l.Source,
+		"assigned_to_membership_id": l.AssignedToMembershipID,
+		"version":                   l.Version,
+		"created_by_membership_id":  l.CreatedByMembershipID,
+		"created_at":                l.CreatedAt,
+		"updated_at":                l.UpdatedAt,
+	}
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, ",")
+}
+
+func parseUUIDPtr(s *string) (*uuid.UUID, error) {
+	if s == nil || *s == "" {
+		return nil, nil
+	}
+	id, err := uuid.Parse(*s)
+	if err != nil {
+		return nil, err
+	}
+	return &id, nil
+}

--- a/crm_be/internal/lead/handler_test.go
+++ b/crm_be/internal/lead/handler_test.go
@@ -1,0 +1,410 @@
+package lead_test
+
+// Integration tests (real Postgres via dbtest) for issue #20's HTTP
+// layer. TestHandler_Create_ConcurrentSameIdempotencyKey_ExactlyOneNew
+// is the Definition of Done's explicit concurrency requirement — the
+// other handler tests could in principle be written against a fake, but
+// this one specifically needs the real uq_leads_org_idempotency
+// constraint racing two real requests.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/accesstoken"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const testJWTSecret = "lead-handler-test-jwt-secret-32-bytes" // #nosec G101 -- test-only value, not a real credential
+
+type testClaimsParser struct{}
+
+func (testClaimsParser) ParseAccessToken(raw string) (*accesstoken.Claims, error) {
+	return accesstoken.Parse([]byte(testJWTSecret), raw)
+}
+
+type testStore struct{ pool *pgxpool.Pool }
+
+func newTestStore(pool *pgxpool.Pool) lead.Store { return &testStore{pool: pool} }
+
+func (s *testStore) InTx(ctx context.Context, fn func(lead.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error { return fn(lead.Repos{Lead: lead.New(tx)}) })
+}
+
+func (s *testStore) Repos() lead.Repos { return lead.Repos{Lead: lead.New(s.pool)} }
+
+func newTestRouter(t *testing.T) (*gin.Engine, *pgxpool.Pool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pool := dbtest.NewPool(t)
+	u := lead.NewUsecase(newTestStore(pool))
+
+	r := gin.New()
+	lead.NewHandler(u).RegisterRoutes(r, authn.Middleware(testClaimsParser{}))
+	return r, pool
+}
+
+func bearerToken(t *testing.T, userID, orgID, membershipID uuid.UUID, role tenant.Role) string {
+	t.Helper()
+	tok, err := accesstoken.Issue([]byte(testJWTSecret), 15*time.Minute, userID, orgID, membershipID, role)
+	if err != nil {
+		t.Fatalf("mint access token: %v", err)
+	}
+	return tok
+}
+
+func doJSON(r *gin.Engine, method, path, bearer string, body any, extraHeaders map[string]string) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(method, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func seedOrgAndOwner(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (org, user, membership uuid.UUID) {
+	t.Helper()
+	org = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, org); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	user = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Owner')`, user, user.String()+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	membership = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'owner')`, membership, org, user); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	return org, user, membership
+}
+
+func TestHandler_Create_ReturnsLeadNumberAnd201(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	w := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Budi Santoso"}, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Data struct {
+			LeadNumber int    `json:"lead_number"`
+			Name       string `json:"name"`
+			Status     string `json:"status"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.LeadNumber != 1 {
+		t.Errorf("expected lead_number 1, got %d", body.Data.LeadNumber)
+	}
+	if body.Data.Status != "new" {
+		t.Errorf("expected default status new, got %q", body.Data.Status)
+	}
+}
+
+// TestHandler_Create_ConcurrentSameIdempotencyKey_ExactlyOneNew is the
+// Definition of Done's explicit requirement: two concurrent POSTs with
+// the same Idempotency-Key must produce exactly one lead, not a race
+// between two application-level checks.
+// TestHandler_Create_InvalidAssignee_Returns400NotInternalError is a
+// regression test for a real bug found while writing THIS issue's own
+// tests: assigning a lead to a membership id that doesn't exist used to
+// surface as a bare 500 (the fk_leads_assignee violation was unhandled).
+func TestHandler_Create_InvalidAssignee_Returns400NotInternalError(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	bogusAssignee := uuid.Must(uuid.NewV7())
+	w := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]any{
+		"name": "Budi", "assigned_to_membership_id": bogusAssignee.String(),
+	}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for a nonexistent assignee, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Create_ConcurrentSameIdempotencyKey_ExactlyOneNew(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	const attempts = 10
+	key := "race-key-" + uuid.Must(uuid.NewV7()).String()
+
+	var wg sync.WaitGroup
+	codes := make([]int, attempts)
+	ids := make([]string, attempts)
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			w := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Race Lead"}, map[string]string{"Idempotency-Key": key})
+			codes[idx] = w.Code
+			var body struct {
+				Data struct {
+					ID string `json:"id"`
+				} `json:"data"`
+			}
+			_ = json.Unmarshal(w.Body.Bytes(), &body)
+			ids[idx] = body.Data.ID
+		}(i)
+	}
+	wg.Wait()
+
+	created, replayed := 0, 0
+	firstID := ids[0]
+	for i, code := range codes {
+		switch code {
+		case http.StatusCreated:
+			created++
+		case http.StatusOK:
+			replayed++
+		default:
+			t.Errorf("attempt %d: unexpected status %d", i, code)
+		}
+		if ids[i] != firstID {
+			t.Errorf("attempt %d: expected lead id %q, got %q — replay must return the SAME lead", i, firstID, ids[i])
+		}
+	}
+	if created != 1 {
+		t.Errorf("expected exactly 1 created (201), got %d", created)
+	}
+	if replayed != attempts-1 {
+		t.Errorf("expected %d replays (200), got %d", attempts-1, replayed)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM leads WHERE organization_id = $1 AND idempotency_key = $2`, org, key).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 row in the database for this idempotency key, got %d", count)
+	}
+}
+
+func TestHandler_Update_StaleVersion_Returns409WithCurrentState(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Budi"}, nil)
+	var createdBody struct {
+		Data struct {
+			ID      string `json:"id"`
+			Version int    `json:"version"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(created.Body.Bytes(), &createdBody)
+
+	w := doJSON(r, http.MethodPatch, "/v1/leads/"+createdBody.Data.ID, token,
+		map[string]any{"version": createdBody.Data.Version - 1, "name": "Stale Update"}, nil)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var conflictBody struct {
+		Error struct {
+			Code    string `json:"code"`
+			Current struct {
+				Name string `json:"name"`
+			} `json:"current"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &conflictBody); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if conflictBody.Error.Code != "version_conflict" {
+		t.Errorf("expected code version_conflict, got %q", conflictBody.Error.Code)
+	}
+	if conflictBody.Error.Current.Name != "Budi" {
+		t.Errorf("expected current.name to reflect the real current state 'Budi', got %q", conflictBody.Error.Current.Name)
+	}
+}
+
+func TestHandler_UpdateStatus_NewToWon_Returns422(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Budi"}, nil)
+	id, version := extractIDAndVersion(t, created)
+
+	w := doJSON(r, http.MethodPatch, "/v1/leads/"+id+"/status", token, map[string]any{"version": version, "status": "won"}, nil)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_UpdateStatus_LostWithoutReason_Rejected(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Budi"}, nil)
+	id, version := extractIDAndVersion(t, created)
+
+	w := doJSON(r, http.MethodPatch, "/v1/leads/"+id+"/status", token, map[string]any{"version": version, "status": "lost"}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for lost without a reason, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Create_PhoneNormalization(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	w := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Budi", "phone": "0812-3456-7890"}, nil)
+	var body struct {
+		Data struct {
+			Phone     string `json:"phone"`
+			PhoneE164 string `json:"phone_e164"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body.Data.PhoneE164 != "+6281234567890" {
+		t.Errorf("expected phone_e164 +6281234567890, got %q", body.Data.PhoneE164)
+	}
+
+	w2 := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Unparseable", "phone": "1234"}, nil)
+	var body2 struct {
+		Data struct {
+			PhoneE164 *string `json:"phone_e164"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(w2.Body.Bytes(), &body2)
+	if w2.Code != http.StatusCreated {
+		t.Fatalf("expected an unparseable phone to still be accepted (201), got %d: %s", w2.Code, w2.Body.String())
+	}
+	if body2.Data.PhoneE164 != nil {
+		t.Errorf("expected phone_e164 null for an unparseable number, got %v", *body2.Data.PhoneE164)
+	}
+}
+
+func TestHandler_Create_EmployeeForbidden(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, _, _ := seedOrgAndOwner(t, ctx, pool)
+	employeeUserID := uuid.Must(uuid.NewV7())
+	employeeMembershipID := uuid.Must(uuid.NewV7())
+	token := bearerToken(t, employeeUserID, org, employeeMembershipID, tenant.RoleEmployee)
+
+	w := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Budi"}, nil)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Get_Employee_OtherPersonsLead_Returns404(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	ownerToken := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	// The assignee must be a real membership row — leads.assigned_to_membership_id
+	// carries a composite FK (Rule #3); a random UUID would fail the INSERT.
+	otherEmployeeMembership := seedEmployeeMembership(t, ctx, pool, org)
+	created := doJSON(r, http.MethodPost, "/v1/leads", ownerToken, map[string]any{
+		"name": "Assigned To Someone Else", "assigned_to_membership_id": otherEmployeeMembership.String(),
+	}, nil)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("seed create failed: %d: %s", created.Code, created.Body.String())
+	}
+	id, _ := extractIDAndVersion(t, created)
+
+	me := uuid.Must(uuid.NewV7())
+	myToken := bearerToken(t, me, org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	w := doJSON(r, http.MethodGet, "/v1/leads/"+id, myToken, nil, nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func seedEmployeeMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID) uuid.UUID {
+	t.Helper()
+	userID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Employee')`, userID, userID.String()+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	membershipID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'employee')`, membershipID, org, userID); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	return membershipID
+}
+
+func TestHandler_List_FilterAssignedToNone(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Unassigned"}, nil)
+	doJSON(r, http.MethodPost, "/v1/leads", token, map[string]any{"name": "Assigned", "assigned_to_membership_id": membershipID.String()}, nil)
+
+	w := doJSON(r, http.MethodGet, "/v1/leads?assigned_to=none", token, nil, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Data []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+		Meta struct {
+			Total int `json:"total"`
+		} `json:"meta"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if body.Meta.Total != 1 || len(body.Data) != 1 || body.Data[0].Name != "Unassigned" {
+		t.Errorf("expected exactly 1 unassigned lead, got %+v", body)
+	}
+}
+
+func extractIDAndVersion(t *testing.T, w *httptest.ResponseRecorder) (string, int) {
+	t.Helper()
+	var body struct {
+		Data struct {
+			ID      string `json:"id"`
+			Version int    `json:"version"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Data.ID, body.Data.Version
+}

--- a/crm_be/internal/lead/port.go
+++ b/crm_be/internal/lead/port.go
@@ -1,0 +1,45 @@
+package lead
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Repository is lead's own table interface — postgresRepository
+// (repository_postgres.go) satisfies it, but Usecase depends only on
+// this interface (ADR-011), which is what makes usecase_unit_test.go's
+// fake possible without Docker. Through #19 this was a concrete
+// exported struct (Repository) with no interface — the same migration
+// internal/membership went through in #11, the moment a real usecase
+// exists to declare the interface it needs.
+type Repository interface {
+	Create(ctx context.Context, t tenant.Context, in CreateInput) (*Lead, error)
+	FindByID(ctx context.Context, t tenant.Context, id uuid.UUID) (*Lead, error)
+	FindByIdempotencyKey(ctx context.Context, t tenant.Context, key string) (*Lead, error)
+	FindAllByOrg(ctx context.Context, t tenant.Context, filter ListFilter) ([]*Lead, int, error)
+	Update(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, in UpdateInput) (*Lead, error)
+	UpdateStatus(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, status string, lostReason *string) (*Lead, error)
+	Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error
+}
+
+// Repos bundles what a single Usecase call needs — one field today.
+// #21 adds an Activity field when lead events need cross-table
+// atomicity with activity rows; #20 writes no activities at all (that's
+// explicitly #21's job), so there's nothing to add yet (Rule #27/#28).
+type Repos struct {
+	Lead Repository
+}
+
+// Store is the Unit of Work Usecase depends on — same shape as every
+// other domain's. Required even though most of Repository's methods are
+// single statements: Create internally needs a transaction (see its doc
+// comment in repository_postgres.go and the proof in #19's
+// repository_test.go), so Usecase.Create must be able to call
+// store.InTx.
+type Store interface {
+	InTx(ctx context.Context, fn func(Repos) error) error
+	Repos() Repos
+}

--- a/crm_be/internal/lead/repository_postgres.go
+++ b/crm_be/internal/lead/repository_postgres.go
@@ -4,27 +4,32 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
 )
 
-// Repository is a plain concrete type — no interface — mirroring
-// internal/membership's shape before #11 gave it a real usecase.
-// Interface-at-consumer (ADR-011) only makes sense once a consumer
-// exists to declare it; #20 adds port.go + usecase.go and renames this
-// to postgresRepository at that point, same migration membership already
-// went through.
-type Repository struct {
+const idempotencyUniqueConstraint = "uq_leads_org_idempotency"
+const assigneeFKConstraint = "fk_leads_assignee"
+
+// postgresRepository is the concrete implementation behind the
+// Repository interface (port.go). Unexported since #20 — callers depend
+// on the interface, not this type, so Usecase can be tested with a fake
+// (ADR-011). Through #19 this was the exported concrete type
+// (Repository); cross-package consumers never existed yet (there were
+// none), so this rename is invisible outside the package.
+type postgresRepository struct {
 	q db.Querier
 }
 
-func New(q db.Querier) *Repository {
-	return &Repository{q: q}
+func New(q db.Querier) Repository {
+	return &postgresRepository{q: q}
 }
 
 // Create allocates the next lead_number for t.OrganizationID and inserts
@@ -41,7 +46,7 @@ func New(q db.Querier) *Repository {
 // requires the transactional form. See
 // TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber in
 // repository_test.go for the proof of that specific guarantee.
-func (r *Repository) Create(ctx context.Context, t tenant.Context, in CreateInput) (*Lead, error) {
+func (r *postgresRepository) Create(ctx context.Context, t tenant.Context, in CreateInput) (*Lead, error) {
 	const allocQ = `
 		UPDATE organizations SET next_lead_number = next_lead_number + 1
 		WHERE id = $1
@@ -67,9 +72,42 @@ func (r *Repository) Create(ctx context.Context, t tenant.Context, in CreateInpu
 	)
 	created, err := scanLead(row)
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			if pgErr.Code == "23505" && pgErr.ConstraintName == idempotencyUniqueConstraint {
+				return nil, ErrIdempotencyKeyExists
+			}
+			// 23503 = FK violation. Found via a test that (by mistake)
+			// assigned a lead to a membership id that didn't exist —
+			// which surfaced as a bare 500 before this check existed.
+			// assigned_to_membership_id is the only nullable FK a
+			// caller-supplied value can violate here.
+			if pgErr.Code == "23503" && pgErr.ConstraintName == assigneeFKConstraint {
+				return nil, ErrAssigneeNotFound
+			}
+		}
 		return nil, fmt.Errorf("lead: create: %w", err)
 	}
 	return created, nil
+}
+
+// FindByIdempotencyKey is how the usecase resolves ErrIdempotencyKeyExists
+// into the existing lead to return instead of erroring.
+func (r *postgresRepository) FindByIdempotencyKey(ctx context.Context, t tenant.Context, key string) (*Lead, error) {
+	const q = `
+		SELECT ` + leadColumns + `
+		FROM leads
+		WHERE organization_id = $1 AND idempotency_key = $2 AND deleted_at IS NULL`
+
+	row := r.q.QueryRow(ctx, q, t.OrganizationID, key)
+	found, err := scanLead(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, httpx.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lead: find by idempotency key: %w", err)
+	}
+	return found, nil
 }
 
 // FindByID is tenant-scoped (Rule #6: cross-org → httpx.ErrNotFound) and,
@@ -77,7 +115,7 @@ func (r *Repository) Create(ctx context.Context, t tenant.Context, in CreateInpu
 // t.MembershipID (TD §9 — the PRD's core requirement for this issue,
 // enforced here once rather than in every future usecase method that
 // touches a single lead).
-func (r *Repository) FindByID(ctx context.Context, t tenant.Context, id uuid.UUID) (*Lead, error) {
+func (r *postgresRepository) FindByID(ctx context.Context, t tenant.Context, id uuid.UUID) (*Lead, error) {
 	const q = `
 		SELECT ` + leadColumns + `
 		FROM leads
@@ -107,7 +145,7 @@ func (r *Repository) FindByID(ctx context.Context, t tenant.Context, id uuid.UUI
 // row not visible in this scope → httpx.ErrNotFound; row visible but
 // version differs → (current state, ErrVersionConflict), so the future
 // usecase can build TD §4's 409 body without a second round trip.
-func (r *Repository) Update(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, in UpdateInput) (*Lead, error) {
+func (r *postgresRepository) Update(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, in UpdateInput) (*Lead, error) {
 	const q = `
 		UPDATE leads
 		SET version = version + 1,
@@ -137,6 +175,129 @@ func (r *Repository) Update(ctx context.Context, t tenant.Context, id uuid.UUID,
 		return nil, fmt.Errorf("lead: update: %w", err)
 	}
 	return updated, nil
+}
+
+// FindAllByOrg builds its WHERE clause by hand (no query-builder
+// library — sqlc/pgx, not an ORM) from whichever filter fields are set,
+// sharing one args slice between the count query and the paginated
+// select so the two never drift apart. Employee scoping is applied
+// UNCONDITIONALLY when t.Role is employee, regardless of filter.AssignedTo
+// — an employee's own filter can only narrow their view further, never
+// widen past their own leads (same rule FindByID/Update already enforce).
+func (r *postgresRepository) FindAllByOrg(ctx context.Context, t tenant.Context, filter ListFilter) ([]*Lead, int, error) {
+	conditions := []string{"organization_id = $1", "deleted_at IS NULL"}
+	args := []any{t.OrganizationID}
+
+	arg := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	if isEmployee(t) {
+		conditions = append(conditions, "assigned_to_membership_id = "+arg(membershipIDOrNil(t)))
+	} else if filter.AssignedToNone {
+		conditions = append(conditions, "assigned_to_membership_id IS NULL")
+	} else if filter.AssignedTo != nil {
+		conditions = append(conditions, "assigned_to_membership_id = "+arg(*filter.AssignedTo))
+	}
+
+	if len(filter.Status) > 0 {
+		conditions = append(conditions, "status = ANY("+arg(filter.Status)+")")
+	}
+	if len(filter.Source) > 0 {
+		conditions = append(conditions, "source = ANY("+arg(filter.Source)+")")
+	}
+	if filter.Query != "" {
+		p := arg("%" + filter.Query + "%")
+		conditions = append(conditions, fmt.Sprintf("(name ILIKE %s OR email ILIKE %s OR phone_e164 ILIKE %s)", p, p, p))
+	}
+	if filter.CreatedFrom != nil {
+		conditions = append(conditions, "created_at >= "+arg(*filter.CreatedFrom))
+	}
+	if filter.CreatedTo != nil {
+		conditions = append(conditions, "created_at <= "+arg(*filter.CreatedTo))
+	}
+
+	where := strings.Join(conditions, " AND ")
+
+	var total int
+	countQ := "SELECT count(*) FROM leads WHERE " + where
+	if err := r.q.QueryRow(ctx, countQ, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("lead: count: %w", err)
+	}
+
+	perPage := filter.PerPage
+	offset := (filter.Page - 1) * perPage
+	listQ := "SELECT " + leadColumns + " FROM leads WHERE " + where +
+		" ORDER BY created_at DESC LIMIT " + arg(perPage) + " OFFSET " + arg(offset)
+
+	rows, err := r.q.Query(ctx, listQ, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("lead: find all by org: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Lead
+	for rows.Next() {
+		l, err := scanLead(rows)
+		if err != nil {
+			return nil, 0, fmt.Errorf("lead: scan: %w", err)
+		}
+		out = append(out, l)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("lead: find all by org: %w", err)
+	}
+	return out, total, nil
+}
+
+// UpdateStatus mirrors Update's version+scope-gated shape exactly, but
+// only ever touches status/lost_reason/version — the transition
+// validity check itself lives in Usecase.UpdateStatus (TD §5 is
+// business logic, not a repository concern).
+func (r *postgresRepository) UpdateStatus(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, status string, lostReason *string) (*Lead, error) {
+	const q = `
+		UPDATE leads
+		SET version = version + 1, status = $5, lost_reason = $6
+		WHERE id = $1 AND organization_id = $2 AND version = $3 AND deleted_at IS NULL
+		  AND (NOT $4 OR assigned_to_membership_id = $7)
+		RETURNING ` + leadColumns
+
+	row := r.q.QueryRow(ctx, q,
+		id, t.OrganizationID, expectedVersion, isEmployee(t),
+		status, lostReason, membershipIDOrNil(t),
+	)
+	updated, err := scanLead(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		current, findErr := r.FindByID(ctx, t, id)
+		if findErr != nil {
+			return nil, findErr
+		}
+		return current, ErrVersionConflict
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lead: update status: %w", err)
+	}
+	return updated, nil
+}
+
+// Delete soft-deletes id within t's scope (Rule #18). No version check —
+// TD doesn't gate delete on optimistic locking the way it does field/status
+// updates; deleting an already-stale-looking row is still a safe delete.
+func (r *postgresRepository) Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error {
+	const q = `
+		UPDATE leads SET deleted_at = now()
+		WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
+		  AND (NOT $3 OR assigned_to_membership_id = $4)`
+
+	tag, err := r.q.Exec(ctx, q, id, t.OrganizationID, isEmployee(t), membershipIDOrNil(t))
+	if err != nil {
+		return fmt.Errorf("lead: delete: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return httpx.ErrNotFound
+	}
+	return nil
 }
 
 func isEmployee(t tenant.Context) bool {

--- a/crm_be/internal/lead/usecase.go
+++ b/crm_be/internal/lead/usecase.go
@@ -1,0 +1,299 @@
+package lead
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authz"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/phone"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const (
+	defaultPerPage = 25
+	maxPerPage     = 100
+)
+
+var validSources = map[string]bool{"manual": true, "api": true, "form": true, "webhook": true}
+
+// Usecase depends only on Store (port.go), never on *pgxpool.Pool or
+// pgx.Tx directly (ADR-011). No mailer, no logger — leads don't send
+// email.
+type Usecase struct {
+	store Store
+}
+
+func NewUsecase(store Store) *Usecase {
+	return &Usecase{store: store}
+}
+
+// Create validates and normalizes in, then persists it. isNew is false
+// when in.IdempotencyKey collided with an existing lead — the caller
+// gets that lead back instead of an error, and the handler responds 200
+// instead of 201 (TD §7: idempotent replay returns the ORIGINAL
+// response, never a second lead and never an error).
+func (u *Usecase) Create(ctx context.Context, t tenant.Context, in CreateLeadInput) (result *Lead, isNew bool, err error) {
+	if err := authz.Require(t, authz.ActionLeadCreate); err != nil {
+		return nil, false, err
+	}
+
+	if in.Name == "" {
+		return nil, false, httpx.NewValidationError(httpx.ErrorDetail{Field: "name", Code: "required"})
+	}
+	source := in.Source
+	if source == "" {
+		source = "manual"
+	} else if !validSources[source] {
+		return nil, false, httpx.NewValidationError(httpx.ErrorDetail{Field: "source", Code: "invalid_value"})
+	}
+
+	email := normalizeEmail(in.Email)
+	phoneE164 := normalizePhone(in.Phone)
+
+	repoIn := CreateInput{
+		Name:                   in.Name,
+		Email:                  email,
+		Phone:                  in.Phone,
+		PhoneE164:              phoneE164,
+		Company:                in.Company,
+		Notes:                  in.Notes,
+		Source:                 source,
+		AssignedToMembershipID: in.AssignedToMembershipID,
+		CreatedByMembershipID:  t.MembershipID,
+		IdempotencyKey:         in.IdempotencyKey,
+	}
+
+	var created *Lead
+	txErr := u.store.InTx(ctx, func(r Repos) error {
+		c, err := r.Lead.Create(ctx, t, repoIn)
+		if err != nil {
+			return err
+		}
+		created = c
+		return nil
+	})
+	if txErr != nil {
+		if errors.Is(txErr, ErrIdempotencyKeyExists) {
+			existing, err := u.store.Repos().Lead.FindByIdempotencyKey(ctx, t, *in.IdempotencyKey)
+			if err != nil {
+				return nil, false, fmt.Errorf("lead: create: resolve idempotent replay: %w", err)
+			}
+			return existing, false, nil
+		}
+		if errors.Is(txErr, ErrAssigneeNotFound) {
+			return nil, false, httpx.NewValidationError(httpx.ErrorDetail{Field: "assigned_to_membership_id", Code: "not_found"})
+		}
+		return nil, false, fmt.Errorf("lead: create: %w", txErr)
+	}
+	return created, true, nil
+}
+
+func (u *Usecase) Get(ctx context.Context, t tenant.Context, id uuid.UUID) (*Lead, error) {
+	if err := authz.Require(t, authz.ActionLeadRead); err != nil {
+		return nil, err
+	}
+	found, err := u.store.Repos().Lead.FindByID(ctx, t, id)
+	if err != nil {
+		return nil, err
+	}
+	return found, nil
+}
+
+// ListInput is List's argument — raw query-param values; List clamps
+// Page/PerPage before delegating to the repository.
+type ListInput struct {
+	Status         []string
+	Source         []string
+	AssignedTo     *uuid.UUID
+	AssignedToNone bool
+	Query          string
+	CreatedFrom    *time.Time
+	CreatedTo      *time.Time
+	Page           int
+	PerPage        int
+}
+
+func (u *Usecase) List(ctx context.Context, t tenant.Context, in ListInput) ([]*Lead, httpx.Meta, error) {
+	if err := authz.Require(t, authz.ActionLeadRead); err != nil {
+		return nil, httpx.Meta{}, err
+	}
+
+	page := in.Page
+	if page < 1 {
+		page = 1
+	}
+	perPage := in.PerPage
+	if perPage <= 0 {
+		perPage = defaultPerPage
+	} else if perPage > maxPerPage {
+		perPage = maxPerPage
+	}
+
+	filter := ListFilter{
+		Status:         in.Status,
+		Source:         in.Source,
+		AssignedTo:     in.AssignedTo,
+		AssignedToNone: in.AssignedToNone,
+		Query:          in.Query,
+		CreatedFrom:    in.CreatedFrom,
+		CreatedTo:      in.CreatedTo,
+		Page:           page,
+		PerPage:        perPage,
+	}
+
+	leads, total, err := u.store.Repos().Lead.FindAllByOrg(ctx, t, filter)
+	if err != nil {
+		return nil, httpx.Meta{}, fmt.Errorf("lead: list: %w", err)
+	}
+	return leads, httpx.Meta{Page: page, PerPage: perPage, Total: total}, nil
+}
+
+func (u *Usecase) Update(ctx context.Context, t tenant.Context, id uuid.UUID, in UpdateLeadInput) (*Lead, error) {
+	if err := authz.Require(t, authz.ActionLeadUpdate); err != nil {
+		return nil, err
+	}
+
+	repoIn := UpdateInput{
+		Name:    in.Name,
+		Email:   normalizeEmail(in.Email),
+		Phone:   in.Phone,
+		Company: in.Company,
+		Notes:   in.Notes,
+	}
+	// Phone normalization only replaces PhoneE164 when the new phone
+	// parses — UpdateInput has no PhoneE164 field (see its doc comment
+	// in entity.go: this minimal Update can't clear a field to NULL,
+	// and phone_e164 has the same limitation for now).
+
+	updated, err := u.store.Repos().Lead.Update(ctx, t, id, in.Version, repoIn)
+	if errors.Is(err, ErrVersionConflict) {
+		return nil, &VersionConflictError{Current: updated}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+// UpdateStatus validates the transition (TD §5) before touching the
+// database — loading the current lead first is what makes that possible
+// (transition validity depends on the FROM status, which the client's
+// requested Version alone doesn't tell us).
+func (u *Usecase) UpdateStatus(ctx context.Context, t tenant.Context, id uuid.UUID, in UpdateStatusInput) (*Lead, error) {
+	if err := authz.Require(t, authz.ActionLeadUpdate); err != nil {
+		return nil, err
+	}
+
+	current, err := u.store.Repos().Lead.FindByID(ctx, t, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if !validateStatusTransition(current.Status, in.Status) {
+		return nil, invalidStatusTransitionError()
+	}
+
+	var lostReason *string
+	if in.Status == StatusLost {
+		if in.LostReason == nil || *in.LostReason == "" {
+			return nil, httpx.NewValidationError(httpx.ErrorDetail{Field: "lost_reason", Code: "required"})
+		}
+		lostReason = in.LostReason
+	}
+	// Leaving lost (or any non-lost destination) always clears
+	// lost_reason, regardless of what the client sent — TD §5.
+
+	updated, err := u.store.Repos().Lead.UpdateStatus(ctx, t, id, in.Version, in.Status, lostReason)
+	if errors.Is(err, ErrVersionConflict) {
+		return nil, &VersionConflictError{Current: updated}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func (u *Usecase) Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error {
+	if err := authz.Require(t, authz.ActionLeadDelete); err != nil {
+		return err
+	}
+	return u.store.Repos().Lead.Delete(ctx, t, id)
+}
+
+// validateStatusTransition implements TD §5, with one documented
+// approximation: leaving "lost" allows moving to ANY main-path status,
+// not specifically the one it left from — that requires history only
+// activities (#21) provides, and leads itself never remembers what its
+// status was before the last transition. See notes.md's "## #20" for
+// the full reasoning; none of this issue's acceptance criteria exercise
+// that specific case.
+func validateStatusTransition(from, to string) bool {
+	if from == StatusUnqualified || from == StatusSpam {
+		return false // final — no outgoing transition at all
+	}
+	if to == from {
+		return to == StatusLost // only allowed same-status case: updating lost_reason
+	}
+	if to == StatusUnqualified || to == StatusSpam || to == StatusLost {
+		return true // reachable from any non-final status
+	}
+
+	toIdx := mainPathIndex(to)
+	if toIdx == -1 {
+		return false // not a real status at all
+	}
+	if from == StatusLost {
+		return true // leaving lost — approximation, see doc comment above
+	}
+	fromIdx := mainPathIndex(from)
+	if fromIdx == -1 {
+		return false
+	}
+	diff := toIdx - fromIdx
+	return diff == 1 || diff == -1
+}
+
+func mainPathIndex(status string) int {
+	for i, s := range mainPath {
+		if s == status {
+			return i
+		}
+	}
+	return -1
+}
+
+func normalizeEmail(email *string) *string {
+	if email == nil {
+		return nil
+	}
+	lower := strings.ToLower(strings.TrimSpace(*email))
+	return &lower
+}
+
+// normalizePhone returns the E.164 form when phone parses, nil
+// otherwise — never an error (freeze bagian 2.3, TD §6).
+func normalizePhone(raw *string) *string {
+	if raw == nil {
+		return nil
+	}
+	e164, ok := phone.ToE164(*raw)
+	if !ok {
+		return nil
+	}
+	return &e164
+}
+
+func invalidStatusTransitionError() error {
+	return &httpx.DomainError{
+		Status:  http.StatusUnprocessableEntity,
+		Code:    "invalid_status_transition",
+		Message: "Transisi status tidak diizinkan.",
+	}
+}

--- a/crm_be/internal/lead/usecase_unit_test.go
+++ b/crm_be/internal/lead/usecase_unit_test.go
@@ -1,0 +1,427 @@
+package lead_test
+
+// TestUnit_* tests prove Usecase is decoupled from PostgreSQL (ADR-011) —
+// fake Store, no Docker. Run in isolation with:
+//
+//	go test ./internal/lead/... -run TestUnit
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// --- fakes ---
+
+type fakeLeadRepo struct {
+	byID       map[uuid.UUID]*lead.Lead
+	nextNumber int
+}
+
+func newFakeLeadRepo() *fakeLeadRepo {
+	return &fakeLeadRepo{byID: map[uuid.UUID]*lead.Lead{}, nextNumber: 1}
+}
+
+func (f *fakeLeadRepo) Create(_ context.Context, t tenant.Context, in lead.CreateInput) (*lead.Lead, error) {
+	if in.IdempotencyKey != nil {
+		for _, l := range f.byID {
+			if l.IdempotencyKey != nil && *l.IdempotencyKey == *in.IdempotencyKey && l.OrganizationID == t.OrganizationID {
+				return nil, lead.ErrIdempotencyKeyExists
+			}
+		}
+	}
+	l := &lead.Lead{
+		ID: uuid.Must(uuid.NewV7()), OrganizationID: t.OrganizationID, LeadNumber: f.nextNumber,
+		Name: in.Name, Email: in.Email, Phone: in.Phone, PhoneE164: in.PhoneE164, Company: in.Company, Notes: in.Notes,
+		Status: "new", Source: in.Source, AssignedToMembershipID: in.AssignedToMembershipID,
+		IdempotencyKey: in.IdempotencyKey, Version: 1, CreatedByMembershipID: in.CreatedByMembershipID,
+	}
+	f.nextNumber++
+	f.byID[l.ID] = l
+	return l, nil
+}
+
+func (f *fakeLeadRepo) FindByID(_ context.Context, t tenant.Context, id uuid.UUID) (*lead.Lead, error) {
+	l, ok := f.byID[id]
+	if !ok || l.OrganizationID != t.OrganizationID || l.DeletedAt != nil {
+		return nil, httpx.ErrNotFound
+	}
+	if t.Role == tenant.RoleEmployee && (l.AssignedToMembershipID == nil || t.MembershipID == nil || *l.AssignedToMembershipID != *t.MembershipID) {
+		return nil, httpx.ErrNotFound
+	}
+	return l, nil
+}
+
+func (f *fakeLeadRepo) FindByIdempotencyKey(_ context.Context, t tenant.Context, key string) (*lead.Lead, error) {
+	for _, l := range f.byID {
+		if l.OrganizationID == t.OrganizationID && l.IdempotencyKey != nil && *l.IdempotencyKey == key {
+			return l, nil
+		}
+	}
+	return nil, httpx.ErrNotFound
+}
+
+func (f *fakeLeadRepo) FindAllByOrg(_ context.Context, t tenant.Context, _ lead.ListFilter) ([]*lead.Lead, int, error) {
+	var out []*lead.Lead
+	for _, l := range f.byID {
+		if l.OrganizationID == t.OrganizationID && l.DeletedAt == nil {
+			out = append(out, l)
+		}
+	}
+	return out, len(out), nil
+}
+
+func (f *fakeLeadRepo) Update(_ context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, in lead.UpdateInput) (*lead.Lead, error) {
+	l, err := f.FindByID(context.Background(), t, id)
+	if err != nil {
+		return nil, err
+	}
+	if l.Version != expectedVersion {
+		return l, lead.ErrVersionConflict
+	}
+	if in.Name != nil {
+		l.Name = *in.Name
+	}
+	if in.Email != nil {
+		l.Email = in.Email
+	}
+	l.Version++
+	return l, nil
+}
+
+func (f *fakeLeadRepo) UpdateStatus(_ context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, status string, lostReason *string) (*lead.Lead, error) {
+	l, err := f.FindByID(context.Background(), t, id)
+	if err != nil {
+		return nil, err
+	}
+	if l.Version != expectedVersion {
+		return l, lead.ErrVersionConflict
+	}
+	l.Status = status
+	l.LostReason = lostReason
+	l.Version++
+	return l, nil
+}
+
+func (f *fakeLeadRepo) Delete(_ context.Context, t tenant.Context, id uuid.UUID) error {
+	l, err := f.FindByID(context.Background(), t, id)
+	if err != nil {
+		return err
+	}
+	now := l.CreatedAt
+	l.DeletedAt = &now
+	return nil
+}
+
+type fakeStore struct{ repos lead.Repos }
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{repos: lead.Repos{Lead: newFakeLeadRepo()}}
+}
+
+func (s *fakeStore) InTx(_ context.Context, fn func(lead.Repos) error) error { return fn(s.repos) }
+func (s *fakeStore) Repos() lead.Repos                                       { return s.repos }
+
+func actorContext(orgID, membershipID uuid.UUID, role tenant.Role) tenant.Context {
+	return tenant.Context{OrganizationID: orgID, PrincipalType: tenant.PrincipalUser, MembershipID: &membershipID, Role: role}
+}
+
+func ownerActor() (tenant.Context, uuid.UUID) {
+	org := uuid.Must(uuid.NewV7())
+	return actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleOwner), org
+}
+
+// --- tests ---
+
+func TestUnit_Create_EmployeeForbidden(t *testing.T) {
+	u := lead.NewUsecase(newFakeStore())
+	org := uuid.Must(uuid.NewV7())
+
+	_, _, err := u.Create(context.Background(), actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee), lead.CreateLeadInput{Name: "Budi"})
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "forbidden" {
+		t.Fatalf("expected forbidden, got: %v", err)
+	}
+}
+
+func TestUnit_Create_NameRequired(t *testing.T) {
+	u := lead.NewUsecase(newFakeStore())
+	actor, _ := ownerActor()
+
+	_, _, err := u.Create(context.Background(), actor, lead.CreateLeadInput{})
+
+	var verr *httpx.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected ValidationError, got: %v", err)
+	}
+}
+
+func TestUnit_Create_DefaultsSourceToManual(t *testing.T) {
+	u := lead.NewUsecase(newFakeStore())
+	actor, _ := ownerActor()
+
+	created, isNew, err := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !isNew {
+		t.Error("expected isNew=true for a fresh create")
+	}
+	if created.Source != "manual" {
+		t.Errorf("expected default source 'manual', got %q", created.Source)
+	}
+}
+
+func TestUnit_Create_InvalidSource_Rejected(t *testing.T) {
+	u := lead.NewUsecase(newFakeStore())
+	actor, _ := ownerActor()
+
+	_, _, err := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi", Source: "carrier-pigeon"})
+
+	var verr *httpx.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected ValidationError for an invalid source, got: %v", err)
+	}
+}
+
+func TestUnit_Create_NormalizesEmailAndPhone(t *testing.T) {
+	u := lead.NewUsecase(newFakeStore())
+	actor, _ := ownerActor()
+
+	email := "Budi@Example.COM"
+	phoneRaw := "0812-3456-7890"
+	created, _, err := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi", Email: &email, Phone: &phoneRaw})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.Email == nil || *created.Email != "budi@example.com" {
+		t.Errorf("expected lowercased email, got %v", created.Email)
+	}
+	if created.PhoneE164 == nil || *created.PhoneE164 != "+6281234567890" {
+		t.Errorf("expected normalized phone_e164, got %v", created.PhoneE164)
+	}
+	if created.Phone == nil || *created.Phone != phoneRaw {
+		t.Errorf("expected raw phone preserved, got %v", created.Phone)
+	}
+}
+
+func TestUnit_Create_UnparseablePhone_StillAccepted(t *testing.T) {
+	u := lead.NewUsecase(newFakeStore())
+	actor, _ := ownerActor()
+
+	badPhone := "1234"
+	created, _, err := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi", Phone: &badPhone})
+	if err != nil {
+		t.Fatalf("expected an unparseable phone to still be accepted, got: %v", err)
+	}
+	if created.PhoneE164 != nil {
+		t.Errorf("expected nil phone_e164 for an unparseable number, got %v", *created.PhoneE164)
+	}
+	if created.Phone == nil || *created.Phone != badPhone {
+		t.Error("expected the raw phone value to be preserved even when unparseable")
+	}
+}
+
+func TestUnit_Create_IdempotentReplay_ReturnsSameLeadNotNew(t *testing.T) {
+	u := lead.NewUsecase(newFakeStore())
+	actor, _ := ownerActor()
+
+	key := "client-generated-key"
+	first, isNew1, err := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi", IdempotencyKey: &key})
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if !isNew1 {
+		t.Fatal("expected the first create to be new")
+	}
+
+	second, isNew2, err := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Different Name Ignored", IdempotencyKey: &key})
+	if err != nil {
+		t.Fatalf("replay create: %v", err)
+	}
+	if isNew2 {
+		t.Error("expected the replay to report isNew=false")
+	}
+	if second.ID != first.ID {
+		t.Errorf("expected the replay to return the SAME lead, got a different id")
+	}
+}
+
+func TestUnit_Get_Employee_OtherPersonsLead_ReturnsNotFound(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, org := ownerActor()
+
+	otherEmployee := uuid.Must(uuid.NewV7())
+	assignedIn := lead.CreateLeadInput{Name: "Assigned Elsewhere", AssignedToMembershipID: &otherEmployee}
+	created, _, err := u.Create(context.Background(), actor, assignedIn)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	me := uuid.Must(uuid.NewV7())
+	_, err = u.Get(context.Background(), actorContext(org, me, tenant.RoleEmployee), created.ID)
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound, got: %v", err)
+	}
+}
+
+func TestUnit_Update_StaleVersion_ReturnsVersionConflict(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+
+	created, _, err := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	newName := "Updated"
+	_, err = u.Update(context.Background(), actor, created.ID, lead.UpdateLeadInput{Version: created.Version - 1, Name: &newName})
+
+	var conflict *lead.VersionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected *lead.VersionConflictError, got: %v", err)
+	}
+	if conflict.Current == nil || conflict.Current.ID != created.ID {
+		t.Error("expected the conflict to carry the current lead")
+	}
+}
+
+func TestUnit_Delete_ManagerForbidden(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, org := ownerActor()
+
+	created, _, err := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	managerCtx := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleManager)
+	err = u.Delete(context.Background(), managerCtx, created.ID)
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "forbidden" {
+		t.Fatalf("expected forbidden for manager delete, got: %v", err)
+	}
+}
+
+// --- status transition tests (TD §5) ---
+
+func TestUnit_UpdateStatus_NewToWon_Rejected(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+
+	_, err := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: created.Version, Status: "won"})
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "invalid_status_transition" {
+		t.Fatalf("expected invalid_status_transition, got: %v", err)
+	}
+}
+
+func TestUnit_UpdateStatus_NewToContacted_Accepted(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+
+	updated, err := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: created.Version, Status: "contacted"})
+	if err != nil {
+		t.Fatalf("expected new->contacted to succeed, got: %v", err)
+	}
+	if updated.Status != "contacted" {
+		t.Errorf("expected status contacted, got %q", updated.Status)
+	}
+}
+
+func TestUnit_UpdateStatus_QualifiedToContacted_Accepted(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+	step1, _ := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: created.Version, Status: "contacted"})
+	step2, _ := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: step1.Version, Status: "qualified"})
+
+	updated, err := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: step2.Version, Status: "contacted"})
+	if err != nil {
+		t.Fatalf("expected qualified->contacted (one step back, B7) to succeed, got: %v", err)
+	}
+	if updated.Status != "contacted" {
+		t.Errorf("expected status contacted, got %q", updated.Status)
+	}
+}
+
+func TestUnit_UpdateStatus_Lost_RequiresReason(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+
+	_, err := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: created.Version, Status: "lost"})
+
+	var verr *httpx.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected ValidationError for lost without a reason, got: %v", err)
+	}
+}
+
+func TestUnit_UpdateStatus_LostWithReason_Accepted(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+
+	reason := "price"
+	updated, err := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: created.Version, Status: "lost", LostReason: &reason})
+	if err != nil {
+		t.Fatalf("expected lost with a reason to succeed, got: %v", err)
+	}
+	if updated.LostReason == nil || *updated.LostReason != "price" {
+		t.Errorf("expected lost_reason 'price', got %v", updated.LostReason)
+	}
+}
+
+func TestUnit_UpdateStatus_LeavingLost_ClearsReason(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+	reason := "timing"
+	lost, _ := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: created.Version, Status: "lost", LostReason: &reason})
+
+	// Approximation documented in usecase.go: leaving lost allows any
+	// main-path status, not specifically the one it left from.
+	revived, err := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: lost.Version, Status: "qualified"})
+	if err != nil {
+		t.Fatalf("expected leaving lost to succeed, got: %v", err)
+	}
+	if revived.LostReason != nil {
+		t.Errorf("expected lost_reason to be cleared, got %v", *revived.LostReason)
+	}
+}
+
+func TestUnit_UpdateStatus_UnqualifiedIsFinal(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+	unqualified, _ := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: created.Version, Status: "unqualified"})
+
+	_, err := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: unqualified.Version, Status: "new"})
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "invalid_status_transition" {
+		t.Fatalf("expected unqualified to be final (invalid_status_transition), got: %v", err)
+	}
+}

--- a/crm_be/internal/shared/authz/authz.go
+++ b/crm_be/internal/shared/authz/authz.go
@@ -33,6 +33,17 @@ const (
 	ActionInvitationCreate     Action = "invitation.create"
 	ActionInvitationList       Action = "invitation.list"
 	ActionInvitationRevoke     Action = "invitation.revoke"
+
+	// Lead actions cover only what issue #20 ships — list/read share one
+	// action (identical permissions at every role); lead.assign and
+	// lead.convert land with #22/#23. Employee's read/update access is
+	// further restricted to leads assigned to them, enforced in
+	// internal/lead's repository (Rule: authz answers "this class of
+	// action at all", not "which rows").
+	ActionLeadCreate Action = "lead.create"
+	ActionLeadRead   Action = "lead.read"
+	ActionLeadUpdate Action = "lead.update"
+	ActionLeadDelete Action = "lead.delete"
 )
 
 // permissions mirrors docs/architecture/authorization.md's matrix
@@ -46,6 +57,10 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionInvitationCreate:     true,
 		ActionInvitationList:       true,
 		ActionInvitationRevoke:     true,
+		ActionLeadCreate:           true,
+		ActionLeadRead:             true,
+		ActionLeadUpdate:           true,
+		ActionLeadDelete:           true,
 	},
 	tenant.RoleAdmin: {
 		ActionMembershipList:       true,
@@ -54,11 +69,25 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionInvitationCreate:     true,
 		ActionInvitationList:       true,
 		ActionInvitationRevoke:     true,
+		ActionLeadCreate:           true,
+		ActionLeadRead:             true,
+		ActionLeadUpdate:           true,
+		ActionLeadDelete:           true,
 	},
 	tenant.RoleManager: {
 		ActionMembershipList: true,
+		ActionLeadCreate:     true,
+		ActionLeadRead:       true,
+		ActionLeadUpdate:     true,
+		// ActionLeadDelete deliberately absent — matrix gives delete to
+		// Owner/Admin only.
 	},
-	tenant.RoleEmployee: {},
+	tenant.RoleEmployee: {
+		// Read/update granted here; the repository further restricts
+		// both to leads assigned to this employee.
+		ActionLeadRead:   true,
+		ActionLeadUpdate: true,
+	},
 }
 
 // Require reports whether t.Role may perform action, returning a

--- a/crm_be/internal/shared/authz/authz_test.go
+++ b/crm_be/internal/shared/authz/authz_test.go
@@ -21,6 +21,10 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleOwner, authz.ActionInvitationCreate, true},
 		{tenant.RoleOwner, authz.ActionInvitationList, true},
 		{tenant.RoleOwner, authz.ActionInvitationRevoke, true},
+		{tenant.RoleOwner, authz.ActionLeadCreate, true},
+		{tenant.RoleOwner, authz.ActionLeadRead, true},
+		{tenant.RoleOwner, authz.ActionLeadUpdate, true},
+		{tenant.RoleOwner, authz.ActionLeadDelete, true},
 
 		{tenant.RoleAdmin, authz.ActionMembershipList, true},
 		{tenant.RoleAdmin, authz.ActionMembershipUpdateRole, true},
@@ -28,6 +32,10 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleAdmin, authz.ActionInvitationCreate, true},
 		{tenant.RoleAdmin, authz.ActionInvitationList, true},
 		{tenant.RoleAdmin, authz.ActionInvitationRevoke, true},
+		{tenant.RoleAdmin, authz.ActionLeadCreate, true},
+		{tenant.RoleAdmin, authz.ActionLeadRead, true},
+		{tenant.RoleAdmin, authz.ActionLeadUpdate, true},
+		{tenant.RoleAdmin, authz.ActionLeadDelete, true},
 
 		{tenant.RoleManager, authz.ActionMembershipList, true},
 		{tenant.RoleManager, authz.ActionMembershipUpdateRole, false},
@@ -35,6 +43,10 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleManager, authz.ActionInvitationCreate, false},
 		{tenant.RoleManager, authz.ActionInvitationList, false},
 		{tenant.RoleManager, authz.ActionInvitationRevoke, false},
+		{tenant.RoleManager, authz.ActionLeadCreate, true},
+		{tenant.RoleManager, authz.ActionLeadRead, true},
+		{tenant.RoleManager, authz.ActionLeadUpdate, true},
+		{tenant.RoleManager, authz.ActionLeadDelete, false},
 
 		{tenant.RoleEmployee, authz.ActionMembershipList, false},
 		{tenant.RoleEmployee, authz.ActionMembershipUpdateRole, false},
@@ -42,6 +54,10 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleEmployee, authz.ActionInvitationCreate, false},
 		{tenant.RoleEmployee, authz.ActionInvitationList, false},
 		{tenant.RoleEmployee, authz.ActionInvitationRevoke, false},
+		{tenant.RoleEmployee, authz.ActionLeadCreate, false},
+		{tenant.RoleEmployee, authz.ActionLeadRead, true}, // repository further restricts to own leads
+		{tenant.RoleEmployee, authz.ActionLeadUpdate, true},
+		{tenant.RoleEmployee, authz.ActionLeadDelete, false},
 	}
 
 	for _, c := range cases {

--- a/crm_be/internal/shared/phone/phone.go
+++ b/crm_be/internal/shared/phone/phone.go
@@ -1,0 +1,70 @@
+// Package phone normalizes phone numbers to E.164 — Indonesia-first, on
+// purpose, not a general E.164 implementation. A full port of
+// libphonenumber is a large dependency with metadata for every country
+// on earth, for a product whose customers are Indonesian SMBs (TD phase
+// 2 §6). The rules below are the entire assumption set; when a customer
+// with a non-Indonesian number eventually shows up, ToE164's body is
+// what changes — its signature already accepts and returns exactly what
+// a real implementation would.
+//
+// Rules, in order:
+//   - Strip everything except digits and a leading '+'.
+//   - "+62..."  → already international, validated and returned as-is.
+//   - "62..."   → same as above, missing only the '+'.
+//   - "0..."    → the domestic trunk prefix; replaced with "+62".
+//   - "8..."    → a bare mobile number with neither prefix; "+62" prepended.
+//   - Anything else, or a digit count outside [9,13] after the "+62",
+//     doesn't parse: ("", false).
+//
+// A number that fails to parse is NEVER a caller error — rejecting a
+// lead over phone format means discarding a customer's data, which is
+// unrecoverable (freeze bagian 2.3). Callers store the raw input
+// unconditionally and only use PhoneE164 when ok is true.
+package phone
+
+import "strings"
+
+const (
+	minE164Digits = 9 // after the +62, excluding it
+	maxE164Digits = 13
+)
+
+// ToE164 normalizes raw to E.164 form. ok is false when raw doesn't
+// parse under the rules above — callers must not treat that as an
+// error, only as "no normalized form available".
+func ToE164(raw string) (e164 string, ok bool) {
+	hasPlus := strings.HasPrefix(strings.TrimSpace(raw), "+")
+	digits := onlyDigits(raw)
+	if digits == "" {
+		return "", false
+	}
+
+	var national string
+	switch {
+	case hasPlus && strings.HasPrefix(digits, "62"):
+		national = digits[2:]
+	case strings.HasPrefix(digits, "62"):
+		national = digits[2:]
+	case strings.HasPrefix(digits, "0"):
+		national = digits[1:]
+	case strings.HasPrefix(digits, "8"):
+		national = digits
+	default:
+		return "", false
+	}
+
+	if len(national) < minE164Digits || len(national) > maxE164Digits {
+		return "", false
+	}
+	return "+62" + national, true
+}
+
+func onlyDigits(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/crm_be/internal/shared/phone/phone_test.go
+++ b/crm_be/internal/shared/phone/phone_test.go
@@ -1,0 +1,48 @@
+package phone_test
+
+import (
+	"testing"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/phone"
+)
+
+func TestToE164(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+		ok   bool
+	}{
+		{"domestic trunk prefix", "0812-3456-7890", "+6281234567890", true},
+		{"already E.164 with plus and spaces", "+62 812 3456 7890", "+6281234567890", true},
+		{"international without plus", "62812 3456 7890", "+6281234567890", true},
+		{"bare mobile number", "812 3456 7890", "+6281234567890", true},
+		{"too short to be a real number", "1234", "", false},
+		{"empty string", "", "", false},
+		{"letters only", "not-a-number", "", false},
+		{"too many digits", "0812345678901234567", "", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := phone.ToE164(c.raw)
+			if ok != c.ok {
+				t.Fatalf("ToE164(%q): expected ok=%v, got ok=%v (value=%q)", c.raw, c.ok, ok, got)
+			}
+			if ok && got != c.want {
+				t.Errorf("ToE164(%q) = %q, want %q", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+// TestToE164_UnparseableIsNeverAnError documents the contract callers
+// depend on: a phone number that doesn't parse is not a rejection
+// signal, just an absence of a normalized form (freeze bagian 2.3 —
+// never discard a lead over contact format).
+func TestToE164_UnparseableIsNeverAnError(t *testing.T) {
+	_, ok := phone.ToE164("this is not a phone number")
+	if ok {
+		t.Fatal("expected ok=false for unparseable input")
+	}
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 21 Agustus 2026 — Issue #19 selesai
-**Phase sekarang:** Phase 2 — CRM Core (1/5 issue selesai)
+**Last updated:** 22 Agustus 2026 — Issue #20 selesai
+**Phase sekarang:** Phase 2 — CRM Core (2/5 issue selesai)
 
 ---
 
@@ -30,6 +30,7 @@
 | **Issue #10 — Login, refresh rotation, logout, reset password, CSRF, GET /v1/me** | — | 1 | `POST /v1/auth/{login,refresh,logout,password/forgot,password/reset}`, `GET /v1/me`. Access token JWT (`internal/shared/accesstoken`) + refresh token opaque dengan rotasi & deteksi penggunaan ulang (`SELECT ... FOR UPDATE`, revoke seluruh `family_id`). Dashboard = cookie `HttpOnly`; Mobile = body — dibuktikan lewat test HTTP & smoke test manual. CSRF double-submit (`httpx.VerifyCSRF`) untuk request cookie non-GET. `LoginLimiter` (backoff progresif). `docs/architecture/authentication.md` baru. **12 test integrasi + 13 unit test baru** (plus 5 test `LoginLimiter`, 4 test `accesstoken`), semuanya lolos tanpa perubahan asersi lama. |
 | **Issue #11 — RBAC, invitation, penonaktifan membership, harness isolasi tenant** | — | 1 | `internal/shared/{authn,authz}` (session middleware diekstrak dari `auth`, RBAC baru). `internal/membership` naik jadi domain penuh (`port/usecase/handler_http.go`). `internal/invitation` baru — undangan dua cabang (B4), keduanya diuji termasuk test keamanan wajib. `POST/GET/DELETE /v1/invitations`, `GET/PATCH/DELETE /v1/memberships`. Penonaktifan membership mencabut refresh token dalam transaksi yang sama — **dibuktikan lewat smoke test end-to-end**. `docs/architecture/authorization.md` baru. **Harness isolasi tenant (`cmd/api/tenant_isolation_test.go`) dibangun & dibuktikan bisa gagal** (lapis 4, blocking CI). Satu bug nyata (email tidak terverifikasi otomatis saat accept undangan) ditemukan lewat smoke test manual, diperbaiki, dan mendapat test regresi di kedua level. **Phase 1 selesai.** |
 | **Issue #19 — Schema 0003, repository lead, alokasi `lead_number`, optimistic locking** | — | 2 | Migration `0003_crm_core` (`leads`, `customers`, `activities`, `tasks` + `organizations.next_lead_number`). `internal/lead` — repository murni (`entity.go`+`repository_postgres.go`, tanpa `port.go`/usecase — pola `membership` pra-#11). Alokasi `lead_number` berurutan per organization dan optimistic locking `version`, **dibuktikan di bawah konkurensi nyata** (20 goroutine bersamaan). Visibilitas employee ditegakkan di repository. Klaim awal soal kebutuhan `db.InTx` sempat berlebihan di komentar kode — diuji langsung sebelum commit, ternyata test konkurensi tidak membuktikannya; ditulis test terpisah (`TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber`) yang benar-benar membuktikan. Test katalog (dari #8) otomatis mencakup keempat tabel baru **tanpa perubahan**. |
+| **Issue #20 — Lead CRUD, transisi status, filter, pagination, idempotency, E.164** | — | 2 | `internal/lead` naik jadi domain penuh (`port/usecase/handler_http.go`, `Repository` jadi interface — migrasi yang sama seperti `membership` di #11). `POST/GET/PATCH/DELETE /v1/leads`, `PATCH /v1/leads/{id}/status`. `internal/shared/phone.ToE164` (Indonesia-first). Idempotency-Key dideteksi lewat unique-violation database, **dibuktikan dengan 10 POST bersamaan → tepat 1 lead**. Optimistic locking `409` membawa keadaan terkini di body. Dua `Action` RBAC baru (`lead.create/read/update/delete`). **Bug nyata ditemukan lewat test yang salah pakai** (assignee tak valid → 500 diam-diam) — diperbaiki jadi `400` bersih + test regresi. Satu penyimpangan TD didokumentasikan (keluar dari `lost` belum bisa "satu langkah tepat" tanpa riwayat dari #21). 34 test baru di `internal/lead`, semuanya lolos tanpa perubahan asersi lama. |
 
 ---
 
@@ -41,12 +42,12 @@ _(kosong)_
 
 ## Berikutnya
 
-**Issue #20 — Lead CRUD, transisi status, filter, pagination, idempotency, E.164**
+**Issue #21 — Activity append-only + auto-log, dan Task**
 
-- Cakupan & acceptance: [issue #20](https://github.com/Pravasta/jualin-crm/issues/20)
-- TD: `docs/phases/02-crm-core/td.md` §4, §5, §6, §7, §8, §8.1, §9
-- Menambahkan `port.go` + `usecase.go` ke `internal/lead` — pada titik ini `Repository` di `repository_postgres.go` berganti jadi interface dan struct konkretnya berganti nama `postgresRepository`, persis migrasi `membership` di #11 (lihat notes.md `## #19`).
-- Berurutan: #19 (selesai) → #20 → #21 → #22 → #23. Rincian di `docs/phases/02-crm-core/issues.md`.
+- Cakupan & acceptance: [issue #21](https://github.com/Pravasta/jualin-crm/issues/21)
+- TD: `docs/phases/02-crm-core/td.md` §1.3, §1.4, §8, §10
+- `internal/lead/port.go`'s `Repos` menambah field `Activity` — pada titik ini `Create`/`UpdateStatus` di usecase perlu dibungkus `store.InTx` juga (bukan hanya `Create` seperti sekarang) supaya penulisan activity atomik dengan perubahan lead yang memicunya.
+- Berurutan: #19 (selesai) → #20 (selesai) → #21 → #22 → #23. Rincian di `docs/phases/02-crm-core/issues.md`.
 
 ---
 

--- a/docs/phases/02-crm-core/notes.md
+++ b/docs/phases/02-crm-core/notes.md
@@ -58,3 +58,56 @@ Seluruh acceptance criteria issue #19 terpenuhi.
 - **`internal/lead` mengikuti pola `entity.go`+`repository_postgres.go` murni.** #20 menambah `port.go` (interface `Repository` + `Store`/`Repos`) dan `usecase.go` — pada titik itu, struct `Repository` di `repository_postgres.go` berganti nama jadi `postgresRepository` (unexported), persis migrasi `membership` di #11. Jangan kaget saat rename itu terjadi — sudah direncanakan, bukan refactor darurat.
 - **`Update` di repository ini hanya field umum** (`name`, `email`, `phone`, `company`, `notes`). Transisi status (`PATCH /status`) dan assignment (`PATCH /assignment`) di TD adalah endpoint terpisah dengan aturan sendiri — `#20` kemungkinan menambah method `Repository` baru untuk itu (`UpdateStatus`, atau usecase memanggil `Update` plus logic tambahan), bukan memperluas `UpdateInput` yang ada.
 - **Uji klaim atomisitas secara langsung sebelum menuliskannya di komentar kode**, bukan berasumsi dari desain. Pengalaman di atas (klaim `db.InTx` yang ternyata tidak dibuktikan test konkurensi) adalah contoh konkret kenapa ini penting — desain yang *terlihat* benar bisa salah soal *test mana* yang sebenarnya membuktikannya.
+
+---
+
+## #20 — Lead CRUD, transisi status, filter, pagination, idempotency, E.164
+
+### Menyimpang dari rencana issue
+
+| Yang berbeda | Alasan |
+|---|---|
+| Keluar dari status `lost` mengizinkan pindah ke **status jalur utama manapun**, bukan spesifik "satu langkah kembali ke status sebelum kalah" seperti bunyi literal TD §5 | `leads` hanya menyimpan status **saat ini** — tidak ada memori status sebelumnya. Riwayat itu baru tersedia lewat `activities` (#21). Didokumentasikan sebagai pendekatan sementara di `usecase.go`'s `validateStatusTransition`; tidak ada acceptance criteria issue #20 yang menguji kasus spesifik ini. Akan disempurnakan begitu `activities` memberi riwayat yang bisa dipakai, bukan ditebak dari nol. |
+
+### Keputusan implementasi
+
+- **Migrasi `internal/lead` dari repository murni ke domain penuh** persis seperti direncanakan di notes.md `## #19`: `Repository` (struct konkret) → interface, implementasi berganti nama `postgresRepository`, `port.go`+`usecase.go` baru. Tidak ada kejutan — sudah dicatat sebelum dikerjakan.
+- **Bug nyata ditemukan lewat test yang salah pakai, bukan lewat desain**: saat menulis `TestHandler_Get_Employee_OtherPersonsLead_Returns404`, lead di-assign ke `assigned_to_membership_id` acak yang **tidak** merujuk baris `memberships` sungguhan. `INSERT` melanggar FK composite `fk_leads_assignee` — dan pelanggaran itu **tidak tertangani**, jatuh ke `fmt.Errorf` generik yang dipetakan `internal_error` (500) oleh `httpx.MapError`. Test berikutnya yang memakai id kosong hasil parse gagal itu justru gagal dengan cara membingungkan (301 redirect ke `/v1/leads`, gara-gara path menjadi `/v1/leads/` kosong). Diperbaiki dua arah: (1) test itu sendiri diperbaiki untuk menyeed membership sungguhan, (2) **gap produksi yang terungkap ditutup**: `Create` sekarang mendeteksi pelanggaran FK 23503 pada `fk_leads_assignee` dan mengembalikan `ErrAssigneeNotFound`, dipetakan usecase menjadi `400 validation_failed` yang jelas. Test regresi `TestHandler_Create_InvalidAssignee_Returns400NotInternalError` memastikan ini tidak kembali menjadi 500 diam-diam.
+- **Deteksi idempotency key duplikat lewat unique-violation database** (`uq_leads_org_idempotency`, kode `23505`), persis pola `user.ErrEmailTaken` — bukan `SELECT`-lalu-`INSERT`, yang justru race persis di bawah kondisi retry bersamaan yang menjadi alasan idempotency key ada. Dibuktikan dengan test HTTP 10 request `POST` bersamaan memakai key yang sama: tepat 1 `201`, sisanya `200`, seluruhnya merujuk lead yang sama, dan hanya 1 baris di database.
+- **`FindAllByOrg` membangun `WHERE` secara manual** (bukan query-builder library — "sqlc/pgx bukan ORM") — daftar kondisi + slice argumen dirakit sekali, dipakai bersama oleh query `count(*)` dan query berpaginasi supaya keduanya tidak pernah berbeda filter.
+- **Visibilitas employee di `FindAllByOrg` diterapkan tanpa syarat** — filter `assigned_to` dari query param employee **diabaikan**, diganti paksa dengan `assigned_to_membership_id = t.MembershipID`. Employee yang mencoba memfilter ke lead orang lain mendapat daftar kosong, bukan error — aman by construction, sama seperti `FindByID`/`Update` sejak #19.
+
+### Verifikasi
+
+```
+go build ./...                              → bersih
+go vet ./...                                → bersih
+golangci-lint run                           → 0 issues (setelah perbaikan G101 + 2x S1016)
+gofmt -l .                                  → bersih
+go test -race -count=1 ./... (2x)           → semua PASS
+
+go test ./internal/lead/... -race -count=1  → 34/34 PASS
+go test ./internal/shared/phone/... -count=1 → semua PASS
+
+DOCKER_HOST=unix:///tmp/nonexistent-docker.sock \
+  go test ./internal/... -run 'TestUnit|TestRequire|TestToE164' -count=1
+                                             → PASS tanpa Docker (lead, authz, phone, + semua paket lama)
+
+go list -deps ./cmd/api | grep docker       → kosong
+```
+
+**Test konkurensi idempotency (wajib di Definition of Done)**: 10 request `POST /v1/leads` bersamaan dengan `Idempotency-Key` sama → tepat 1× `201`, 9× `200`, seluruhnya mengembalikan `id` yang sama, dan `SELECT count(*)` di database mengonfirmasi tepat 1 baris.
+
+**Smoke test manual** (`docker compose up --build`): register+verify+login owner → `POST /v1/leads` dengan `Idempotency-Key` → `201`, `lead_number=1`, `phone_e164` ternormalisasi `+6281234567890`, email lower-case → replay key yang sama dengan body berbeda → `200`, lead **sama persis**, nama tidak berubah → `PATCH /status` `new→won` → `422` → `PATCH /status` `new→contacted` → `200` → `PATCH` field umum dengan `version` basi → `409` dengan `error.current` memuat status terkini (`contacted`, `version=2`) → `GET /v1/leads?status=contacted` → daftar & `meta.total` benar.
+
+Seluruh acceptance criteria issue #20 terpenuhi.
+
+### Utang teknis
+
+- Tidak ada item baru dari issue ini sendiri. `docs/STATUS.md` bagian Utang Teknis tetap seperti sebelumnya.
+
+### Catatan untuk session berikutnya
+
+- **`internal/lead/port.go`'s `Repos{Lead Repository}` punya satu field secara sengaja.** #21 menambah field `Activity` saat menulis `activities` perlu atomik dengan perubahan lead (`status_changed`, `lead_assigned`, dst) — pada titik itu, `UpdateStatus`/assignment di usecase perlu dibungkus `store.InTx` juga (saat ini hanya `Create` yang InTx, karena `Create` sendiri butuh atomisitas internal, bukan karena ada tabel lain yang ditulis).
+- **Pola deteksi pelanggaran constraint database (unique ATAU foreign key) sebagai sinyal, bukan `SELECT` dulu**, sekarang punya dua contoh di paket ini (`ErrIdempotencyKeyExists`, `ErrAssigneeNotFound`) selain `user.ErrEmailTaken` di Phase 1. Pola yang sama berlaku untuk constraint baru yang muncul di #21/#22/#23 (mis. `uq_customers_org_lead` saat konversi).
+- **Manual smoke test menemukan bug produksi untuk ketiga kalinya berturut-turut** (setelah #11 dan sesi ini sendiri, lewat jalur test bukan `docker compose` kali ini) — pola yang konsisten cukup kuat untuk terus dipertahankan di issue berikutnya, bukan dianggap kebetulan.


### PR DESCRIPTION
## Summary

Second issue of Phase 2, built on #19's repository foundation. Adds the usecase + HTTP layer for `lead`: full CRUD, status-transition validation, filter/pagination, idempotency-key replay, and E.164 phone normalization.

- `internal/lead` migrates from a pure repository package to a full domain (`port.go` + `usecase.go` land, `Repository` becomes an interface, concrete type renamed `postgresRepository`) — same migration `internal/membership` went through in #11.
- New `internal/shared/phone` package: hand-written, Indonesia-first E.164 normalization (TD §6). Unparseable input is never rejected, only left unnormalized (freeze 2.3 — never discard a lead over contact format).
- Idempotency: `Idempotency-Key` header → `leads.idempotency_key`, `UNIQUE (organization_id, idempotency_key)`. Detected via the unique-violation, never a pre-check `SELECT` — proven safe with 10 concurrent identical requests (`TestHandler_Create_ConcurrentSameIdempotencyKey_ExactlyOneNew`): exactly one `201`, the rest `200`, all pointing at the same lead, exactly one DB row.
- Status transitions (TD §5): forward/backward one step within `new → contacted → qualified → proposal → won`; `lost`/`unqualified`/`spam` reachable from any non-final status; `unqualified`/`spam` are truly terminal; `lost` requires `lost_reason`, leaving it clears the reason.
- **Documented deviation**: TD says leaving `lost` should return to the specific status the lead lost from — that requires history only `activities` (#21) will provide. `leads` only stores current status, so #20 approximates by allowing return to *any* main-path status. Flagged in the usecase doc comment and in `notes.md`; none of #20's acceptance criteria exercise this specific case.
- Optimistic locking (`version`) on `Update`/`UpdateStatus`: conflict → `409` with `error.current` carrying the row's live state, via a small `VersionConflictError` envelope extension (same pattern as `auth`'s `organization_selection_required`).
- `authz` gains `lead.create/read/update/delete`: Owner/Admin get all four, Manager gets create/read/update (not delete), Employee gets read/update only, repository-restricted to leads assigned to them.
- **Real bug found and fixed**: an invalid `assigned_to_membership_id` on create violated the `fk_leads_assignee` composite FK and surfaced as a bare `500`. `Create` now detects the `23503` violation and maps it to a clean `400 validation_failed` (regression test: `TestHandler_Create_InvalidAssignee_Returns400NotInternalError`).

## Test plan

- [x] `go build/vet ./...`, `gofmt -l .` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./... -race -count=1` — green, run twice for flakiness
- [x] `DOCKER_HOST=<bogus> go test ./internal/... -run TestUnit` — business logic confirmed Docker-free
- [x] `go list -deps ./cmd/api | grep docker` — production binary confirmed testcontainers-free
- [x] Manual `docker compose up` smoke test: create with `Idempotency-Key` → `201`, `lead_number` sequencing, phone/email normalization; replay same key with a different body → `200`, identical original lead; `new→won` → `422`; `new→contacted` → `200`; stale-version `PATCH` → `409` with accurate `error.current`; `GET /v1/leads?status=contacted` filter + `meta.total` correct

Refs #20