### PR TITLE
feat(activity,task): add append-only timeline and follow-up tasks

### DIFF
--- a/crm_be/cmd/api/activity_store.go
+++ b/crm_be/cmd/api/activity_store.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+)
+
+// activityStore is the composition root's implementation of
+// activity.Store — same wiring pattern as lead_store.go.
+type activityStore struct {
+	pool *pgxpool.Pool
+}
+
+func newActivityStore(pool *pgxpool.Pool) activity.Store {
+	return &activityStore{pool: pool}
+}
+
+func (s *activityStore) InTx(ctx context.Context, fn func(activity.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(activityReposFor(tx))
+	})
+}
+
+func (s *activityStore) Repos() activity.Repos {
+	return activityReposFor(s.pool)
+}
+
+func activityReposFor(q db.Querier) activity.Repos {
+	return activity.Repos{
+		Activity: activity.New(q),
+	}
+}

--- a/crm_be/cmd/api/lead_store.go
+++ b/crm_be/cmd/api/lead_store.go
@@ -6,14 +6,17 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
 )
 
 // leadStore is the composition root's implementation of lead.Store —
 // same wiring pattern as auth_store.go/membership_store.go/
-// invitation_store.go. internal/lead has no cross-package dependency
-// yet, so reposFor here is the simplest of the four so far.
+// invitation_store.go. Its Activity repository comes from
+// activity.NewRecorder, added in #21 — internal/lead never imports
+// internal/activity's domain types, only this file (and
+// internal/activity itself) knows both packages exist (ADR-011).
 type leadStore struct {
 	pool *pgxpool.Pool
 }
@@ -34,6 +37,7 @@ func (s *leadStore) Repos() lead.Repos {
 
 func leadReposFor(q db.Querier) lead.Repos {
 	return lead.Repos{
-		Lead: lead.New(q),
+		Lead:     lead.New(q),
+		Activity: activity.NewRecorder(q),
 	}
 }

--- a/crm_be/cmd/api/main.go
+++ b/crm_be/cmd/api/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/auth"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/invitation"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
@@ -25,6 +26,7 @@ import (
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/logger"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/mailer"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/task"
 )
 
 const readyPingTimeout = 2 * time.Second
@@ -107,6 +109,12 @@ func newRouter(log *slog.Logger, pool *pgxpool.Pool, cfg *config.Config) *gin.En
 
 	leadUsecase := lead.NewUsecase(newLeadStore(pool))
 	lead.NewHandler(leadUsecase).RegisterRoutes(r, authMW)
+
+	activityUsecase := activity.NewUsecase(newActivityStore(pool))
+	activity.NewHandler(activityUsecase).RegisterRoutes(r, authMW)
+
+	taskUsecase := task.NewUsecase(newTaskStore(pool))
+	task.NewHandler(taskUsecase).RegisterRoutes(r, authMW)
 
 	r.NoRoute(func(c *gin.Context) {
 		httpx.RespondError(c, http.StatusNotFound, "not_found", "Route tidak ditemukan.")

--- a/crm_be/cmd/api/task_store.go
+++ b/crm_be/cmd/api/task_store.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/task"
+)
+
+// taskStore is the composition root's implementation of task.Store.
+// Its Activity repository comes from activity.NewRecorder —
+// internal/task never imports internal/activity's domain types, only
+// this file (and internal/activity itself) knows both packages exist
+// (ADR-011).
+type taskStore struct {
+	pool *pgxpool.Pool
+}
+
+func newTaskStore(pool *pgxpool.Pool) task.Store {
+	return &taskStore{pool: pool}
+}
+
+func (s *taskStore) InTx(ctx context.Context, fn func(task.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(taskReposFor(tx))
+	})
+}
+
+func (s *taskStore) Repos() task.Repos {
+	return taskReposFor(s.pool)
+}
+
+func taskReposFor(q db.Querier) task.Repos {
+	return task.Repos{
+		Task:     task.New(q),
+		Activity: activity.NewRecorder(q),
+	}
+}

--- a/crm_be/internal/activity/entity.go
+++ b/crm_be/internal/activity/entity.go
@@ -1,0 +1,59 @@
+// Package activity is CRM Core's append-only timeline. Rows are never
+// updated or deleted (TD §1.3) — the absence of updated_at/deleted_at
+// columns and of any PATCH/DELETE route is the enforcement, not a
+// convention that has to be remembered elsewhere. See
+// docs/phases/02-crm-core/td.md §1.3, §8, §10.
+package activity
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Activity struct {
+	ID                uuid.UUID
+	OrganizationID    uuid.UUID
+	LeadID            uuid.UUID
+	Type              string
+	ActorMembershipID *uuid.UUID
+	Body              *string
+	// Metadata is raw jsonb bytes, never decoded back into a Go value —
+	// its shape differs per Type (status_changed stores {from,to},
+	// call_logged stores a duration, …) and TD §1.3 is explicit that it
+	// is "tidak pernah di-query, hanya dirender di timeline". Callers
+	// that need to render it just re-marshal this into the JSON
+	// response verbatim.
+	Metadata  json.RawMessage
+	CreatedAt time.Time
+}
+
+// CreateInput is Repository.Create's argument. Metadata is a friendly
+// map here — the repository is what converts it to jsonb bytes on the
+// way in, keeping "how metadata is encoded" a single decision made in
+// one place.
+type CreateInput struct {
+	LeadID            uuid.UUID
+	Type              string
+	ActorMembershipID *uuid.UUID
+	Body              *string
+	Metadata          map[string]any
+}
+
+// userTypes are the only activity types POST /v1/leads/{id}/activities
+// accepts from a client (TD §8) — every other value in
+// ck_activities_type is system-generated (TD §10) and gets 422 if a
+// client tries to submit it. Allowing a client to fabricate a system
+// type would make the timeline stop being trustworthy.
+var userTypes = map[string]bool{
+	"note_added":      true,
+	"call_logged":     true,
+	"whatsapp_opened": true,
+}
+
+// IsUserType reports whether t is one of the types a client may submit
+// directly via POST.
+func IsUserType(t string) bool {
+	return userTypes[t]
+}

--- a/crm_be/internal/activity/handler_http.go
+++ b/crm_be/internal/activity/handler_http.go
@@ -1,0 +1,99 @@
+package activity
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+)
+
+type Handler struct {
+	usecase *Usecase
+}
+
+func NewHandler(usecase *Usecase) *Handler {
+	return &Handler{usecase: usecase}
+}
+
+// RegisterRoutes mounts a SECOND group at /v1/leads — gin allows
+// multiple independent groups sharing a path prefix as long as the
+// final method+path pairs never collide. The wildcard segment MUST be
+// named :id here, matching lead.Handler's own /v1/leads/:id exactly —
+// gin panics at router-build time if two routes disagree on a
+// wildcard's name at the same tree position.
+//
+// No PATCH or DELETE route exists anywhere in this file — append-only
+// (TD §1.3/§8) is enforced by the router literally not having those
+// routes, not by a convention someone has to remember.
+func (h *Handler) RegisterRoutes(r gin.IRouter, authMW gin.HandlerFunc) {
+	g := r.Group("/v1/leads")
+	g.Use(authMW)
+	g.GET("/:id/activities", h.list)
+	g.POST("/:id/activities", h.create)
+}
+
+func (h *Handler) list(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	leadID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	activities, err := h.usecase.List(c.Request.Context(), t, leadID)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+
+	out := make([]gin.H, 0, len(activities))
+	for _, a := range activities {
+		out = append(out, activityJSON(a))
+	}
+	httpx.OK(c, http.StatusOK, out)
+}
+
+type createRequest struct {
+	Type     string         `json:"type"`
+	Body     *string        `json:"body"`
+	Metadata map[string]any `json:"metadata"`
+}
+
+func (h *Handler) create(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	leadID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	var req createRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	created, err := h.usecase.Create(c.Request.Context(), t, leadID, CreateActivityInput(req))
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusCreated, activityJSON(created))
+}
+
+func activityJSON(a *Activity) gin.H {
+	return gin.H{
+		"id":                  a.ID,
+		"lead_id":             a.LeadID,
+		"type":                a.Type,
+		"actor_membership_id": a.ActorMembershipID,
+		"body":                a.Body,
+		"metadata":            a.Metadata,
+		"created_at":          a.CreatedAt,
+	}
+}

--- a/crm_be/internal/activity/handler_test.go
+++ b/crm_be/internal/activity/handler_test.go
@@ -1,0 +1,226 @@
+package activity_test
+
+// Integration tests (real Postgres via dbtest) for issue #21's activity
+// HTTP layer.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/accesstoken"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const testJWTSecret = "activity-handler-test-jwt-secret-32b" // #nosec G101 -- test-only value, not a real credential
+
+type testClaimsParser struct{}
+
+func (testClaimsParser) ParseAccessToken(raw string) (*accesstoken.Claims, error) {
+	return accesstoken.Parse([]byte(testJWTSecret), raw)
+}
+
+type testStore struct{ pool *pgxpool.Pool }
+
+func newTestStore(pool *pgxpool.Pool) activity.Store { return &testStore{pool: pool} }
+
+func (s *testStore) InTx(ctx context.Context, fn func(activity.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error { return fn(activity.Repos{Activity: activity.New(tx)}) })
+}
+
+func (s *testStore) Repos() activity.Repos { return activity.Repos{Activity: activity.New(s.pool)} }
+
+func newTestRouter(t *testing.T) (*gin.Engine, *pgxpool.Pool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pool := dbtest.NewPool(t)
+	u := activity.NewUsecase(newTestStore(pool))
+
+	r := gin.New()
+	activity.NewHandler(u).RegisterRoutes(r, authn.Middleware(testClaimsParser{}))
+	return r, pool
+}
+
+func bearerToken(t *testing.T, userID, orgID, membershipID uuid.UUID, role tenant.Role) string {
+	t.Helper()
+	tok, err := accesstoken.Issue([]byte(testJWTSecret), 15*time.Minute, userID, orgID, membershipID, role)
+	if err != nil {
+		t.Fatalf("mint access token: %v", err)
+	}
+	return tok
+}
+
+func doJSON(r *gin.Engine, method, path, bearer string, body any) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(method, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func seedOrgAndOwner(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (org, user, membership uuid.UUID) {
+	t.Helper()
+	org = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, org); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	user = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Owner')`, user, user.String()+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	membership = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'owner')`, membership, org, user); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	return org, user, membership
+}
+
+func seedEmployeeMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID) uuid.UUID {
+	t.Helper()
+	userID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Employee')`, userID, userID.String()+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	membershipID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'employee')`, membershipID, org, userID); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	return membershipID
+}
+
+// seedLead is defined in repository_test.go (same package) and reused
+// here.
+
+func TestHandler_Create_NoteAdded_Returns201(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil)
+
+	w := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/activities", token, map[string]string{"type": "note_added", "body": "Called, no answer"})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandler_Create_SystemType_Returns422 is TD §8/#21's explicit
+// requirement: a client submitting a system-generated type is rejected
+// 422, never silently accepted.
+func TestHandler_Create_SystemType_Returns422(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil)
+
+	w := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/activities", token, map[string]string{"type": "status_changed"})
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422 for a client-submitted system type, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Get_Employee_OtherPersonsLead_Returns404(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, _, _ := seedOrgAndOwner(t, ctx, pool)
+	otherEmployee := seedEmployeeMembership(t, ctx, pool, org)
+	leadID := seedLead(t, ctx, pool, org, &otherEmployee)
+
+	me := uuid.Must(uuid.NewV7())
+	myToken := bearerToken(t, me, org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	w := doJSON(r, http.MethodGet, "/v1/leads/"+leadID.String()+"/activities", myToken, nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Create_Employee_OtherPersonsLead_Returns404(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, _, _ := seedOrgAndOwner(t, ctx, pool)
+	otherEmployee := seedEmployeeMembership(t, ctx, pool, org)
+	leadID := seedLead(t, ctx, pool, org, &otherEmployee)
+
+	me := uuid.Must(uuid.NewV7())
+	myToken := bearerToken(t, me, org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	w := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/activities", myToken, map[string]string{"type": "note_added"})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandler_RoutesAreAppendOnly checks the actual registered route
+// list — not assumption — for exactly GET and POST on
+// /v1/leads/:id/activities, per TD §8's explicit "no PATCH/DELETE"
+// requirement and this issue's acceptance criteria ("diperiksa lewat
+// daftar route, bukan asumsi").
+func TestHandler_RoutesAreAppendOnly(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	u := activity.NewUsecase(newTestStore(nil))
+	activity.NewHandler(u).RegisterRoutes(r, func(c *gin.Context) { c.Next() })
+
+	methods := map[string]bool{}
+	for _, route := range r.Routes() {
+		if route.Path == "/v1/leads/:id/activities" {
+			methods[route.Method] = true
+		}
+	}
+	if !methods[http.MethodGet] || !methods[http.MethodPost] {
+		t.Fatalf("expected GET and POST registered on /v1/leads/:id/activities, got %v", methods)
+	}
+	if methods[http.MethodPatch] || methods[http.MethodDelete] || methods[http.MethodPut] {
+		t.Fatalf("expected NO PATCH/DELETE/PUT on /v1/leads/:id/activities — append-only, got %v", methods)
+	}
+	if len(methods) != 2 {
+		t.Fatalf("expected exactly 2 methods registered, got %v", methods)
+	}
+}
+
+func TestHandler_List_NewestFirst(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil)
+
+	doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/activities", token, map[string]string{"type": "note_added", "body": "first"})
+	doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/activities", token, map[string]string{"type": "note_added", "body": "second"})
+
+	w := doJSON(r, http.MethodGet, "/v1/leads/"+leadID.String()+"/activities", token, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Data []struct {
+			Body string `json:"body"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 2 || body.Data[0].Body != "second" || body.Data[1].Body != "first" {
+		t.Fatalf("expected newest-first ordering, got %+v", body.Data)
+	}
+}

--- a/crm_be/internal/activity/port.go
+++ b/crm_be/internal/activity/port.go
@@ -1,0 +1,44 @@
+package activity
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Repository is activity's own table interface — postgresRepository
+// (repository_postgres.go) satisfies it, but Usecase depends only on
+// this interface (ADR-011).
+type Repository interface {
+	Create(ctx context.Context, t tenant.Context, in CreateInput) (*Activity, error)
+	FindAllByLead(ctx context.Context, t tenant.Context, leadID uuid.UUID) ([]*Activity, error)
+}
+
+// Recorder is the narrow surface lead and task need to append a
+// system-generated activity from inside their own Store.InTx (TD §10) —
+// expressed with only primitive/shared types (no *Activity, no
+// CreateInput) so that lead.ActivityRecorder and task.ActivityRecorder,
+// each declared locally in their own package per ADR-011, are satisfied
+// structurally by whatever NewRecorder returns without either package
+// importing this one. Same bridging role as auth.RefreshTokenRevoker
+// plays for membership (#11).
+type Recorder interface {
+	Record(ctx context.Context, t tenant.Context, leadID uuid.UUID, activityType string, actorMembershipID *uuid.UUID, metadata map[string]any) error
+}
+
+// Repos bundles what a single Usecase call needs — one field today,
+// same shape as every other domain's Unit of Work even though
+// activity's own usecase never itself needs a multi-repository
+// transaction (kept for composition-root wiring consistency, not extra
+// machinery beyond that).
+type Repos struct {
+	Activity Repository
+}
+
+// Store is the Unit of Work Usecase depends on.
+type Store interface {
+	InTx(ctx context.Context, fn func(Repos) error) error
+	Repos() Repos
+}

--- a/crm_be/internal/activity/repository_postgres.go
+++ b/crm_be/internal/activity/repository_postgres.go
@@ -1,0 +1,177 @@
+package activity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+type postgresRepository struct {
+	q db.Querier
+}
+
+func New(q db.Querier) Repository {
+	return &postgresRepository{q: q}
+}
+
+// NewRecorder exposes the same concrete implementation as New, typed
+// through Recorder — see that interface's doc comment in port.go for
+// why this exists (same pattern as auth.NewRefreshTokenRevoker).
+func NewRecorder(q db.Querier) Recorder {
+	return &postgresRepository{q: q}
+}
+
+// Create inserts one activity, but only if leadID is visible to t —
+// tenant-scoped always, and additionally restricted to leads assigned
+// to t.MembershipID when t.Role is employee (TD §9's rule, re-expressed
+// here as a SQL WHERE EXISTS rather than a Go-level call into
+// internal/lead: both packages share one Postgres database, so this
+// needs no cross-package interface). Zero rows (lead not visible) comes
+// back as pgx.ErrNoRows from QueryRow, mapped to httpx.ErrNotFound —
+// same as any other cross-org/cross-scope lookup in this codebase
+// (Rule #6: never 403 for a resource in someone else's scope).
+func (r *postgresRepository) Create(ctx context.Context, t tenant.Context, in CreateInput) (*Activity, error) {
+	metadataJSON, err := marshalMetadata(in.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("activity: marshal metadata: %w", err)
+	}
+
+	const q = `
+		INSERT INTO activities (id, organization_id, lead_id, type, actor_membership_id, body, metadata)
+		SELECT $1, $2, $3, $4, $5, $6, $7
+		WHERE EXISTS (
+			SELECT 1 FROM leads
+			WHERE id = $3 AND organization_id = $2 AND deleted_at IS NULL
+			  AND (NOT $8 OR assigned_to_membership_id = $9)
+		)
+		RETURNING ` + activityColumns
+
+	id := uuid.Must(uuid.NewV7())
+	row := r.q.QueryRow(ctx, q,
+		id, t.OrganizationID, in.LeadID, in.Type, in.ActorMembershipID, in.Body, metadataJSON,
+		isEmployee(t), membershipIDOrNil(t),
+	)
+	created, err := scanActivity(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, httpx.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("activity: create: %w", err)
+	}
+	return created, nil
+}
+
+// Record is Recorder's implementation — called only from inside
+// lead/task's own Store.InTx, immediately after they've already
+// loaded or written that exact lead in the same transaction. The
+// WHERE EXISTS guard still runs (it's the same statement as Create) but
+// is a formality in that call path, never expected to fail.
+func (r *postgresRepository) Record(ctx context.Context, t tenant.Context, leadID uuid.UUID, activityType string, actorMembershipID *uuid.UUID, metadata map[string]any) error {
+	_, err := r.Create(ctx, t, CreateInput{
+		LeadID:            leadID,
+		Type:              activityType,
+		ActorMembershipID: actorMembershipID,
+		Metadata:          metadata,
+	})
+	return err
+}
+
+// FindAllByLead returns leadID's timeline, newest first (TD §8: "terbaru
+// dulu"), scoped the same way Create is — wrong org or (for an
+// employee) a lead not assigned to them both look identical to "empty
+// timeline" from a pure SELECT, so the visibility check runs
+// separately here and yields httpx.ErrNotFound when the lead itself
+// isn't visible, rather than a silently empty list that would leak
+// nothing but also confirm nothing.
+func (r *postgresRepository) FindAllByLead(ctx context.Context, t tenant.Context, leadID uuid.UUID) ([]*Activity, error) {
+	visible, err := r.leadVisible(ctx, t, leadID)
+	if err != nil {
+		return nil, err
+	}
+	if !visible {
+		return nil, httpx.ErrNotFound
+	}
+
+	const q = `
+		SELECT ` + activityColumns + `
+		FROM activities
+		WHERE organization_id = $1 AND lead_id = $2
+		ORDER BY created_at DESC`
+
+	rows, err := r.q.Query(ctx, q, t.OrganizationID, leadID)
+	if err != nil {
+		return nil, fmt.Errorf("activity: find all by lead: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Activity
+	for rows.Next() {
+		a, err := scanActivity(rows)
+		if err != nil {
+			return nil, fmt.Errorf("activity: scan: %w", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("activity: find all by lead: %w", err)
+	}
+	return out, nil
+}
+
+func (r *postgresRepository) leadVisible(ctx context.Context, t tenant.Context, leadID uuid.UUID) (bool, error) {
+	const q = `
+		SELECT EXISTS (
+			SELECT 1 FROM leads
+			WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
+			  AND (NOT $3 OR assigned_to_membership_id = $4)
+		)`
+	var visible bool
+	if err := r.q.QueryRow(ctx, q, leadID, t.OrganizationID, isEmployee(t), membershipIDOrNil(t)).Scan(&visible); err != nil {
+		return false, fmt.Errorf("activity: check lead visibility: %w", err)
+	}
+	return visible, nil
+}
+
+func isEmployee(t tenant.Context) bool {
+	return t.Role == tenant.RoleEmployee
+}
+
+func membershipIDOrNil(t tenant.Context) uuid.UUID {
+	if t.MembershipID == nil {
+		return uuid.UUID{}
+	}
+	return *t.MembershipID
+}
+
+func marshalMetadata(m map[string]any) ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return json.Marshal(m)
+}
+
+const activityColumns = `
+	id, organization_id, lead_id, type, actor_membership_id, body, metadata, created_at`
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanActivity(row rowScanner) (*Activity, error) {
+	var a Activity
+	err := row.Scan(
+		&a.ID, &a.OrganizationID, &a.LeadID, &a.Type, &a.ActorMembershipID, &a.Body, &a.Metadata, &a.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}

--- a/crm_be/internal/activity/repository_test.go
+++ b/crm_be/internal/activity/repository_test.go
@@ -1,0 +1,210 @@
+package activity_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// TestRepository_Create_MetadataRoundTrips is the first jsonb WRITE this
+// codebase exercises against a real database (lead.RawPayload is
+// written-through but never actually populated by any caller) — the
+// project's own discipline is to verify claims like "pgx accepts a
+// []byte json.Marshal result for a jsonb column" directly rather than
+// assume it, per notes.md's #19/#20 entries.
+func TestRepository_Create_MetadataRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := activity.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil)
+
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, activity.CreateInput{
+		LeadID: leadID, Type: "status_changed",
+		Metadata: map[string]any{"from": "new", "to": "contacted"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(created.Metadata, &decoded); err != nil {
+		t.Fatalf("expected metadata to be valid JSON, got %q: %v", created.Metadata, err)
+	}
+	if decoded["from"] != "new" || decoded["to"] != "contacted" {
+		t.Errorf("expected {from: new, to: contacted}, got %v", decoded)
+	}
+
+	// Read back via FindAllByLead too, to prove the round trip survives
+	// a fresh SELECT, not just the RETURNING clause of the INSERT.
+	list, err := repo.FindAllByLead(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, leadID)
+	if err != nil {
+		t.Fatalf("find all by lead: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 activity, got %d", len(list))
+	}
+	var reDecoded map[string]any
+	if err := json.Unmarshal(list[0].Metadata, &reDecoded); err != nil {
+		t.Fatalf("expected metadata read back via SELECT to be valid JSON, got %q: %v", list[0].Metadata, err)
+	}
+	if reDecoded["from"] != "new" || reDecoded["to"] != "contacted" {
+		t.Errorf("expected {from: new, to: contacted} on re-read, got %v", reDecoded)
+	}
+}
+
+func TestRepository_Create_NilMetadata_StaysNull(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := activity.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil)
+
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, activity.CreateInput{
+		LeadID: leadID, Type: "note_added",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.Metadata != nil {
+		t.Errorf("expected nil metadata to stay NULL, got %q", created.Metadata)
+	}
+}
+
+func TestRepository_Create_CrossOrgLead_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := activity.New(pool)
+
+	orgA := seedOrganization(t, ctx, pool)
+	orgB := seedOrganization(t, ctx, pool)
+	leadInA := seedLead(t, ctx, pool, orgA, nil)
+
+	_, err := repo.Create(ctx, tenant.Context{OrganizationID: orgB, Role: tenant.RoleOwner}, activity.CreateInput{
+		LeadID: leadInA, Type: "note_added",
+	})
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound for a lead in a different organization, got: %v", err)
+	}
+}
+
+func TestRepository_Create_Employee_OtherPersonsLead_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := activity.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	employeeA := seedMembership(t, ctx, pool, org, "employee-a@example.com", tenant.RoleEmployee)
+	employeeB := seedMembership(t, ctx, pool, org, "employee-b@example.com", tenant.RoleEmployee)
+	leadForA := seedLead(t, ctx, pool, org, &employeeA)
+
+	_, err := repo.Create(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleEmployee, MembershipID: &employeeB}, activity.CreateInput{
+		LeadID: leadForA, Type: "note_added",
+	})
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound for an employee acting on someone else's lead, got: %v", err)
+	}
+
+	// The assignee themself must succeed.
+	if _, err := repo.Create(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleEmployee, MembershipID: &employeeA}, activity.CreateInput{
+		LeadID: leadForA, Type: "note_added",
+	}); err != nil {
+		t.Errorf("expected the assignee to be able to add an activity, got: %v", err)
+	}
+}
+
+func TestRepository_FindAllByLead_NewestFirst(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := activity.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil)
+	tenantCtx := tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}
+
+	first, err := repo.Create(ctx, tenantCtx, activity.CreateInput{LeadID: leadID, Type: "note_added"})
+	if err != nil {
+		t.Fatalf("create first: %v", err)
+	}
+	second, err := repo.Create(ctx, tenantCtx, activity.CreateInput{LeadID: leadID, Type: "call_logged"})
+	if err != nil {
+		t.Fatalf("create second: %v", err)
+	}
+
+	list, err := repo.FindAllByLead(ctx, tenantCtx, leadID)
+	if err != nil {
+		t.Fatalf("find all by lead: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 activities, got %d", len(list))
+	}
+	if list[0].ID != second.ID || list[1].ID != first.ID {
+		t.Error("expected newest-first ordering")
+	}
+}
+
+func TestRepository_FindAllByLead_InvisibleLead_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := activity.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	other := seedOrganization(t, ctx, pool)
+	leadInOther := seedLead(t, ctx, pool, other, nil)
+
+	_, err := repo.FindAllByLead(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, leadInOther)
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound for a lead in a different organization, got: %v", err)
+	}
+}
+
+func seedOrganization(t *testing.T, ctx context.Context, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, id); err != nil {
+		t.Fatalf("failed to seed organization: %v", err)
+	}
+	return id
+}
+
+func seedMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, email string, role tenant.Role) uuid.UUID {
+	t.Helper()
+	userID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Test User')`, userID, email); err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+	membershipID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, $4)`, membershipID, org, userID, role); err != nil {
+		t.Fatalf("failed to seed membership: %v", err)
+	}
+	return membershipID
+}
+
+// seedLead inserts a minimal lead row directly via SQL — internal/activity
+// doesn't depend on internal/lead, so its tests build the lead they need
+// with a raw INSERT rather than importing lead.Repository.
+func seedLead(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, assignedTo *uuid.UUID) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	const q = `
+		INSERT INTO leads (id, organization_id, lead_number, name, source, assigned_to_membership_id)
+		VALUES ($1, $2, (SELECT next_lead_number FROM organizations WHERE id = $2), 'Test Lead', 'manual', $3)`
+	if _, err := pool.Exec(ctx, q, id, org, assignedTo); err != nil {
+		t.Fatalf("failed to seed lead: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE organizations SET next_lead_number = next_lead_number + 1 WHERE id = $1`, org); err != nil {
+		t.Fatalf("failed to bump next_lead_number: %v", err)
+	}
+	return id
+}

--- a/crm_be/internal/activity/usecase.go
+++ b/crm_be/internal/activity/usecase.go
@@ -1,0 +1,72 @@
+package activity
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authz"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Usecase depends only on Store (port.go), never on *pgxpool.Pool or
+// pgx.Tx directly (ADR-011).
+type Usecase struct {
+	store Store
+}
+
+func NewUsecase(store Store) *Usecase {
+	return &Usecase{store: store}
+}
+
+// List returns leadID's timeline, newest first. Employee visibility
+// (leads assigned to them only) is enforced in the repository, not
+// here — same split lead itself uses (TD §9).
+func (u *Usecase) List(ctx context.Context, t tenant.Context, leadID uuid.UUID) ([]*Activity, error) {
+	if err := authz.Require(t, authz.ActionActivityList); err != nil {
+		return nil, err
+	}
+	return u.store.Repos().Activity.FindAllByLead(ctx, t, leadID)
+}
+
+// CreateActivityInput is Usecase.Create's argument — Type is validated
+// against the user-submittable allowlist here, before it ever reaches
+// the repository.
+type CreateActivityInput struct {
+	Type     string
+	Body     *string
+	Metadata map[string]any
+}
+
+// Create appends a user-submitted activity (note_added, call_logged,
+// whatsapp_opened only — TD §8). A client submitting a system type
+// (status_changed, lead_created, …) is rejected 422, not 400: this is
+// TD's own error code choice, distinct from a plain validation failure,
+// so it's built as a one-off *httpx.DomainError rather than
+// httpx.NewValidationError (which always maps to 400).
+func (u *Usecase) Create(ctx context.Context, t tenant.Context, leadID uuid.UUID, in CreateActivityInput) (*Activity, error) {
+	if err := authz.Require(t, authz.ActionActivityCreate); err != nil {
+		return nil, err
+	}
+	if !IsUserType(in.Type) {
+		return nil, invalidActivityTypeError()
+	}
+
+	return u.store.Repos().Activity.Create(ctx, t, CreateInput{
+		LeadID:            leadID,
+		Type:              in.Type,
+		ActorMembershipID: t.MembershipID,
+		Body:              in.Body,
+		Metadata:          in.Metadata,
+	})
+}
+
+func invalidActivityTypeError() error {
+	return &httpx.DomainError{
+		Status:  http.StatusUnprocessableEntity,
+		Code:    "invalid_activity_type",
+		Message: "Tipe activity ini hanya bisa dibuat oleh sistem.",
+	}
+}

--- a/crm_be/internal/activity/usecase_unit_test.go
+++ b/crm_be/internal/activity/usecase_unit_test.go
@@ -1,0 +1,141 @@
+package activity_test
+
+// TestUnit_* tests prove Usecase is decoupled from PostgreSQL (ADR-011) —
+// fake Store, no Docker. Run in isolation with:
+//
+//	go test ./internal/activity/... -run TestUnit
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// --- fakes ---
+
+type fakeActivityRepo struct {
+	byLead map[uuid.UUID][]*activity.Activity
+}
+
+func newFakeActivityRepo() *fakeActivityRepo {
+	return &fakeActivityRepo{byLead: map[uuid.UUID][]*activity.Activity{}}
+}
+
+func (f *fakeActivityRepo) Create(_ context.Context, t tenant.Context, in activity.CreateInput) (*activity.Activity, error) {
+	a := &activity.Activity{
+		ID: uuid.Must(uuid.NewV7()), OrganizationID: t.OrganizationID, LeadID: in.LeadID,
+		Type: in.Type, ActorMembershipID: in.ActorMembershipID, Body: in.Body,
+	}
+	f.byLead[in.LeadID] = append(f.byLead[in.LeadID], a)
+	return a, nil
+}
+
+func (f *fakeActivityRepo) FindAllByLead(_ context.Context, _ tenant.Context, leadID uuid.UUID) ([]*activity.Activity, error) {
+	return f.byLead[leadID], nil
+}
+
+type fakeStore struct{ repos activity.Repos }
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{repos: activity.Repos{Activity: newFakeActivityRepo()}}
+}
+
+func (s *fakeStore) InTx(_ context.Context, fn func(activity.Repos) error) error { return fn(s.repos) }
+func (s *fakeStore) Repos() activity.Repos                                       { return s.repos }
+
+func actorContext(role tenant.Role) tenant.Context {
+	membershipID := uuid.Must(uuid.NewV7())
+	return tenant.Context{
+		OrganizationID: uuid.Must(uuid.NewV7()), PrincipalType: tenant.PrincipalUser,
+		MembershipID: &membershipID, Role: role,
+	}
+}
+
+// --- tests ---
+
+func TestUnit_Create_EmployeeAllowed(t *testing.T) {
+	u := activity.NewUsecase(newFakeStore())
+	leadID := uuid.Must(uuid.NewV7())
+
+	_, err := u.Create(context.Background(), actorContext(tenant.RoleEmployee), leadID, activity.CreateActivityInput{Type: "note_added"})
+	if err != nil {
+		t.Fatalf("expected employee to be allowed to create a user activity, got: %v", err)
+	}
+}
+
+func TestUnit_Create_UserTypesAccepted(t *testing.T) {
+	for _, typ := range []string{"note_added", "call_logged", "whatsapp_opened"} {
+		t.Run(typ, func(t *testing.T) {
+			u := activity.NewUsecase(newFakeStore())
+			leadID := uuid.Must(uuid.NewV7())
+
+			created, err := u.Create(context.Background(), actorContext(tenant.RoleOwner), leadID, activity.CreateActivityInput{Type: typ})
+			if err != nil {
+				t.Fatalf("expected %s to be accepted, got: %v", typ, err)
+			}
+			if created.Type != typ {
+				t.Errorf("expected type %s, got %s", typ, created.Type)
+			}
+		})
+	}
+}
+
+func TestUnit_Create_SystemTypesRejected(t *testing.T) {
+	systemTypes := []string{
+		"lead_created", "lead_assigned", "lead_unassigned", "status_changed",
+		"lead_converted", "task_created", "task_completed",
+	}
+	for _, typ := range systemTypes {
+		t.Run(typ, func(t *testing.T) {
+			u := activity.NewUsecase(newFakeStore())
+			leadID := uuid.Must(uuid.NewV7())
+
+			_, err := u.Create(context.Background(), actorContext(tenant.RoleOwner), leadID, activity.CreateActivityInput{Type: typ})
+
+			var derr *httpx.DomainError
+			if !errors.As(err, &derr) || derr.Status != 422 || derr.Code != "invalid_activity_type" {
+				t.Fatalf("expected 422 invalid_activity_type for client-submitted %q, got: %v", typ, err)
+			}
+		})
+	}
+}
+
+func TestUnit_Create_ActorIsCaller(t *testing.T) {
+	u := activity.NewUsecase(newFakeStore())
+	leadID := uuid.Must(uuid.NewV7())
+	actor := actorContext(tenant.RoleOwner)
+
+	created, err := u.Create(context.Background(), actor, leadID, activity.CreateActivityInput{Type: "note_added"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.ActorMembershipID == nil || *created.ActorMembershipID != *actor.MembershipID {
+		t.Errorf("expected actor to be the caller's membership, got %v", created.ActorMembershipID)
+	}
+}
+
+func TestUnit_List_ReturnsLeadTimeline(t *testing.T) {
+	store := newFakeStore()
+	u := activity.NewUsecase(store)
+	leadID := uuid.Must(uuid.NewV7())
+	actor := actorContext(tenant.RoleOwner)
+
+	_, err := u.Create(context.Background(), actor, leadID, activity.CreateActivityInput{Type: "note_added"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	list, err := u.List(context.Background(), actor, leadID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 activity, got %d", len(list))
+	}
+}

--- a/crm_be/internal/lead/handler_test.go
+++ b/crm_be/internal/lead/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/accesstoken"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
@@ -43,10 +44,14 @@ type testStore struct{ pool *pgxpool.Pool }
 func newTestStore(pool *pgxpool.Pool) lead.Store { return &testStore{pool: pool} }
 
 func (s *testStore) InTx(ctx context.Context, fn func(lead.Repos) error) error {
-	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error { return fn(lead.Repos{Lead: lead.New(tx)}) })
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(lead.Repos{Lead: lead.New(tx), Activity: activity.NewRecorder(tx)})
+	})
 }
 
-func (s *testStore) Repos() lead.Repos { return lead.Repos{Lead: lead.New(s.pool)} }
+func (s *testStore) Repos() lead.Repos {
+	return lead.Repos{Lead: lead.New(s.pool), Activity: activity.NewRecorder(s.pool)}
+}
 
 func newTestRouter(t *testing.T) (*gin.Engine, *pgxpool.Pool) {
 	t.Helper()

--- a/crm_be/internal/lead/port.go
+++ b/crm_be/internal/lead/port.go
@@ -25,12 +25,24 @@ type Repository interface {
 	Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error
 }
 
-// Repos bundles what a single Usecase call needs — one field today.
-// #21 adds an Activity field when lead events need cross-table
-// atomicity with activity rows; #20 writes no activities at all (that's
-// explicitly #21's job), so there's nothing to add yet (Rule #27/#28).
+// ActivityRecorder is declared locally per ADR-011 — lead needs only to
+// append a system-generated activity, not activity's full domain type.
+// Structurally identical to task.ActivityRecorder (both declared
+// independently, not shared — three lines, not worth a common package
+// for two call sites) and satisfied by activity.NewRecorder's return
+// value at the composition root, same bridging pattern
+// auth.RefreshTokenRevoker established for membership in #11.
+type ActivityRecorder interface {
+	Record(ctx context.Context, t tenant.Context, leadID uuid.UUID, activityType string, actorMembershipID *uuid.UUID, metadata map[string]any) error
+}
+
+// Repos bundles what a single Usecase call needs. Activity was added in
+// #21 when lead events first needed cross-table atomicity with activity
+// rows (TD §10) — #20 wrote no activities at all, so there was nothing
+// to add before now.
 type Repos struct {
-	Lead Repository
+	Lead     Repository
+	Activity ActivityRecorder
 }
 
 // Store is the Unit of Work Usecase depends on — same shape as every

--- a/crm_be/internal/lead/repository_atomicity_test.go
+++ b/crm_be/internal/lead/repository_atomicity_test.go
@@ -1,0 +1,71 @@
+package lead_test
+
+// TestCreate_ActivityRecordFailureInsideInTx_RollsBackLead is issue
+// #21's atomicity acceptance criterion proven against a REAL
+// transaction, not just usecase_unit_test.go's fake — the fake proves
+// the Go-level wiring returns an error; this proves the database
+// actually rolls back the lead insert alongside it. Same "prove it
+// against real Postgres, not just a fake" discipline as
+// repository_test.go's TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// failingRecorder satisfies lead.ActivityRecorder and always fails —
+// standing in for a real activity write that goes wrong mid-transaction.
+type failingRecorder struct{}
+
+func (failingRecorder) Record(context.Context, tenant.Context, uuid.UUID, string, *uuid.UUID, map[string]any) error {
+	return errors.New("simulated activity recording failure")
+}
+
+func TestCreate_ActivityRecordFailureInsideInTx_RollsBackLead(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	org := seedOrganization(t, ctx, pool)
+	tenantCtx := tenant.Context{OrganizationID: org}
+
+	txErr := db.InTx(ctx, pool, func(tx pgx.Tx) error {
+		r := lead.Repos{Lead: lead.New(tx), Activity: failingRecorder{}}
+		created, err := r.Lead.Create(ctx, tenantCtx, minimalInput("Should Roll Back"))
+		if err != nil {
+			return err
+		}
+		return r.Activity.Record(ctx, tenantCtx, created.ID, "lead_created", nil, nil)
+	})
+	if txErr == nil {
+		t.Fatal("expected the activity recording failure to abort the transaction")
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM leads WHERE organization_id = $1`, org).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected the lead insert to be rolled back alongside the failed activity, but found %d rows", count)
+	}
+
+	// The allocated lead_number must not be burned either — same
+	// no-gaps guarantee TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber
+	// proves for an INSERT failure; this proves it for an activity
+	// failure too, since both share the same db.InTx boundary.
+	repo := lead.New(pool)
+	next, err := repo.Create(ctx, tenantCtx, minimalInput("Should Get Number 1"))
+	if err != nil {
+		t.Fatalf("create after rollback: %v", err)
+	}
+	if next.LeadNumber != 1 {
+		t.Errorf("expected lead_number 1 (rolled-back attempt should leave no gap), got %d", next.LeadNumber)
+	}
+}

--- a/crm_be/internal/lead/usecase.go
+++ b/crm_be/internal/lead/usecase.go
@@ -77,7 +77,11 @@ func (u *Usecase) Create(ctx context.Context, t tenant.Context, in CreateLeadInp
 			return err
 		}
 		created = c
-		return nil
+		// lead_created is written in the SAME transaction as the row
+		// itself (TD §10) — a lead that exists without this activity,
+		// or an activity for a lead that got rolled back, are both
+		// worse than neither existing.
+		return r.Activity.Record(ctx, t, c.ID, "lead_created", repoIn.CreatedByMembershipID, nil)
 	})
 	if txErr != nil {
 		if errors.Is(txErr, ErrIdempotencyKeyExists) {
@@ -185,37 +189,64 @@ func (u *Usecase) Update(ctx context.Context, t tenant.Context, id uuid.UUID, in
 // UpdateStatus validates the transition (TD §5) before touching the
 // database — loading the current lead first is what makes that possible
 // (transition validity depends on the FROM status, which the client's
-// requested Version alone doesn't tell us).
+// requested Version alone doesn't tell us). The whole thing — load,
+// validate, update, record status_changed — runs inside one
+// store.InTx: TD §10 requires the activity to be atomic with the status
+// change it describes, so this can no longer read the current lead via
+// a plain store.Repos() call the way #20 originally wrote it.
 func (u *Usecase) UpdateStatus(ctx context.Context, t tenant.Context, id uuid.UUID, in UpdateStatusInput) (*Lead, error) {
 	if err := authz.Require(t, authz.ActionLeadUpdate); err != nil {
 		return nil, err
 	}
 
-	current, err := u.store.Repos().Lead.FindByID(ctx, t, id)
-	if err != nil {
-		return nil, err
-	}
-
-	if !validateStatusTransition(current.Status, in.Status) {
-		return nil, invalidStatusTransitionError()
-	}
-
-	var lostReason *string
-	if in.Status == StatusLost {
-		if in.LostReason == nil || *in.LostReason == "" {
-			return nil, httpx.NewValidationError(httpx.ErrorDetail{Field: "lost_reason", Code: "required"})
+	var updated *Lead
+	var conflict bool
+	txErr := u.store.InTx(ctx, func(r Repos) error {
+		current, err := r.Lead.FindByID(ctx, t, id)
+		if err != nil {
+			return err
 		}
-		lostReason = in.LostReason
-	}
-	// Leaving lost (or any non-lost destination) always clears
-	// lost_reason, regardless of what the client sent — TD §5.
+		// Captured now, not read from current after UpdateStatus runs:
+		// current may be the same backing struct a subsequent call
+		// mutates in place (true of the in-memory test fake; not
+		// something the real Postgres repository does, but nothing here
+		// should depend on that).
+		fromStatus := current.Status
 
-	updated, err := u.store.Repos().Lead.UpdateStatus(ctx, t, id, in.Version, in.Status, lostReason)
-	if errors.Is(err, ErrVersionConflict) {
+		if !validateStatusTransition(fromStatus, in.Status) {
+			return invalidStatusTransitionError()
+		}
+
+		var lostReason *string
+		if in.Status == StatusLost {
+			if in.LostReason == nil || *in.LostReason == "" {
+				return httpx.NewValidationError(httpx.ErrorDetail{Field: "lost_reason", Code: "required"})
+			}
+			lostReason = in.LostReason
+		}
+		// Leaving lost (or any non-lost destination) always clears
+		// lost_reason, regardless of what the client sent — TD §5.
+
+		result, err := r.Lead.UpdateStatus(ctx, t, id, in.Version, in.Status, lostReason)
+		if errors.Is(err, ErrVersionConflict) {
+			updated = result
+			conflict = true
+			return ErrVersionConflict
+		}
+		if err != nil {
+			return err
+		}
+		updated = result
+
+		return r.Activity.Record(ctx, t, id, "status_changed", t.MembershipID, map[string]any{
+			"from": fromStatus, "to": in.Status,
+		})
+	})
+	if conflict {
 		return nil, &VersionConflictError{Current: updated}
 	}
-	if err != nil {
-		return nil, err
+	if txErr != nil {
+		return nil, txErr
 	}
 	return updated, nil
 }

--- a/crm_be/internal/lead/usecase_unit_test.go
+++ b/crm_be/internal/lead/usecase_unit_test.go
@@ -119,10 +119,47 @@ func (f *fakeLeadRepo) Delete(_ context.Context, t tenant.Context, id uuid.UUID)
 	return nil
 }
 
-type fakeStore struct{ repos lead.Repos }
+// recordedActivity captures one fakeActivityRecorder.Record call.
+type recordedActivity struct {
+	leadID            uuid.UUID
+	activityType      string
+	actorMembershipID *uuid.UUID
+	metadata          map[string]any
+}
+
+// fakeActivityRecorder lets tests assert Create/UpdateStatus call
+// Record with the right arguments, and that a Record failure
+// propagates as an error from the whole InTx call (the wiring half of
+// the atomicity acceptance criterion — the other half, that a real
+// Postgres transaction actually rolls back, is proven separately in
+// repository_test.go against a live database).
+type fakeActivityRecorder struct {
+	calls []recordedActivity
+	err   error
+}
+
+func (f *fakeActivityRecorder) Record(_ context.Context, _ tenant.Context, leadID uuid.UUID, activityType string, actorMembershipID *uuid.UUID, metadata map[string]any) error {
+	f.calls = append(f.calls, recordedActivity{leadID, activityType, actorMembershipID, metadata})
+	return f.err
+}
+
+type fakeStore struct {
+	repos    lead.Repos
+	activity *fakeActivityRecorder
+}
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{repos: lead.Repos{Lead: newFakeLeadRepo()}}
+	rec := &fakeActivityRecorder{}
+	return &fakeStore{repos: lead.Repos{Lead: newFakeLeadRepo(), Activity: rec}, activity: rec}
+}
+
+// newFakeStoreWithFailingActivity is newFakeStore, but Activity.Record
+// always fails — used to prove a recording failure aborts the whole
+// operation instead of silently succeeding with no activity written.
+func newFakeStoreWithFailingActivity() *fakeStore {
+	s := newFakeStore()
+	s.activity.err = errors.New("activity: record failed")
+	return s
 }
 
 func (s *fakeStore) InTx(_ context.Context, fn func(lead.Repos) error) error { return fn(s.repos) }
@@ -423,5 +460,77 @@ func TestUnit_UpdateStatus_UnqualifiedIsFinal(t *testing.T) {
 	var derr *httpx.DomainError
 	if !errors.As(err, &derr) || derr.Code != "invalid_status_transition" {
 		t.Fatalf("expected unqualified to be final (invalid_status_transition), got: %v", err)
+	}
+}
+
+// --- auto-log tests (TD §10) ---
+
+func TestUnit_Create_RecordsLeadCreatedActivity(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+
+	created, _, err := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if len(store.activity.calls) != 1 {
+		t.Fatalf("expected exactly one activity recorded, got %d", len(store.activity.calls))
+	}
+	got := store.activity.calls[0]
+	if got.leadID != created.ID {
+		t.Errorf("expected activity leadID %v, got %v", created.ID, got.leadID)
+	}
+	if got.activityType != "lead_created" {
+		t.Errorf("expected activity type lead_created, got %q", got.activityType)
+	}
+}
+
+func TestUnit_Create_ActivityRecordFailure_PropagatesError(t *testing.T) {
+	store := newFakeStoreWithFailingActivity()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+
+	_, _, err := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+	if err == nil {
+		t.Fatal("expected Create to fail when recording the activity fails")
+	}
+}
+
+func TestUnit_UpdateStatus_RecordsStatusChangedActivityWithFromTo(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+	store.activity.calls = nil // drop the lead_created call from Create
+
+	_, err := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: created.Version, Status: "contacted"})
+	if err != nil {
+		t.Fatalf("update status: %v", err)
+	}
+
+	if len(store.activity.calls) != 1 {
+		t.Fatalf("expected exactly one activity recorded, got %d", len(store.activity.calls))
+	}
+	got := store.activity.calls[0]
+	if got.activityType != "status_changed" {
+		t.Errorf("expected activity type status_changed, got %q", got.activityType)
+	}
+	if got.metadata["from"] != "new" || got.metadata["to"] != "contacted" {
+		t.Errorf("expected metadata {from: new, to: contacted}, got %v", got.metadata)
+	}
+}
+
+func TestUnit_UpdateStatus_ActivityRecordFailure_PropagatesError(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+
+	store.activity.err = errors.New("activity: record failed")
+	_, err := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: created.Version, Status: "contacted"})
+	if err == nil {
+		t.Fatal("expected UpdateStatus to fail when recording the activity fails")
 	}
 }

--- a/crm_be/internal/shared/authz/authz.go
+++ b/crm_be/internal/shared/authz/authz.go
@@ -44,6 +44,26 @@ const (
 	ActionLeadRead   Action = "lead.read"
 	ActionLeadUpdate Action = "lead.update"
 	ActionLeadDelete Action = "lead.delete"
+
+	// Activity and task actions cover only what issue #21 ships.
+	// Employee access is further restricted in the repository to leads
+	// assigned to them (and, for task, to tasks on those leads) — same
+	// split as lead's own read/update.
+	ActionActivityCreate Action = "activity.create"
+	ActionActivityList   Action = "activity.list"
+	ActionTaskCreate     Action = "task.create"
+	// ActionTaskRead has no dedicated row in TD §9's matrix — it's added
+	// here with the same permissions as task.create/update/complete
+	// (all four roles) so GET /v1/tasks and GET /v1/leads/{id}/tasks
+	// have an explicit gate instead of reusing ActionTaskCreate for
+	// reads, mirroring activity.list existing alongside activity.create.
+	ActionTaskRead     Action = "task.read"
+	ActionTaskUpdate   Action = "task.update"
+	ActionTaskComplete Action = "task.complete"
+	// ActionTaskDelete is the one action in this issue Employee does
+	// NOT get, even repo-restricted — TD §9's matrix draws that line
+	// explicitly.
+	ActionTaskDelete Action = "task.delete"
 )
 
 // permissions mirrors docs/architecture/authorization.md's matrix
@@ -61,6 +81,13 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionLeadRead:             true,
 		ActionLeadUpdate:           true,
 		ActionLeadDelete:           true,
+		ActionActivityCreate:       true,
+		ActionActivityList:         true,
+		ActionTaskCreate:           true,
+		ActionTaskRead:             true,
+		ActionTaskUpdate:           true,
+		ActionTaskComplete:         true,
+		ActionTaskDelete:           true,
 	},
 	tenant.RoleAdmin: {
 		ActionMembershipList:       true,
@@ -73,6 +100,13 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionLeadRead:             true,
 		ActionLeadUpdate:           true,
 		ActionLeadDelete:           true,
+		ActionActivityCreate:       true,
+		ActionActivityList:         true,
+		ActionTaskCreate:           true,
+		ActionTaskRead:             true,
+		ActionTaskUpdate:           true,
+		ActionTaskComplete:         true,
+		ActionTaskDelete:           true,
 	},
 	tenant.RoleManager: {
 		ActionMembershipList: true,
@@ -81,12 +115,27 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionLeadUpdate:     true,
 		// ActionLeadDelete deliberately absent — matrix gives delete to
 		// Owner/Admin only.
+		ActionActivityCreate: true,
+		ActionActivityList:   true,
+		ActionTaskCreate:     true,
+		ActionTaskRead:       true,
+		ActionTaskUpdate:     true,
+		ActionTaskComplete:   true,
+		ActionTaskDelete:     true,
 	},
 	tenant.RoleEmployee: {
 		// Read/update granted here; the repository further restricts
 		// both to leads assigned to this employee.
-		ActionLeadRead:   true,
-		ActionLeadUpdate: true,
+		ActionLeadRead:       true,
+		ActionLeadUpdate:     true,
+		ActionActivityCreate: true,
+		ActionActivityList:   true,
+		ActionTaskCreate:     true,
+		ActionTaskRead:       true,
+		ActionTaskUpdate:     true,
+		ActionTaskComplete:   true,
+		// ActionTaskDelete deliberately absent — TD §9's matrix denies
+		// Employee this one, unlike every other activity/task action.
 	},
 }
 

--- a/crm_be/internal/shared/authz/authz_test.go
+++ b/crm_be/internal/shared/authz/authz_test.go
@@ -25,6 +25,13 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleOwner, authz.ActionLeadRead, true},
 		{tenant.RoleOwner, authz.ActionLeadUpdate, true},
 		{tenant.RoleOwner, authz.ActionLeadDelete, true},
+		{tenant.RoleOwner, authz.ActionActivityCreate, true},
+		{tenant.RoleOwner, authz.ActionActivityList, true},
+		{tenant.RoleOwner, authz.ActionTaskCreate, true},
+		{tenant.RoleOwner, authz.ActionTaskRead, true},
+		{tenant.RoleOwner, authz.ActionTaskUpdate, true},
+		{tenant.RoleOwner, authz.ActionTaskComplete, true},
+		{tenant.RoleOwner, authz.ActionTaskDelete, true},
 
 		{tenant.RoleAdmin, authz.ActionMembershipList, true},
 		{tenant.RoleAdmin, authz.ActionMembershipUpdateRole, true},
@@ -36,6 +43,13 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleAdmin, authz.ActionLeadRead, true},
 		{tenant.RoleAdmin, authz.ActionLeadUpdate, true},
 		{tenant.RoleAdmin, authz.ActionLeadDelete, true},
+		{tenant.RoleAdmin, authz.ActionActivityCreate, true},
+		{tenant.RoleAdmin, authz.ActionActivityList, true},
+		{tenant.RoleAdmin, authz.ActionTaskCreate, true},
+		{tenant.RoleAdmin, authz.ActionTaskRead, true},
+		{tenant.RoleAdmin, authz.ActionTaskUpdate, true},
+		{tenant.RoleAdmin, authz.ActionTaskComplete, true},
+		{tenant.RoleAdmin, authz.ActionTaskDelete, true},
 
 		{tenant.RoleManager, authz.ActionMembershipList, true},
 		{tenant.RoleManager, authz.ActionMembershipUpdateRole, false},
@@ -47,6 +61,13 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleManager, authz.ActionLeadRead, true},
 		{tenant.RoleManager, authz.ActionLeadUpdate, true},
 		{tenant.RoleManager, authz.ActionLeadDelete, false},
+		{tenant.RoleManager, authz.ActionActivityCreate, true},
+		{tenant.RoleManager, authz.ActionActivityList, true},
+		{tenant.RoleManager, authz.ActionTaskCreate, true},
+		{tenant.RoleManager, authz.ActionTaskRead, true},
+		{tenant.RoleManager, authz.ActionTaskUpdate, true},
+		{tenant.RoleManager, authz.ActionTaskComplete, true},
+		{tenant.RoleManager, authz.ActionTaskDelete, true},
 
 		{tenant.RoleEmployee, authz.ActionMembershipList, false},
 		{tenant.RoleEmployee, authz.ActionMembershipUpdateRole, false},
@@ -58,6 +79,13 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleEmployee, authz.ActionLeadRead, true}, // repository further restricts to own leads
 		{tenant.RoleEmployee, authz.ActionLeadUpdate, true},
 		{tenant.RoleEmployee, authz.ActionLeadDelete, false},
+		{tenant.RoleEmployee, authz.ActionActivityCreate, true}, // repository further restricts to own leads
+		{tenant.RoleEmployee, authz.ActionActivityList, true},
+		{tenant.RoleEmployee, authz.ActionTaskCreate, true},
+		{tenant.RoleEmployee, authz.ActionTaskRead, true},
+		{tenant.RoleEmployee, authz.ActionTaskUpdate, true},
+		{tenant.RoleEmployee, authz.ActionTaskComplete, true},
+		{tenant.RoleEmployee, authz.ActionTaskDelete, false}, // the one action Employee never gets
 	}
 
 	for _, c := range cases {

--- a/crm_be/internal/task/entity.go
+++ b/crm_be/internal/task/entity.go
@@ -1,0 +1,93 @@
+// Package task is CRM Core's follow-up entity — always attached to a
+// lead (lead_id NOT NULL, decision B8). See
+// docs/phases/02-crm-core/td.md §1.4, §8, §10.
+package task
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Task struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+	LeadID         uuid.UUID
+
+	Title       string
+	Description *string
+	DueAt       *time.Time
+	Status      string
+
+	AssignedToMembershipID  *uuid.UUID
+	CompletedAt             *time.Time
+	CompletedByMembershipID *uuid.UUID
+
+	Version               int
+	CreatedByMembershipID *uuid.UUID
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+	DeletedAt             *time.Time
+}
+
+const (
+	StatusOpen = "open"
+	StatusDone = "done"
+)
+
+// CreateInput is Repository.Create's argument — no validation here;
+// that's the usecase's job.
+type CreateInput struct {
+	LeadID                 uuid.UUID
+	Title                  string
+	Description            *string
+	DueAt                  *time.Time
+	AssignedToMembershipID *uuid.UUID
+	CreatedByMembershipID  *uuid.UUID
+}
+
+// UpdateInput is the mutable-field subset PATCH /v1/tasks/{id} exposes —
+// nil means "don't touch", same limitation lead.UpdateInput already
+// documents: this minimal shape has no way to clear a field to NULL.
+type UpdateInput struct {
+	Title                  *string
+	Description            *string
+	DueAt                  *time.Time
+	AssignedToMembershipID *uuid.UUID
+}
+
+// ListFilter is FindAllByOrg's argument — org-wide, paginated (GET
+// /v1/tasks). GET /v1/leads/{id}/tasks is a separate repository method,
+// FindAllByLead, not a LeadID field here — it needs an explicit
+// lead-visibility check (404 when the lead isn't visible), not a filter
+// that would just quietly narrow the result set to empty (TD §8's
+// acceptance criteria: reading a sub-resource of a lead you can't see
+// is a 404).
+type ListFilter struct {
+	AssignedTo *uuid.UUID
+	Status     []string
+	DueBefore  *time.Time
+	Page       int
+	PerPage    int
+}
+
+// ErrVersionConflict is what Update/Complete return — alongside the
+// row's CURRENT state — when expectedVersion no longer matches. Same
+// shape as lead.ErrVersionConflict.
+var ErrVersionConflict = errors.New("task: version conflict")
+
+// ErrAssigneeNotFound mirrors lead.ErrAssigneeNotFound — detected via
+// the fk_tasks_assignee foreign-key violation, same
+// database-constraint-as-source-of-truth pattern. Included proactively
+// since it's the identical shape of bug #20 already found once for
+// leads, not a speculative addition.
+var ErrAssigneeNotFound = errors.New("task: assignee not found")
+
+// VersionConflictError carries the row's current state — same pattern
+// as lead.VersionConflictError.
+type VersionConflictError struct {
+	Current *Task
+}
+
+func (e *VersionConflictError) Error() string { return "version conflict" }

--- a/crm_be/internal/task/handler_http.go
+++ b/crm_be/internal/task/handler_http.go
@@ -1,0 +1,261 @@
+package task
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+)
+
+type Handler struct {
+	usecase *Usecase
+}
+
+func NewHandler(usecase *Usecase) *Handler {
+	return &Handler{usecase: usecase}
+}
+
+// RegisterRoutes mounts two groups: a lead-scoped one sharing
+// /v1/leads' :id wildcard (same discipline as activity.Handler — gin
+// requires the same wildcard NAME wherever paths share a prefix), and
+// task's own /v1/tasks resource group.
+func (h *Handler) RegisterRoutes(r gin.IRouter, authMW gin.HandlerFunc) {
+	leads := r.Group("/v1/leads")
+	leads.Use(authMW)
+	leads.POST("/:id/tasks", h.create)
+	leads.GET("/:id/tasks", h.listByLead)
+
+	tasks := r.Group("/v1/tasks")
+	tasks.Use(authMW)
+	tasks.GET("", h.listByOrg)
+	tasks.PATCH("/:id", h.update)
+	tasks.POST("/:id/complete", h.complete)
+	tasks.DELETE("/:id", h.delete)
+}
+
+type createRequest struct {
+	Title                  string     `json:"title"`
+	Description            *string    `json:"description"`
+	DueAt                  *time.Time `json:"due_at"`
+	AssignedToMembershipID *string    `json:"assigned_to_membership_id"`
+}
+
+func (h *Handler) create(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	leadID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	var req createRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	in := CreateTaskInput{Title: req.Title, Description: req.Description, DueAt: req.DueAt}
+	if assignee, err := parseUUIDPtr(req.AssignedToMembershipID); err == nil {
+		in.AssignedToMembershipID = assignee
+	}
+
+	created, err := h.usecase.Create(c.Request.Context(), t, leadID, in)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusCreated, taskJSON(created))
+}
+
+func (h *Handler) listByLead(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	leadID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	tasks, err := h.usecase.ListByLead(c.Request.Context(), t, leadID)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+
+	out := make([]gin.H, 0, len(tasks))
+	for _, tsk := range tasks {
+		out = append(out, taskJSON(tsk))
+	}
+	httpx.OK(c, http.StatusOK, out)
+}
+
+func (h *Handler) listByOrg(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	in := ListTasksInput{Status: splitCSV(c.Query("status"))}
+	if assignedTo := c.Query("assigned_to"); assignedTo != "" {
+		if id, err := uuid.Parse(assignedTo); err == nil {
+			in.AssignedTo = &id
+		}
+	}
+	if due, err := time.Parse(time.RFC3339, c.Query("due_before")); err == nil {
+		in.DueBefore = &due
+	}
+	if page, err := strconv.Atoi(c.Query("page")); err == nil {
+		in.Page = page
+	}
+	if perPage, err := strconv.Atoi(c.Query("per_page")); err == nil {
+		in.PerPage = perPage
+	}
+
+	tasks, meta, err := h.usecase.ListByOrg(c.Request.Context(), t, in)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+
+	out := make([]gin.H, 0, len(tasks))
+	for _, tsk := range tasks {
+		out = append(out, taskJSON(tsk))
+	}
+	httpx.List(c, out, meta)
+}
+
+type updateRequest struct {
+	Version                int        `json:"version"`
+	Title                  *string    `json:"title"`
+	Description            *string    `json:"description"`
+	DueAt                  *time.Time `json:"due_at"`
+	AssignedToMembershipID *string    `json:"assigned_to_membership_id"`
+}
+
+func (h *Handler) update(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	var req updateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	in := UpdateTaskInput{Version: req.Version, Title: req.Title, Description: req.Description, DueAt: req.DueAt}
+	if assignee, err := parseUUIDPtr(req.AssignedToMembershipID); err == nil {
+		in.AssignedToMembershipID = assignee
+	}
+
+	updated, err := h.usecase.Update(c.Request.Context(), t, id, in)
+	if err != nil {
+		respondTaskError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusOK, taskJSON(updated))
+}
+
+type completeRequest struct {
+	Version int `json:"version"`
+}
+
+func (h *Handler) complete(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	var req completeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	completed, err := h.usecase.Complete(c.Request.Context(), t, id, req.Version)
+	if err != nil {
+		respondTaskError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusOK, taskJSON(completed))
+}
+
+func (h *Handler) delete(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	if err := h.usecase.Delete(c.Request.Context(), t, id); err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// respondTaskError type-switches for *VersionConflictError before
+// falling through to the generic mapper — same pattern as lead's
+// respondLeadError.
+func respondTaskError(c *gin.Context, err error) {
+	var conflict *VersionConflictError
+	if errors.As(err, &conflict) {
+		c.JSON(http.StatusConflict, gin.H{"error": gin.H{
+			"code":    "version_conflict",
+			"message": "Data sudah diubah oleh orang lain. Muat ulang dan coba lagi.",
+			"current": taskJSON(conflict.Current),
+		}})
+		return
+	}
+	httpx.WriteError(c, err)
+}
+
+func taskJSON(tsk *Task) gin.H {
+	return gin.H{
+		"id":                         tsk.ID,
+		"lead_id":                    tsk.LeadID,
+		"title":                      tsk.Title,
+		"description":                tsk.Description,
+		"due_at":                     tsk.DueAt,
+		"status":                     tsk.Status,
+		"assigned_to_membership_id":  tsk.AssignedToMembershipID,
+		"completed_at":               tsk.CompletedAt,
+		"completed_by_membership_id": tsk.CompletedByMembershipID,
+		"version":                    tsk.Version,
+		"created_by_membership_id":   tsk.CreatedByMembershipID,
+		"created_at":                 tsk.CreatedAt,
+		"updated_at":                 tsk.UpdatedAt,
+	}
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, ",")
+}
+
+func parseUUIDPtr(s *string) (*uuid.UUID, error) {
+	if s == nil || *s == "" {
+		return nil, nil
+	}
+	id, err := uuid.Parse(*s)
+	if err != nil {
+		return nil, err
+	}
+	return &id, nil
+}

--- a/crm_be/internal/task/handler_test.go
+++ b/crm_be/internal/task/handler_test.go
@@ -1,0 +1,240 @@
+package task_test
+
+// Integration tests (real Postgres via dbtest) for issue #21's task
+// HTTP layer.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/accesstoken"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/task"
+)
+
+const testJWTSecret = "task-handler-test-jwt-secret-32-bytes" // #nosec G101 -- test-only value, not a real credential
+
+type testClaimsParser struct{}
+
+func (testClaimsParser) ParseAccessToken(raw string) (*accesstoken.Claims, error) {
+	return accesstoken.Parse([]byte(testJWTSecret), raw)
+}
+
+type testStore struct{ pool *pgxpool.Pool }
+
+func newTestStore(pool *pgxpool.Pool) task.Store { return &testStore{pool: pool} }
+
+func (s *testStore) InTx(ctx context.Context, fn func(task.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(task.Repos{Task: task.New(tx), Activity: activity.NewRecorder(tx)})
+	})
+}
+
+func (s *testStore) Repos() task.Repos {
+	return task.Repos{Task: task.New(s.pool), Activity: activity.NewRecorder(s.pool)}
+}
+
+func newTestRouter(t *testing.T) (*gin.Engine, *pgxpool.Pool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pool := dbtest.NewPool(t)
+	u := task.NewUsecase(newTestStore(pool))
+
+	r := gin.New()
+	task.NewHandler(u).RegisterRoutes(r, authn.Middleware(testClaimsParser{}))
+	return r, pool
+}
+
+func bearerToken(t *testing.T, userID, orgID, membershipID uuid.UUID, role tenant.Role) string {
+	t.Helper()
+	tok, err := accesstoken.Issue([]byte(testJWTSecret), 15*time.Minute, userID, orgID, membershipID, role)
+	if err != nil {
+		t.Fatalf("mint access token: %v", err)
+	}
+	return tok
+}
+
+func doJSON(r *gin.Engine, method, path, bearer string, body any) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(method, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func seedOrgAndOwner(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (org, user, membership uuid.UUID) {
+	t.Helper()
+	org = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, org); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	user = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Owner')`, user, user.String()+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	membership = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'owner')`, membership, org, user); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	return org, user, membership
+}
+
+func extractIDAndVersion(t *testing.T, w *httptest.ResponseRecorder) (string, int) {
+	t.Helper()
+	var body struct {
+		Data struct {
+			ID      string `json:"id"`
+			Version int    `json:"version"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Data.ID, body.Data.Version
+}
+
+func TestHandler_Create_RecordsTaskCreatedActivity(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil)
+
+	w := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/tasks", token, map[string]string{"title": "Follow up"})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM activities WHERE lead_id = $1 AND type = 'task_created'`, leadID).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 task_created activity, got %d", count)
+	}
+}
+
+func TestHandler_Complete_SetsFieldsAndRecordsTaskCompleted(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/tasks", token, map[string]string{"title": "Follow up"})
+	id, version := extractIDAndVersion(t, created)
+
+	w := doJSON(r, http.MethodPost, "/v1/tasks/"+id+"/complete", token, map[string]int{"version": version})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Data struct {
+			Status                  string  `json:"status"`
+			CompletedAt             *string `json:"completed_at"`
+			CompletedByMembershipID *string `json:"completed_by_membership_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.Status != "done" {
+		t.Errorf("expected status done, got %q", body.Data.Status)
+	}
+	if body.Data.CompletedAt == nil {
+		t.Error("expected completed_at to be set")
+	}
+	if body.Data.CompletedByMembershipID == nil || *body.Data.CompletedByMembershipID != membershipID.String() {
+		t.Errorf("expected completed_by %v, got %v", membershipID, body.Data.CompletedByMembershipID)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM activities WHERE lead_id = $1 AND type = 'task_completed'`, leadID).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 task_completed activity, got %d", count)
+	}
+}
+
+func TestHandler_Update_StaleVersion_Returns409(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/tasks", token, map[string]string{"title": "Follow up"})
+	id, version := extractIDAndVersion(t, created)
+
+	w := doJSON(r, http.MethodPatch, "/v1/tasks/"+id, token, map[string]any{"version": version - 1, "title": "Stale"})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Employee_ReadTaskOnAnotherEmployeesLead_Returns404(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, ownerUser, ownerMembership := seedOrgAndOwner(t, ctx, pool)
+	ownerToken := bearerToken(t, ownerUser, org, ownerMembership, tenant.RoleOwner)
+
+	otherEmployeeUser := uuid.Must(uuid.NewV7())
+	otherEmployeeMembership := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Employee')`, otherEmployeeUser, otherEmployeeUser.String()+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'employee')`, otherEmployeeMembership, org, otherEmployeeUser); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	leadID := seedLead(t, ctx, pool, org, &otherEmployeeMembership)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/tasks", ownerToken, map[string]string{"title": "Follow up"})
+	if created.Code != http.StatusCreated {
+		t.Fatalf("seed create failed: %d: %s", created.Code, created.Body.String())
+	}
+
+	me := uuid.Must(uuid.NewV7())
+	myToken := bearerToken(t, me, org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	w := doJSON(r, http.MethodGet, "/v1/leads/"+leadID.String()+"/tasks", myToken, nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Employee_DeleteForbidden(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, ownerUser, ownerMembership := seedOrgAndOwner(t, ctx, pool)
+	ownerToken := bearerToken(t, ownerUser, org, ownerMembership, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/tasks", ownerToken, map[string]string{"title": "Follow up"})
+	id, _ := extractIDAndVersion(t, created)
+
+	employeeToken := bearerToken(t, uuid.Must(uuid.NewV7()), org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+	w := doJSON(r, http.MethodDelete, "/v1/tasks/"+id, employeeToken, nil)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/crm_be/internal/task/port.go
+++ b/crm_be/internal/task/port.go
@@ -1,0 +1,46 @@
+package task
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Repository is task's own table interface — postgresRepository
+// (repository_postgres.go) satisfies it, but Usecase depends only on
+// this interface (ADR-011).
+type Repository interface {
+	Create(ctx context.Context, t tenant.Context, in CreateInput) (*Task, error)
+	FindByID(ctx context.Context, t tenant.Context, id uuid.UUID) (*Task, error)
+	FindAllByOrg(ctx context.Context, t tenant.Context, filter ListFilter) ([]*Task, int, error)
+	FindAllByLead(ctx context.Context, t tenant.Context, leadID uuid.UUID) ([]*Task, error)
+	Update(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, in UpdateInput) (*Task, error)
+	Complete(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, completedByMembershipID *uuid.UUID) (*Task, error)
+	Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error
+}
+
+// ActivityRecorder is declared locally per ADR-011 — task needs only to
+// append a system-generated activity, not activity's full domain type.
+// Structurally identical to lead.ActivityRecorder (both declared
+// independently, not shared — three lines, not worth a common package
+// for two call sites) and satisfied by activity.NewRecorder's return
+// value at the composition root.
+type ActivityRecorder interface {
+	Record(ctx context.Context, t tenant.Context, leadID uuid.UUID, activityType string, actorMembershipID *uuid.UUID, metadata map[string]any) error
+}
+
+// Repos bundles what a single Usecase call needs.
+type Repos struct {
+	Task     Repository
+	Activity ActivityRecorder
+}
+
+// Store is the Unit of Work Usecase depends on — required because
+// Create and Complete each write a task row and an activity row
+// atomically (TD §10).
+type Store interface {
+	InTx(ctx context.Context, fn func(Repos) error) error
+	Repos() Repos
+}

--- a/crm_be/internal/task/repository_postgres.go
+++ b/crm_be/internal/task/repository_postgres.go
@@ -1,0 +1,346 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const assigneeFKConstraint = "fk_tasks_assignee"
+
+type postgresRepository struct {
+	q db.Querier
+}
+
+func New(q db.Querier) Repository {
+	return &postgresRepository{q: q}
+}
+
+// Create inserts a task, but only if leadID is visible to t — same
+// tenant+employee visibility rule as activity.Create, expressed the
+// same way (WHERE EXISTS against leads, no cross-package call). Zero
+// rows (lead not visible) → httpx.ErrNotFound. A bad
+// assigned_to_membership_id violates fk_tasks_assignee (23503),
+// detected the same way lead.Create detects fk_leads_assignee since
+// #20 — proactive, not speculative: it's the identical shape of bug
+// already found once.
+func (r *postgresRepository) Create(ctx context.Context, t tenant.Context, in CreateInput) (*Task, error) {
+	const q = `
+		INSERT INTO tasks (
+			id, organization_id, lead_id, title, description, due_at,
+			assigned_to_membership_id, created_by_membership_id
+		)
+		SELECT $1, $2, $3, $4, $5, $6, $7, $8
+		WHERE EXISTS (
+			SELECT 1 FROM leads
+			WHERE id = $3 AND organization_id = $2 AND deleted_at IS NULL
+			  AND (NOT $9 OR assigned_to_membership_id = $10)
+		)
+		RETURNING ` + taskColumns
+
+	id := uuid.Must(uuid.NewV7())
+	row := r.q.QueryRow(ctx, q,
+		id, t.OrganizationID, in.LeadID, in.Title, in.Description, in.DueAt,
+		in.AssignedToMembershipID, in.CreatedByMembershipID,
+		isEmployee(t), membershipIDOrNil(t),
+	)
+	created, err := scanTask(row)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" && pgErr.ConstraintName == assigneeFKConstraint {
+			return nil, ErrAssigneeNotFound
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, httpx.ErrNotFound
+		}
+		return nil, fmt.Errorf("task: create: %w", err)
+	}
+	return created, nil
+}
+
+// FindByID is tenant-scoped (Rule #6) and, for an employee, further
+// scoped through the LEAD's assignment, not the task's own — TD §9:
+// "task pada lead miliknya", not "task yang di-assign ke saya". A task
+// can be assigned to a colleague on a lead you own and you must still
+// see it; a task on someone else's lead must stay invisible even if
+// it's assigned to you.
+func (r *postgresRepository) FindByID(ctx context.Context, t tenant.Context, id uuid.UUID) (*Task, error) {
+	const q = `
+		SELECT ` + taskColumns + `
+		FROM tasks
+		WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
+		  AND (NOT $3 OR EXISTS (
+		      SELECT 1 FROM leads l WHERE l.id = tasks.lead_id AND l.organization_id = $2
+		        AND l.assigned_to_membership_id = $4
+		  ))`
+
+	row := r.q.QueryRow(ctx, q, id, t.OrganizationID, isEmployee(t), membershipIDOrNil(t))
+	found, err := scanTask(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, httpx.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("task: find by id: %w", err)
+	}
+	return found, nil
+}
+
+// FindAllByOrg is GET /v1/tasks's backing query — org-wide, paginated.
+func (r *postgresRepository) FindAllByOrg(ctx context.Context, t tenant.Context, filter ListFilter) ([]*Task, int, error) {
+	where, args := buildTaskWhere(t, filter)
+
+	var total int
+	countQ := "SELECT count(*) FROM tasks WHERE " + where
+	if err := r.q.QueryRow(ctx, countQ, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("task: count: %w", err)
+	}
+
+	arg := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
+	}
+	perPage := filter.PerPage
+	offset := (filter.Page - 1) * perPage
+	listQ := "SELECT " + taskColumns + " FROM tasks WHERE " + where +
+		" ORDER BY created_at DESC LIMIT " + arg(perPage) + " OFFSET " + arg(offset)
+
+	rows, err := r.q.Query(ctx, listQ, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("task: find all by org: %w", err)
+	}
+	defer rows.Close()
+
+	out, err := scanTasks(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return out, total, nil
+}
+
+// FindAllByLead is GET /v1/leads/{id}/tasks's backing query — a single
+// lead's tasks, unpaginated (TD §8's endpoint table has no page/per_page
+// for this route). Unlike FindAllByOrg, this checks lead visibility
+// EXPLICITLY and returns httpx.ErrNotFound when it fails, rather than
+// letting employee-scoping quietly filter the list down to empty — the
+// acceptance criteria are explicit that reading a sub-resource of a
+// lead you can't see is a 404, same as activity.FindAllByLead.
+func (r *postgresRepository) FindAllByLead(ctx context.Context, t tenant.Context, leadID uuid.UUID) ([]*Task, error) {
+	visible, err := r.leadVisible(ctx, t, leadID)
+	if err != nil {
+		return nil, err
+	}
+	if !visible {
+		return nil, httpx.ErrNotFound
+	}
+
+	const q = `
+		SELECT ` + taskColumns + `
+		FROM tasks
+		WHERE organization_id = $1 AND lead_id = $2 AND deleted_at IS NULL
+		ORDER BY created_at DESC`
+	rows, err := r.q.Query(ctx, q, t.OrganizationID, leadID)
+	if err != nil {
+		return nil, fmt.Errorf("task: find all by lead: %w", err)
+	}
+	defer rows.Close()
+
+	return scanTasks(rows)
+}
+
+func (r *postgresRepository) leadVisible(ctx context.Context, t tenant.Context, leadID uuid.UUID) (bool, error) {
+	const q = `
+		SELECT EXISTS (
+			SELECT 1 FROM leads
+			WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
+			  AND (NOT $3 OR assigned_to_membership_id = $4)
+		)`
+	var visible bool
+	if err := r.q.QueryRow(ctx, q, leadID, t.OrganizationID, isEmployee(t), membershipIDOrNil(t)).Scan(&visible); err != nil {
+		return false, fmt.Errorf("task: check lead visibility: %w", err)
+	}
+	return visible, nil
+}
+
+// buildTaskWhere backs FindAllByOrg — employee scoping here quietly
+// narrows an org-wide list, which is correct for that endpoint (same as
+// lead.FindAllByOrg). FindAllByLead does NOT use this: a single lead's
+// task list needs an explicit visible/not-visible answer (404), not a
+// filter that happens to return zero rows.
+func buildTaskWhere(t tenant.Context, filter ListFilter) (string, []any) {
+	conditions := []string{"organization_id = $1", "deleted_at IS NULL"}
+	args := []any{t.OrganizationID}
+
+	arg := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	if isEmployee(t) {
+		conditions = append(conditions, fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM leads l WHERE l.id = tasks.lead_id AND l.organization_id = $1 AND l.assigned_to_membership_id = %s)",
+			arg(membershipIDOrNil(t))))
+	}
+	if filter.AssignedTo != nil {
+		conditions = append(conditions, "assigned_to_membership_id = "+arg(*filter.AssignedTo))
+	}
+	if len(filter.Status) > 0 {
+		conditions = append(conditions, "status = ANY("+arg(filter.Status)+")")
+	}
+	if filter.DueBefore != nil {
+		conditions = append(conditions, "due_at <= "+arg(*filter.DueBefore))
+	}
+
+	return strings.Join(conditions, " AND "), args
+}
+
+// Update applies optimistic locking (TD §4), same shape as
+// lead.Update — zero rows disambiguated via a re-run scoped FindByID.
+func (r *postgresRepository) Update(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, in UpdateInput) (*Task, error) {
+	const q = `
+		UPDATE tasks
+		SET version = version + 1,
+		    title       = COALESCE($5, title),
+		    description = COALESCE($6, description),
+		    due_at      = COALESCE($7, due_at),
+		    assigned_to_membership_id = COALESCE($8, assigned_to_membership_id)
+		WHERE id = $1 AND organization_id = $2 AND version = $3 AND deleted_at IS NULL
+		  AND (NOT $4 OR EXISTS (
+		      SELECT 1 FROM leads l WHERE l.id = tasks.lead_id AND l.organization_id = $2
+		        AND l.assigned_to_membership_id = $9
+		  ))
+		RETURNING ` + taskColumns
+
+	row := r.q.QueryRow(ctx, q,
+		id, t.OrganizationID, expectedVersion, isEmployee(t),
+		in.Title, in.Description, in.DueAt, in.AssignedToMembershipID,
+		membershipIDOrNil(t),
+	)
+	updated, err := scanTask(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		current, findErr := r.FindByID(ctx, t, id)
+		if findErr != nil {
+			return nil, findErr
+		}
+		return current, ErrVersionConflict
+	}
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" && pgErr.ConstraintName == assigneeFKConstraint {
+			return nil, ErrAssigneeNotFound
+		}
+		return nil, fmt.Errorf("task: update: %w", err)
+	}
+	return updated, nil
+}
+
+// Complete sets status/completed_at/completed_by unconditionally on a
+// version+scope match — no extra "status must be open" guard.
+// Re-completing an already-done task at its current version just
+// re-stamps completion; nothing in TD's acceptance criteria exercises
+// this edge case either way, so no separate error is invented for it.
+func (r *postgresRepository) Complete(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, completedByMembershipID *uuid.UUID) (*Task, error) {
+	const q = `
+		UPDATE tasks
+		SET version = version + 1, status = 'done', completed_at = now(), completed_by_membership_id = $5
+		WHERE id = $1 AND organization_id = $2 AND version = $3 AND deleted_at IS NULL
+		  AND (NOT $4 OR EXISTS (
+		      SELECT 1 FROM leads l WHERE l.id = tasks.lead_id AND l.organization_id = $2
+		        AND l.assigned_to_membership_id = $6
+		  ))
+		RETURNING ` + taskColumns
+
+	row := r.q.QueryRow(ctx, q,
+		id, t.OrganizationID, expectedVersion, isEmployee(t),
+		completedByMembershipID, membershipIDOrNil(t),
+	)
+	updated, err := scanTask(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		current, findErr := r.FindByID(ctx, t, id)
+		if findErr != nil {
+			return nil, findErr
+		}
+		return current, ErrVersionConflict
+	}
+	if err != nil {
+		return nil, fmt.Errorf("task: complete: %w", err)
+	}
+	return updated, nil
+}
+
+// Delete soft-deletes id within t's scope. No version check — same
+// precedent as lead.Delete.
+func (r *postgresRepository) Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error {
+	const q = `
+		UPDATE tasks SET deleted_at = now()
+		WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL
+		  AND (NOT $3 OR EXISTS (
+		      SELECT 1 FROM leads l WHERE l.id = tasks.lead_id AND l.organization_id = $2
+		        AND l.assigned_to_membership_id = $4
+		  ))`
+
+	tag, err := r.q.Exec(ctx, q, id, t.OrganizationID, isEmployee(t), membershipIDOrNil(t))
+	if err != nil {
+		return fmt.Errorf("task: delete: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return httpx.ErrNotFound
+	}
+	return nil
+}
+
+func isEmployee(t tenant.Context) bool {
+	return t.Role == tenant.RoleEmployee
+}
+
+func membershipIDOrNil(t tenant.Context) uuid.UUID {
+	if t.MembershipID == nil {
+		return uuid.UUID{}
+	}
+	return *t.MembershipID
+}
+
+const taskColumns = `
+	id, organization_id, lead_id, title, description, due_at, status,
+	assigned_to_membership_id, completed_at, completed_by_membership_id,
+	version, created_by_membership_id, created_at, updated_at, deleted_at`
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanTask(row rowScanner) (*Task, error) {
+	var tsk Task
+	err := row.Scan(
+		&tsk.ID, &tsk.OrganizationID, &tsk.LeadID, &tsk.Title, &tsk.Description, &tsk.DueAt, &tsk.Status,
+		&tsk.AssignedToMembershipID, &tsk.CompletedAt, &tsk.CompletedByMembershipID,
+		&tsk.Version, &tsk.CreatedByMembershipID, &tsk.CreatedAt, &tsk.UpdatedAt, &tsk.DeletedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &tsk, nil
+}
+
+func scanTasks(rows pgx.Rows) ([]*Task, error) {
+	var out []*Task
+	for rows.Next() {
+		tsk, err := scanTask(rows)
+		if err != nil {
+			return nil, fmt.Errorf("task: scan: %w", err)
+		}
+		out = append(out, tsk)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("task: scan: %w", err)
+	}
+	return out, nil
+}

--- a/crm_be/internal/task/repository_test.go
+++ b/crm_be/internal/task/repository_test.go
@@ -1,0 +1,224 @@
+package task_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/task"
+)
+
+func TestRepository_Create_Succeeds(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := task.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil)
+
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, task.CreateInput{
+		LeadID: leadID, Title: "Follow up",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.Status != task.StatusOpen {
+		t.Errorf("expected default status open, got %q", created.Status)
+	}
+	if created.Version != 1 {
+		t.Errorf("expected initial version 1, got %d", created.Version)
+	}
+}
+
+func TestRepository_Create_InvalidAssignee_ReturnsErrAssigneeNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := task.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil)
+	bogus := uuid.Must(uuid.NewV7())
+
+	_, err := repo.Create(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, task.CreateInput{
+		LeadID: leadID, Title: "Follow up", AssignedToMembershipID: &bogus,
+	})
+	if !errors.Is(err, task.ErrAssigneeNotFound) {
+		t.Fatalf("expected task.ErrAssigneeNotFound, got: %v", err)
+	}
+}
+
+func TestRepository_Create_LeadInAnotherOrg_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := task.New(pool)
+
+	orgA := seedOrganization(t, ctx, pool)
+	orgB := seedOrganization(t, ctx, pool)
+	leadInA := seedLead(t, ctx, pool, orgA, nil)
+
+	_, err := repo.Create(ctx, tenant.Context{OrganizationID: orgB, Role: tenant.RoleOwner}, task.CreateInput{
+		LeadID: leadInA, Title: "Follow up",
+	})
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound, got: %v", err)
+	}
+}
+
+// TestRepository_Employee_VisibilityIsThroughLeadAssignment is the case
+// worth a dedicated test: an employee's task visibility is scoped by
+// which LEAD they're assigned to, not by the task's own
+// assigned_to_membership_id — a task can be assigned to a colleague on
+// a lead you own, and you must still see it.
+func TestRepository_Employee_VisibilityIsThroughLeadAssignment(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := task.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadOwner := seedMembership(t, ctx, pool, org, "lead-owner@example.com", tenant.RoleEmployee)
+	taskAssignee := seedMembership(t, ctx, pool, org, "task-assignee@example.com", tenant.RoleEmployee)
+	stranger := seedMembership(t, ctx, pool, org, "stranger@example.com", tenant.RoleEmployee)
+	leadID := seedLead(t, ctx, pool, org, &leadOwner)
+
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, task.CreateInput{
+		LeadID: leadID, Title: "Follow up", AssignedToMembershipID: &taskAssignee,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// The lead's owner must see it, even though the TASK is assigned to
+	// someone else.
+	if _, err := repo.FindByID(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleEmployee, MembershipID: &leadOwner}, created.ID); err != nil {
+		t.Errorf("expected the lead owner to see the task, got: %v", err)
+	}
+
+	// The task's own assignee, who does NOT own the lead, must NOT see
+	// it — visibility is lead-based, not task-assignee-based.
+	if _, err := repo.FindByID(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleEmployee, MembershipID: &taskAssignee}, created.ID); !errors.Is(err, httpx.ErrNotFound) {
+		t.Errorf("expected httpx.ErrNotFound for the task's assignee who doesn't own the lead, got: %v", err)
+	}
+
+	// An unrelated employee must not see it either.
+	if _, err := repo.FindByID(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleEmployee, MembershipID: &stranger}, created.ID); !errors.Is(err, httpx.ErrNotFound) {
+		t.Errorf("expected httpx.ErrNotFound for an unrelated employee, got: %v", err)
+	}
+}
+
+func TestRepository_Complete_SetsStatusCompletedAtCompletedBy(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := task.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil)
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, task.CreateInput{LeadID: leadID, Title: "Follow up"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	completer := uuid.Must(uuid.NewV7())
+	seedSpecificMembership(t, ctx, pool, org, completer, "completer@example.com", tenant.RoleOwner)
+
+	completed, err := repo.Complete(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, created.ID, created.Version, &completer)
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if completed.Status != task.StatusDone {
+		t.Errorf("expected status done, got %q", completed.Status)
+	}
+	if completed.CompletedAt == nil {
+		t.Error("expected completed_at to be set")
+	}
+	if completed.CompletedByMembershipID == nil || *completed.CompletedByMembershipID != completer {
+		t.Errorf("expected completed_by %v, got %v", completer, completed.CompletedByMembershipID)
+	}
+}
+
+func TestRepository_FindAllByLead_InvisibleLead_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := task.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	other := seedOrganization(t, ctx, pool)
+	leadInOther := seedLead(t, ctx, pool, other, nil)
+
+	_, err := repo.FindAllByLead(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, leadInOther)
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound for a lead in a different organization, got: %v", err)
+	}
+}
+
+func TestRepository_Update_StaleVersion_ReturnsConflictWithCurrentState(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := task.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil)
+	created, err := repo.Create(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, task.CreateInput{LeadID: leadID, Title: "Original"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	newTitle := "Should Not Apply"
+	current, err := repo.Update(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, created.ID, created.Version-1, task.UpdateInput{Title: &newTitle})
+	if !errors.Is(err, task.ErrVersionConflict) {
+		t.Fatalf("expected task.ErrVersionConflict, got: %v", err)
+	}
+	if current == nil || current.Title == newTitle {
+		t.Error("expected current state to be returned and the stale update to not apply")
+	}
+}
+
+func seedOrganization(t *testing.T, ctx context.Context, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, id); err != nil {
+		t.Fatalf("failed to seed organization: %v", err)
+	}
+	return id
+}
+
+func seedMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, email string, role tenant.Role) uuid.UUID {
+	t.Helper()
+	membershipID := uuid.Must(uuid.NewV7())
+	seedSpecificMembership(t, ctx, pool, org, membershipID, email, role)
+	return membershipID
+}
+
+func seedSpecificMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org, membershipID uuid.UUID, email string, role tenant.Role) {
+	t.Helper()
+	userID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Test User')`, userID, email); err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, $4)`, membershipID, org, userID, role); err != nil {
+		t.Fatalf("failed to seed membership: %v", err)
+	}
+}
+
+// seedLead inserts a minimal lead row directly via SQL — internal/task
+// doesn't depend on internal/lead, so its tests build the lead they
+// need with a raw INSERT rather than importing lead.Repository.
+func seedLead(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, assignedTo *uuid.UUID) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	const q = `
+		INSERT INTO leads (id, organization_id, lead_number, name, source, assigned_to_membership_id)
+		VALUES ($1, $2, (SELECT next_lead_number FROM organizations WHERE id = $2), 'Test Lead', 'manual', $3)`
+	if _, err := pool.Exec(ctx, q, id, org, assignedTo); err != nil {
+		t.Fatalf("failed to seed lead: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE organizations SET next_lead_number = next_lead_number + 1 WHERE id = $1`, org); err != nil {
+		t.Fatalf("failed to bump next_lead_number: %v", err)
+	}
+	return id
+}

--- a/crm_be/internal/task/usecase.go
+++ b/crm_be/internal/task/usecase.go
@@ -1,0 +1,199 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authz"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const (
+	defaultPerPage = 25
+	maxPerPage     = 100
+)
+
+// Usecase depends only on Store (port.go), never on *pgxpool.Pool or
+// pgx.Tx directly (ADR-011).
+type Usecase struct {
+	store Store
+}
+
+func NewUsecase(store Store) *Usecase {
+	return &Usecase{store: store}
+}
+
+// CreateTaskInput is Usecase.Create's argument.
+type CreateTaskInput struct {
+	Title                  string
+	Description            *string
+	DueAt                  *time.Time
+	AssignedToMembershipID *uuid.UUID
+}
+
+// Create makes a task on leadID and records task_created in the SAME
+// transaction (TD §10) — atomicity is the point: a task that exists
+// without a timeline entry, or an activity entry for a task that was
+// rolled back, are both worse than neither existing.
+func (u *Usecase) Create(ctx context.Context, t tenant.Context, leadID uuid.UUID, in CreateTaskInput) (*Task, error) {
+	if err := authz.Require(t, authz.ActionTaskCreate); err != nil {
+		return nil, err
+	}
+	if in.Title == "" {
+		return nil, httpx.NewValidationError(httpx.ErrorDetail{Field: "title", Code: "required"})
+	}
+
+	repoIn := CreateInput{
+		LeadID: leadID, Title: in.Title, Description: in.Description, DueAt: in.DueAt,
+		AssignedToMembershipID: in.AssignedToMembershipID, CreatedByMembershipID: t.MembershipID,
+	}
+
+	var created *Task
+	txErr := u.store.InTx(ctx, func(r Repos) error {
+		c, err := r.Task.Create(ctx, t, repoIn)
+		if err != nil {
+			return err
+		}
+		created = c
+		return r.Activity.Record(ctx, t, leadID, "task_created", t.MembershipID, map[string]any{
+			"task_id": c.ID, "title": c.Title,
+		})
+	})
+	if txErr != nil {
+		if errors.Is(txErr, ErrAssigneeNotFound) {
+			return nil, httpx.NewValidationError(httpx.ErrorDetail{Field: "assigned_to_membership_id", Code: "not_found"})
+		}
+		return nil, fmt.Errorf("task: create: %w", txErr)
+	}
+	return created, nil
+}
+
+// ListTasksInput is ListByOrg's argument — raw query-param values;
+// ListByOrg clamps Page/PerPage before delegating to the repository.
+type ListTasksInput struct {
+	AssignedTo *uuid.UUID
+	Status     []string
+	DueBefore  *time.Time
+	Page       int
+	PerPage    int
+}
+
+// ListByOrg backs GET /v1/tasks.
+func (u *Usecase) ListByOrg(ctx context.Context, t tenant.Context, in ListTasksInput) ([]*Task, httpx.Meta, error) {
+	if err := authz.Require(t, authz.ActionTaskRead); err != nil {
+		return nil, httpx.Meta{}, err
+	}
+
+	page := in.Page
+	if page < 1 {
+		page = 1
+	}
+	perPage := in.PerPage
+	if perPage <= 0 {
+		perPage = defaultPerPage
+	} else if perPage > maxPerPage {
+		perPage = maxPerPage
+	}
+
+	filter := ListFilter{
+		AssignedTo: in.AssignedTo, Status: in.Status, DueBefore: in.DueBefore,
+		Page: page, PerPage: perPage,
+	}
+	tasks, total, err := u.store.Repos().Task.FindAllByOrg(ctx, t, filter)
+	if err != nil {
+		return nil, httpx.Meta{}, fmt.Errorf("task: list by org: %w", err)
+	}
+	return tasks, httpx.Meta{Page: page, PerPage: perPage, Total: total}, nil
+}
+
+// ListByLead backs GET /v1/leads/{id}/tasks — unpaginated (see
+// ListFilter's doc comment).
+func (u *Usecase) ListByLead(ctx context.Context, t tenant.Context, leadID uuid.UUID) ([]*Task, error) {
+	if err := authz.Require(t, authz.ActionTaskRead); err != nil {
+		return nil, err
+	}
+	return u.store.Repos().Task.FindAllByLead(ctx, t, leadID)
+}
+
+// UpdateTaskInput is Usecase.Update's argument.
+type UpdateTaskInput struct {
+	Version                int
+	Title                  *string
+	Description            *string
+	DueAt                  *time.Time
+	AssignedToMembershipID *uuid.UUID
+}
+
+// Update applies general field changes — no activity type exists for
+// "task updated" in ck_activities_type (TD §10's table), so none is
+// written here, unlike Create/Complete.
+func (u *Usecase) Update(ctx context.Context, t tenant.Context, id uuid.UUID, in UpdateTaskInput) (*Task, error) {
+	if err := authz.Require(t, authz.ActionTaskUpdate); err != nil {
+		return nil, err
+	}
+
+	repoIn := UpdateInput{
+		Title: in.Title, Description: in.Description, DueAt: in.DueAt,
+		AssignedToMembershipID: in.AssignedToMembershipID,
+	}
+	updated, err := u.store.Repos().Task.Update(ctx, t, id, in.Version, repoIn)
+	if errors.Is(err, ErrVersionConflict) {
+		return nil, &VersionConflictError{Current: updated}
+	}
+	if errors.Is(err, ErrAssigneeNotFound) {
+		return nil, httpx.NewValidationError(httpx.ErrorDetail{Field: "assigned_to_membership_id", Code: "not_found"})
+	}
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+// Complete marks id done and records task_completed in the SAME
+// transaction (TD §10) — same atomicity reasoning as Create.
+func (u *Usecase) Complete(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int) (*Task, error) {
+	if err := authz.Require(t, authz.ActionTaskComplete); err != nil {
+		return nil, err
+	}
+
+	var completed *Task
+	var conflict bool
+	txErr := u.store.InTx(ctx, func(r Repos) error {
+		c, err := r.Task.Complete(ctx, t, id, expectedVersion, t.MembershipID)
+		if errors.Is(err, ErrVersionConflict) {
+			completed = c
+			conflict = true
+			return ErrVersionConflict
+		}
+		if err != nil {
+			return err
+		}
+		completed = c
+		return r.Activity.Record(ctx, t, c.LeadID, "task_completed", t.MembershipID, map[string]any{
+			"task_id": c.ID,
+		})
+	})
+	if conflict {
+		return nil, &VersionConflictError{Current: completed}
+	}
+	if txErr != nil {
+		return nil, fmt.Errorf("task: complete: %w", txErr)
+	}
+	return completed, nil
+}
+
+// Delete soft-deletes id — Employee is deliberately excluded by
+// authz.ActionTaskDelete (TD §9's matrix, the one place this issue
+// denies Employee something). No activity — no "task deleted" type
+// exists.
+func (u *Usecase) Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error {
+	if err := authz.Require(t, authz.ActionTaskDelete); err != nil {
+		return err
+	}
+	return u.store.Repos().Task.Delete(ctx, t, id)
+}

--- a/crm_be/internal/task/usecase_unit_test.go
+++ b/crm_be/internal/task/usecase_unit_test.go
@@ -1,0 +1,302 @@
+package task_test
+
+// TestUnit_* tests prove Usecase is decoupled from PostgreSQL (ADR-011) —
+// fake Store, no Docker. Run in isolation with:
+//
+//	go test ./internal/task/... -run TestUnit
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/task"
+)
+
+// --- fakes ---
+
+type fakeTaskRepo struct {
+	byID map[uuid.UUID]*task.Task
+}
+
+func newFakeTaskRepo() *fakeTaskRepo {
+	return &fakeTaskRepo{byID: map[uuid.UUID]*task.Task{}}
+}
+
+func (f *fakeTaskRepo) Create(_ context.Context, t tenant.Context, in task.CreateInput) (*task.Task, error) {
+	tsk := &task.Task{
+		ID: uuid.Must(uuid.NewV7()), OrganizationID: t.OrganizationID, LeadID: in.LeadID,
+		Title: in.Title, Description: in.Description, DueAt: in.DueAt, Status: task.StatusOpen,
+		AssignedToMembershipID: in.AssignedToMembershipID, Version: 1, CreatedByMembershipID: in.CreatedByMembershipID,
+	}
+	f.byID[tsk.ID] = tsk
+	return tsk, nil
+}
+
+func (f *fakeTaskRepo) FindByID(_ context.Context, t tenant.Context, id uuid.UUID) (*task.Task, error) {
+	tsk, ok := f.byID[id]
+	if !ok || tsk.OrganizationID != t.OrganizationID || tsk.DeletedAt != nil {
+		return nil, httpx.ErrNotFound
+	}
+	return tsk, nil
+}
+
+func (f *fakeTaskRepo) FindAllByOrg(_ context.Context, t tenant.Context, _ task.ListFilter) ([]*task.Task, int, error) {
+	var out []*task.Task
+	for _, tsk := range f.byID {
+		if tsk.OrganizationID == t.OrganizationID && tsk.DeletedAt == nil {
+			out = append(out, tsk)
+		}
+	}
+	return out, len(out), nil
+}
+
+func (f *fakeTaskRepo) FindAllByLead(_ context.Context, t tenant.Context, leadID uuid.UUID) ([]*task.Task, error) {
+	var out []*task.Task
+	for _, tsk := range f.byID {
+		if tsk.OrganizationID == t.OrganizationID && tsk.LeadID == leadID && tsk.DeletedAt == nil {
+			out = append(out, tsk)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeTaskRepo) Update(_ context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, in task.UpdateInput) (*task.Task, error) {
+	tsk, err := f.FindByID(context.Background(), t, id)
+	if err != nil {
+		return nil, err
+	}
+	if tsk.Version != expectedVersion {
+		return tsk, task.ErrVersionConflict
+	}
+	if in.Title != nil {
+		tsk.Title = *in.Title
+	}
+	if in.AssignedToMembershipID != nil {
+		tsk.AssignedToMembershipID = in.AssignedToMembershipID
+	}
+	tsk.Version++
+	return tsk, nil
+}
+
+func (f *fakeTaskRepo) Complete(_ context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, completedByMembershipID *uuid.UUID) (*task.Task, error) {
+	tsk, err := f.FindByID(context.Background(), t, id)
+	if err != nil {
+		return nil, err
+	}
+	if tsk.Version != expectedVersion {
+		return tsk, task.ErrVersionConflict
+	}
+	tsk.Status = task.StatusDone
+	tsk.CompletedByMembershipID = completedByMembershipID
+	tsk.Version++
+	return tsk, nil
+}
+
+func (f *fakeTaskRepo) Delete(_ context.Context, t tenant.Context, id uuid.UUID) error {
+	tsk, err := f.FindByID(context.Background(), t, id)
+	if err != nil {
+		return err
+	}
+	now := tsk.CreatedAt
+	tsk.DeletedAt = &now
+	return nil
+}
+
+// fakeActivityRecorder records every Record call; when err is set, it
+// propagates instead of succeeding — used to prove a recording failure
+// aborts the whole operation (the wiring half of TD §10's atomicity
+// requirement).
+type fakeActivityRecorder struct {
+	calls []recordedActivity
+	err   error
+}
+
+type recordedActivity struct {
+	leadID       uuid.UUID
+	activityType string
+	metadata     map[string]any
+}
+
+func (f *fakeActivityRecorder) Record(_ context.Context, _ tenant.Context, leadID uuid.UUID, activityType string, _ *uuid.UUID, metadata map[string]any) error {
+	f.calls = append(f.calls, recordedActivity{leadID, activityType, metadata})
+	return f.err
+}
+
+type fakeStore struct {
+	repos    task.Repos
+	activity *fakeActivityRecorder
+}
+
+func newFakeStore() *fakeStore {
+	rec := &fakeActivityRecorder{}
+	return &fakeStore{repos: task.Repos{Task: newFakeTaskRepo(), Activity: rec}, activity: rec}
+}
+
+func (s *fakeStore) InTx(_ context.Context, fn func(task.Repos) error) error { return fn(s.repos) }
+func (s *fakeStore) Repos() task.Repos                                       { return s.repos }
+
+func actorContext(orgID, membershipID uuid.UUID, role tenant.Role) tenant.Context {
+	return tenant.Context{OrganizationID: orgID, PrincipalType: tenant.PrincipalUser, MembershipID: &membershipID, Role: role}
+}
+
+func ownerActor() (tenant.Context, uuid.UUID) {
+	org := uuid.Must(uuid.NewV7())
+	return actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleOwner), org
+}
+
+// --- tests ---
+
+func TestUnit_Create_TitleRequired(t *testing.T) {
+	u := task.NewUsecase(newFakeStore())
+	actor, _ := ownerActor()
+
+	_, err := u.Create(context.Background(), actor, uuid.Must(uuid.NewV7()), task.CreateTaskInput{})
+
+	var verr *httpx.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected ValidationError, got: %v", err)
+	}
+}
+
+func TestUnit_Create_RecordsTaskCreatedActivity(t *testing.T) {
+	store := newFakeStore()
+	u := task.NewUsecase(store)
+	actor, _ := ownerActor()
+	leadID := uuid.Must(uuid.NewV7())
+
+	created, err := u.Create(context.Background(), actor, leadID, task.CreateTaskInput{Title: "Follow up"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if len(store.activity.calls) != 1 {
+		t.Fatalf("expected exactly one activity recorded, got %d", len(store.activity.calls))
+	}
+	got := store.activity.calls[0]
+	if got.leadID != leadID || got.activityType != "task_created" {
+		t.Errorf("expected task_created on lead %v, got %+v", leadID, got)
+	}
+	if got.metadata["task_id"] != created.ID || got.metadata["title"] != "Follow up" {
+		t.Errorf("expected metadata {task_id, title}, got %v", got.metadata)
+	}
+}
+
+func TestUnit_Create_ActivityRecordFailure_PropagatesError(t *testing.T) {
+	store := newFakeStore()
+	store.activity.err = errors.New("activity: record failed")
+	u := task.NewUsecase(store)
+	actor, _ := ownerActor()
+
+	_, err := u.Create(context.Background(), actor, uuid.Must(uuid.NewV7()), task.CreateTaskInput{Title: "Follow up"})
+	if err == nil {
+		t.Fatal("expected Create to fail when recording the activity fails")
+	}
+}
+
+func TestUnit_Update_StaleVersion_ReturnsVersionConflict(t *testing.T) {
+	store := newFakeStore()
+	u := task.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, err := u.Create(context.Background(), actor, uuid.Must(uuid.NewV7()), task.CreateTaskInput{Title: "Follow up"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	newTitle := "Updated"
+	_, err = u.Update(context.Background(), actor, created.ID, task.UpdateTaskInput{Version: created.Version - 1, Title: &newTitle})
+
+	var conflict *task.VersionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected *task.VersionConflictError, got: %v", err)
+	}
+}
+
+func TestUnit_Update_NoActivityRecorded(t *testing.T) {
+	store := newFakeStore()
+	u := task.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _ := u.Create(context.Background(), actor, uuid.Must(uuid.NewV7()), task.CreateTaskInput{Title: "Follow up"})
+	store.activity.calls = nil // drop the task_created call from Create
+
+	newTitle := "Updated"
+	_, err := u.Update(context.Background(), actor, created.ID, task.UpdateTaskInput{Version: created.Version, Title: &newTitle})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if len(store.activity.calls) != 0 {
+		t.Errorf("expected no activity for a general update (no task_updated type exists), got %d", len(store.activity.calls))
+	}
+}
+
+func TestUnit_Complete_SetsStatusAndRecordsTaskCompleted(t *testing.T) {
+	store := newFakeStore()
+	u := task.NewUsecase(store)
+	actor, _ := ownerActor()
+	leadID := uuid.Must(uuid.NewV7())
+	created, _ := u.Create(context.Background(), actor, leadID, task.CreateTaskInput{Title: "Follow up"})
+	store.activity.calls = nil
+
+	completed, err := u.Complete(context.Background(), actor, created.ID, created.Version)
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	if completed.Status != task.StatusDone {
+		t.Errorf("expected status done, got %q", completed.Status)
+	}
+	if completed.CompletedByMembershipID == nil || *completed.CompletedByMembershipID != *actor.MembershipID {
+		t.Errorf("expected completed_by to be the caller, got %v", completed.CompletedByMembershipID)
+	}
+
+	if len(store.activity.calls) != 1 || store.activity.calls[0].activityType != "task_completed" {
+		t.Fatalf("expected exactly one task_completed activity, got %+v", store.activity.calls)
+	}
+	if store.activity.calls[0].leadID != leadID {
+		t.Errorf("expected activity on lead %v, got %v", leadID, store.activity.calls[0].leadID)
+	}
+}
+
+func TestUnit_Complete_StaleVersion_ReturnsVersionConflict(t *testing.T) {
+	store := newFakeStore()
+	u := task.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _ := u.Create(context.Background(), actor, uuid.Must(uuid.NewV7()), task.CreateTaskInput{Title: "Follow up"})
+
+	_, err := u.Complete(context.Background(), actor, created.ID, created.Version-1)
+
+	var conflict *task.VersionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected *task.VersionConflictError, got: %v", err)
+	}
+}
+
+func TestUnit_Delete_EmployeeForbidden(t *testing.T) {
+	store := newFakeStore()
+	u := task.NewUsecase(store)
+	actor, org := ownerActor()
+	created, _ := u.Create(context.Background(), actor, uuid.Must(uuid.NewV7()), task.CreateTaskInput{Title: "Follow up"})
+
+	employeeCtx := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+	err := u.Delete(context.Background(), employeeCtx, created.ID)
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "forbidden" {
+		t.Fatalf("expected forbidden for employee delete, got: %v", err)
+	}
+}
+
+func TestUnit_Delete_ManagerAllowed(t *testing.T) {
+	store := newFakeStore()
+	u := task.NewUsecase(store)
+	actor, org := ownerActor()
+	created, _ := u.Create(context.Background(), actor, uuid.Must(uuid.NewV7()), task.CreateTaskInput{Title: "Follow up"})
+
+	managerCtx := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleManager)
+	if err := u.Delete(context.Background(), managerCtx, created.ID); err != nil {
+		t.Fatalf("expected manager to be allowed to delete, got: %v", err)
+	}
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 22 Agustus 2026 — Issue #20 selesai
-**Phase sekarang:** Phase 2 — CRM Core (2/5 issue selesai)
+**Last updated:** 24 Agustus 2026 — Issue #21 selesai
+**Phase sekarang:** Phase 2 — CRM Core (3/5 issue selesai)
 
 ---
 
@@ -31,6 +31,7 @@
 | **Issue #11 — RBAC, invitation, penonaktifan membership, harness isolasi tenant** | — | 1 | `internal/shared/{authn,authz}` (session middleware diekstrak dari `auth`, RBAC baru). `internal/membership` naik jadi domain penuh (`port/usecase/handler_http.go`). `internal/invitation` baru — undangan dua cabang (B4), keduanya diuji termasuk test keamanan wajib. `POST/GET/DELETE /v1/invitations`, `GET/PATCH/DELETE /v1/memberships`. Penonaktifan membership mencabut refresh token dalam transaksi yang sama — **dibuktikan lewat smoke test end-to-end**. `docs/architecture/authorization.md` baru. **Harness isolasi tenant (`cmd/api/tenant_isolation_test.go`) dibangun & dibuktikan bisa gagal** (lapis 4, blocking CI). Satu bug nyata (email tidak terverifikasi otomatis saat accept undangan) ditemukan lewat smoke test manual, diperbaiki, dan mendapat test regresi di kedua level. **Phase 1 selesai.** |
 | **Issue #19 — Schema 0003, repository lead, alokasi `lead_number`, optimistic locking** | — | 2 | Migration `0003_crm_core` (`leads`, `customers`, `activities`, `tasks` + `organizations.next_lead_number`). `internal/lead` — repository murni (`entity.go`+`repository_postgres.go`, tanpa `port.go`/usecase — pola `membership` pra-#11). Alokasi `lead_number` berurutan per organization dan optimistic locking `version`, **dibuktikan di bawah konkurensi nyata** (20 goroutine bersamaan). Visibilitas employee ditegakkan di repository. Klaim awal soal kebutuhan `db.InTx` sempat berlebihan di komentar kode — diuji langsung sebelum commit, ternyata test konkurensi tidak membuktikannya; ditulis test terpisah (`TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber`) yang benar-benar membuktikan. Test katalog (dari #8) otomatis mencakup keempat tabel baru **tanpa perubahan**. |
 | **Issue #20 — Lead CRUD, transisi status, filter, pagination, idempotency, E.164** | — | 2 | `internal/lead` naik jadi domain penuh (`port/usecase/handler_http.go`, `Repository` jadi interface — migrasi yang sama seperti `membership` di #11). `POST/GET/PATCH/DELETE /v1/leads`, `PATCH /v1/leads/{id}/status`. `internal/shared/phone.ToE164` (Indonesia-first). Idempotency-Key dideteksi lewat unique-violation database, **dibuktikan dengan 10 POST bersamaan → tepat 1 lead**. Optimistic locking `409` membawa keadaan terkini di body. Dua `Action` RBAC baru (`lead.create/read/update/delete`). **Bug nyata ditemukan lewat test yang salah pakai** (assignee tak valid → 500 diam-diam) — diperbaiki jadi `400` bersih + test regresi. Satu penyimpangan TD didokumentasikan (keluar dari `lost` belum bisa "satu langkah tepat" tanpa riwayat dari #21). 34 test baru di `internal/lead`, semuanya lolos tanpa perubahan asersi lama. |
+| **Issue #21 — Activity append-only + auto-log, dan Task** | — | 2 | `internal/activity` dan `internal/task` baru — dua domain penuh. `ActivityRecorder` dideklarasikan konsumen (`lead`, `task`), dijembatani `activity.NewRecorder(q)` di composition root — pola `auth.RefreshTokenRevoker` (#11). `lead_created`, `status_changed` (`metadata={from,to}`), `task_created`, `task_completed` ditulis **di dalam `Store.InTx` yang sama** dengan pemicunya — `lead.Usecase.UpdateStatus` kini juga dibungkus `InTx`. `GET/POST /v1/leads/{id}/activities` (append-only — **tidak ada** `PATCH`/`DELETE`, diverifikasi lewat daftar route sungguhan). Tipe sistem dari client → `422`. `internal/task`: visibilitas employee lewat kepemilikan **lead**, bukan assignee task sendiri — dibuktikan test khusus. jsonb pertama yang benar-benar ditulis di codebase ini (`activities.metadata`), diverifikasi round-trip langsung terhadap Postgres asli. Atomisitas dibuktikan dua lapis: fake (unit) dan transaksi Postgres sungguhan (`repository_atomicity_test.go`, membuktikan rollback nyata + `lead_number` tidak "terbakar"). Satu bug desain (visibilitas `task.FindAllByLead`) ketahuan dan diperbaiki sebelum commit. Enam `Action` RBAC baru. Smoke test manual end-to-end lolos seluruh acceptance criteria. |
 
 ---
 
@@ -42,12 +43,13 @@ _(kosong)_
 
 ## Berikutnya
 
-**Issue #21 — Activity append-only + auto-log, dan Task**
+**Issue #22 — Assignment, notification (`0004`), penutupan kewajiban penonaktifan membership**
 
-- Cakupan & acceptance: [issue #21](https://github.com/Pravasta/jualin-crm/issues/21)
-- TD: `docs/phases/02-crm-core/td.md` §1.3, §1.4, §8, §10
-- `internal/lead/port.go`'s `Repos` menambah field `Activity` — pada titik ini `Create`/`UpdateStatus` di usecase perlu dibungkus `store.InTx` juga (bukan hanya `Create` seperti sekarang) supaya penulisan activity atomik dengan perubahan lead yang memicunya.
-- Berurutan: #19 (selesai) → #20 (selesai) → #21 → #22 → #23. Rincian di `docs/phases/02-crm-core/issues.md`.
+- Cakupan & acceptance: [issue #22](https://github.com/Pravasta/jualin-crm/issues/22)
+- TD: `docs/phases/02-crm-core/td.md` §2, §8, §11, §13
+- `internal/lead/port.go`'s `Repos` kemungkinan menambah field lagi (mis. `Notification`) — assignment menulis `lead_assigned`/`lead_unassigned` (activity) **dan** notification dalam satu `Store.InTx` (TD §11).
+- Menutup kewajiban warisan Phase 1 (`docs/phases/01-auth-organization/td.md` §17): `DELETE /v1/memberships/{id}` menolak default bila ada lead terbuka — `internal/membership` akan butuh interface sempit ke `lead` (`OpenLeadRepository`), didekralasikan `membership`, diimplementasikan `lead`, dirakit di composition root — pola yang sama `auth.RefreshTokenRevoker`/`activity.Recorder` sudah pakai dua kali.
+- Berurutan: #19 (selesai) → #20 (selesai) → #21 (selesai) → #22 → #23. Rincian di `docs/phases/02-crm-core/issues.md`.
 
 ---
 

--- a/docs/phases/02-crm-core/notes.md
+++ b/docs/phases/02-crm-core/notes.md
@@ -111,3 +111,51 @@ Seluruh acceptance criteria issue #20 terpenuhi.
 - **`internal/lead/port.go`'s `Repos{Lead Repository}` punya satu field secara sengaja.** #21 menambah field `Activity` saat menulis `activities` perlu atomik dengan perubahan lead (`status_changed`, `lead_assigned`, dst) — pada titik itu, `UpdateStatus`/assignment di usecase perlu dibungkus `store.InTx` juga (saat ini hanya `Create` yang InTx, karena `Create` sendiri butuh atomisitas internal, bukan karena ada tabel lain yang ditulis).
 - **Pola deteksi pelanggaran constraint database (unique ATAU foreign key) sebagai sinyal, bukan `SELECT` dulu**, sekarang punya dua contoh di paket ini (`ErrIdempotencyKeyExists`, `ErrAssigneeNotFound`) selain `user.ErrEmailTaken` di Phase 1. Pola yang sama berlaku untuk constraint baru yang muncul di #21/#22/#23 (mis. `uq_customers_org_lead` saat konversi).
 - **Manual smoke test menemukan bug produksi untuk ketiga kalinya berturut-turut** (setelah #11 dan sesi ini sendiri, lewat jalur test bukan `docker compose` kali ini) — pola yang konsisten cukup kuat untuk terus dipertahankan di issue berikutnya, bukan dianggap kebetulan.
+
+---
+
+## #21 — Activity append-only + auto-log, dan Task
+
+### Keputusan implementasi
+
+- **`ActivityRecorder` dideklarasikan konsumen (`lead`, `task`), bukan diimpor dari `internal/activity`** — persis pola `auth.RefreshTokenRevoker` di #11. Kedua interface lokal identik bentuknya (`Record(ctx, t, leadID, activityType, actorMembershipID, metadata)`), sengaja diduplikasi tiga baris, bukan ditarik ke paket bersama untuk dua titik pakai. `internal/activity` mengekspor `Recorder` + `NewRecorder(q)` sebagai jembatan yang dipasang di composition root (`activity.NewRecorder(q)` dipakai baik oleh `lead.Repos.Activity` maupun `task.Repos.Activity`).
+- **Visibilitas lead untuk `activity`/`task` tidak butuh interface lintas paket** — cukup `WHERE EXISTS (SELECT 1 FROM leads ...)` langsung di query masing-masing paket, karena `activity`/`task`/`lead` berbagi satu database Postgres yang sama. Menghindari interface `LeadVisibility` yang tidak diminta issue manapun.
+- **`internal/task`'s visibilitas employee lewat kepemilikan LEAD, bukan `tasks.assigned_to_membership_id`** — TD §9 eksplisit: "task pada lead miliknya". Task boleh di-assign ke kolega di lead yang Anda miliki, dan Anda tetap harus melihatnya; task yang di-assign ke Anda di lead orang lain tetap harus **tidak** terlihat. Dibuktikan lewat `TestRepository_Employee_VisibilityIsThroughLeadAssignment` yang sengaja menguji ketiga kombinasi (pemilik lead, assignee task yang bukan pemilik lead, orang lain sama sekali).
+- **`task.FindAllByLead` memeriksa visibilitas lead secara eksplisit** (404 bila tidak terlihat), **berbeda** dari `task.FindAllByOrg` yang membiarkan scoping employee diam-diam mempersempit hasil ke kosong. Desain awal memakai `buildTaskWhere` yang sama untuk keduanya — salah, karena itu membuat `GET /v1/leads/{id}/tasks` pada lead orang lain mengembalikan `200` dengan daftar kosong, bukan `404` seperti bunyi acceptance criteria ("Employee membaca activity/task pada lead orang lain → 404"). Ketahuan lewat test integrasi sendiri sebelum commit, diperbaiki dengan helper `leadVisible` terpisah — pola yang sama `activity.FindAllByLead` sudah pakai.
+- **`authz.ActionTaskRead` ditambah di luar tabel TD §9 yang literal** — TD hanya menyebut `task.create/update/complete` dan `task.delete`, tidak ada baris baca eksplisit. Menambah action baca sendiri (permission identik keempat role, sama seperti `activity.list` mendampingi `activity.create`) lebih jelas ketimbang memakai `ActionTaskCreate` sebagai gerbang baca — nama aksi yang salah mengaburkan niat saat dibaca ulang nanti.
+- **Bug ditemukan lewat test unit (fake), bukan lewat desain**: `TestUnit_UpdateStatus_RecordsStatusChangedActivityWithFromTo` awalnya gagal — `metadata.from` terisi status **baru**, bukan status lama. Penyebabnya alias pointer di fake test double: `fakeLeadRepo.FindByID` dan `fakeLeadRepo.UpdateStatus` sama-sama mengembalikan pointer ke struct yang sama di map, sehingga membaca `current.Status` **setelah** `UpdateStatus` dipanggil sudah melihat nilai yang sudah berubah. Postgres asli tidak akan pernah berperilaku begini (`scanLead` selalu mengalokasikan struct baru), tapi `usecase.go` diperbaiki supaya tidak bergantung pada asumsi itu sama sekali — `fromStatus` ditangkap ke variabel lokal segera setelah `FindByID`, sebelum `UpdateStatus` dipanggil.
+- **`lead.Usecase.UpdateStatus` sekarang berjalan di dalam `store.InTx`** — sebelumnya (#20) memanggil `store.Repos()` langsung. Perubahan ini wajib supaya `status_changed` atomik dengan perubahan status yang memicunya (TD §10), persis seperti dicatat sebagai "catatan untuk session berikutnya" di bagian `## #20` di atas.
+- **jsonb pertama yang benar-benar ditulis di codebase ini** (`activities.metadata`) — `lead.RawPayload` sejak #19 tulus-tembus tapi tidak pernah benar-benar diisi pemanggil manapun. Klaim "pgx menerima `[]byte` hasil `json.Marshal` untuk kolom jsonb" diverifikasi langsung lewat `TestRepository_Create_MetadataRoundTrips` sebelum dipakai di tempat lain — insert `{"from":"new","to":"contacted"}`, baca lewat `RETURNING` **dan** lewat `SELECT` terpisah, keduanya di-unmarshal dan dicocokkan.
+
+### Verifikasi
+
+```
+go build ./...                              → bersih
+go vet ./...                                → bersih
+golangci-lint run                           → 0 issues (setelah 1x perbaikan S1016)
+gofmt -l .                                  → bersih
+go test -race -count=1 ./... (2x)           → semua PASS
+
+DOCKER_HOST=unix:///nonexistent/docker.sock \
+  go test ./internal/... -run TestUnit -count=1
+                                             → PASS tanpa Docker (activity, task, lead, + semua paket lama)
+
+go list -deps ./cmd/api | grep docker       → kosong
+```
+
+**Test atomisitas (wajib di Definition of Done)**: dibuktikan dua lapis — `usecase_unit_test.go` (fake `ActivityRecorder` yang gagal, membuktikan kegagalan menular sebagai error dari seluruh operasi) **dan** `repository_atomicity_test.go` di `internal/lead` (transaksi Postgres sungguhan: `Activity.Record` sengaja gagal setelah `Lead.Create` sukses, baris `leads` dipastikan **tidak ada** setelahnya, dan `lead_number` yang teralokasi tidak "terbakar" — percobaan berikutnya tetap dapat nomor 1).
+
+**Smoke test manual** (`docker compose up --build`): register+verify+login owner → `POST /v1/leads` → `201`, `GET /v1/leads/{id}/activities` → tepat satu `lead_created` dengan `actor_membership_id` = owner → `PATCH /status` `new→contacted` → `GET activities` → `status_changed` dengan `metadata={from:new,to:contacted}`, urutan terbaru dulu → `POST activities {"type":"status_changed"}` → `422 invalid_activity_type` → `POST activities {"type":"note_added"}` → `201` → `PATCH` ke `/v1/leads/{id}/activities/{id}` → `404` (route memang tidak terdaftar) → `POST /v1/leads/{id}/tasks` → `201` → `POST /v1/tasks/{id}/complete` → `200`, `status=done`, `completed_at`/`completed_by` terisi → `GET activities` menunjukkan `task_created` dan `task_completed` → `PATCH` task dengan `version` basi → `409` → `GET /v1/tasks` dan `GET /v1/leads/{id}/tasks` keduanya mengembalikan task yang sama → `DELETE /v1/tasks/{id}` → `204`.
+
+Seluruh acceptance criteria issue #21 terpenuhi. Kasus 404 employee (activity & task) diverifikasi otomatis lewat test Postgres (`TestHandler_Get_Employee_OtherPersonsLead_Returns404`, `TestHandler_Employee_ReadTaskOnAnotherEmployeesLead_Returns404`), tidak diulang manual — sudah terbukti lewat jalur HTTP sungguhan di test integrasi.
+
+### Utang teknis
+
+- Tidak ada item baru dari issue ini sendiri.
+
+### Catatan untuk session berikutnya
+
+- **`internal/lead/port.go`'s `Repos{Lead, Activity}` sekarang dua field** — #22 kemungkinan menambah lagi saat assignment perlu menulis `notifications` sekaligus (`lead_assigned`/`lead_unassigned` + notification, satu transaksi, TD §11).
+- **Pola visibilitas-eksplisit-lalu-404 vs filter-diam-diam** sekarang punya preseden jelas: gunakan yang pertama untuk "satu resource spesifik milik satu lead" (`FindByID`, `FindAllByLead`), gunakan yang kedua untuk "daftar lintas-lead yang boleh menyempit" (`FindAllByOrg`). Jangan pakai `buildXWhere` yang sama untuk keduanya tanpa mikir ulang — itu persis kesalahan yang tertangkap di atas.
+- **`docs/architecture/authorization.md`'s matrix belum diperbarui** — tetap ditunda ke #23 seperti sudah dicatat di TD §9, sekarang dengan `activity.*`/`task.*` (termasuk `task.read` yang tidak ada di TD literal) sebagai baris tambahan yang perlu masuk saat itu.
+- **`internal/task`'s `Complete` tidak menolak menyelesaikan task yang sudah `done`** — pada `version` yang benar, memanggil `complete` lagi hanya menimpa ulang `completed_at`/`completed_by` tanpa error. Tidak diuji acceptance criteria manapun; disebutkan di sini supaya bukan kejutan bila suatu saat dianggap perlu perilaku berbeda.


### PR DESCRIPTION
## Summary

Third issue of Phase 2, on top of #20's lead usecase/HTTP layer. Adds two new full domain packages — `internal/activity` and `internal/task` — plus retrofits `internal/lead`'s `Create`/`UpdateStatus` to write the auto-generated activities TD §10 requires, atomically, in the same `Store.InTx` as the event that triggers them. Stops exactly where #22 (assignment/notification) and #23 (conversion) begin.

- **`internal/activity`** (new domain): `GET/POST /v1/leads/{id}/activities`. POST accepts only `note_added`/`call_logged`/`whatsapp_opened` — system types (`lead_created`, `status_changed`, …) are rejected `422 invalid_activity_type`. No `PATCH`/`DELETE` route exists anywhere — append-only is enforced by the router literally not having those routes, checked via a route-listing test, not assumption.
- **`internal/task`** (new domain): `POST /v1/leads/{id}/tasks`, `GET /v1/tasks`, `GET /v1/leads/{id}/tasks`, `PATCH /v1/tasks/{id}`, `POST /v1/tasks/{id}/complete`, `DELETE /v1/tasks/{id}`. Employee visibility is scoped through **lead ownership**, not the task's own assignee — a task can be assigned to a colleague on a lead you own and must still be visible; the reverse (a task assigned to you on someone else's lead) must stay invisible. Proven with a dedicated three-way test.
- **`ActivityRecorder` declared by its consumers** (`lead`, `task`), per ADR-011 — same bridging pattern `auth.RefreshTokenRevoker` established for `membership` in #11. `activity.NewRecorder(q)` is wired into both `lead.Repos.Activity` and `task.Repos.Activity` at the composition root; neither package imports `internal/activity`'s domain types.
- **Auto-log, atomically**: `lead_created` (on `Create`), `status_changed` with `metadata={from,to}` (on `UpdateStatus`), `task_created`, `task_completed` are all written inside the same `Store.InTx` as their trigger. `lead.Usecase.UpdateStatus` now runs inside `store.InTx` — previously (#20) it called `store.Repos()` directly outside any transaction.
- **First real jsonb write in this codebase** (`activities.metadata` — `lead.RawPayload` since #19 is written-through but never actually populated by any caller). Verified directly against real Postgres with a round-trip test before relying on it anywhere else.
- **A design bug caught before commit**: `task.FindAllByLead`'s first draft reused the same employee-scoping WHERE clause as `FindAllByOrg`, which meant an employee reading tasks on someone else's lead got a silently empty `200` instead of `404` — wrong per this issue's own acceptance criteria. Fixed with an explicit lead-visibility check (mirrors `activity.FindAllByLead`).
- **Atomicity proven two ways**: a fake `ActivityRecorder` (unit-level, proves the Go wiring propagates a recording failure as an error) and a real Postgres transaction test (`internal/lead/repository_atomicity_test.go` — forces `Activity.Record` to fail after `Lead.Create` succeeds, confirms the lead row does **not** exist afterward and the allocated `lead_number` isn't burned).

## Test plan

- [x] `go build/vet ./...`, `gofmt -l .` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./... -race -count=1` — green, run twice for flakiness
- [x] `DOCKER_HOST=<bogus> go test ./internal/... -run TestUnit` — business logic confirmed Docker-free
- [x] `go list -deps ./cmd/api | grep docker` — production binary confirmed testcontainers-free
- [x] Manual `docker compose up` smoke test: create lead → exactly one `lead_created` activity; `PATCH /status` → `status_changed` with correct `metadata.from/to`, newest-first ordering; `POST activities {"type":"status_changed"}` → `422`; `POST activities {"type":"note_added"}` → `201`; `PATCH` on an activity route → `404` (route not registered); create task → `task_created` activity; complete task → `status/completed_at/completed_by` set + `task_completed` activity; stale-version `PATCH /v1/tasks/{id}` → `409`; `GET /v1/tasks` and `GET /v1/leads/{id}/tasks` both consistent; `DELETE /v1/tasks/{id}` → `204`. Employee 404 cases verified via the automated Postgres integration tests rather than repeated manually.

Refs #21