### PR TITLE
feat(lead,membership,notification): add assignment, notifications, and close the Phase 1 deactivation obligation

### DIFF
--- a/crm_be/cmd/api/lead_store.go
+++ b/crm_be/cmd/api/lead_store.go
@@ -8,15 +8,17 @@ import (
 
 	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/notification"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
 )
 
 // leadStore is the composition root's implementation of lead.Store —
 // same wiring pattern as auth_store.go/membership_store.go/
 // invitation_store.go. Its Activity repository comes from
-// activity.NewRecorder, added in #21 — internal/lead never imports
-// internal/activity's domain types, only this file (and
-// internal/activity itself) knows both packages exist (ADR-011).
+// activity.NewRecorder (#21) and its Notification sender from
+// notification.NewNotifier (#22) — internal/lead never imports either
+// package's domain types, only this file (and those packages
+// themselves) know all three exist (ADR-011).
 type leadStore struct {
 	pool *pgxpool.Pool
 }
@@ -37,7 +39,8 @@ func (s *leadStore) Repos() lead.Repos {
 
 func leadReposFor(q db.Querier) lead.Repos {
 	return lead.Repos{
-		Lead:     lead.New(q),
-		Activity: activity.NewRecorder(q),
+		Lead:         lead.New(q),
+		Activity:     activity.NewRecorder(q),
+		Notification: notification.NewNotifier(q),
 	}
 }

--- a/crm_be/cmd/api/main.go
+++ b/crm_be/cmd/api/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Pravasta/jualin-crm/crm_be/internal/invitation"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/membership"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/notification"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/config"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
@@ -115,6 +116,9 @@ func newRouter(log *slog.Logger, pool *pgxpool.Pool, cfg *config.Config) *gin.En
 
 	taskUsecase := task.NewUsecase(newTaskStore(pool))
 	task.NewHandler(taskUsecase).RegisterRoutes(r, authMW)
+
+	notificationUsecase := notification.NewUsecase(newNotificationStore(pool))
+	notification.NewHandler(notificationUsecase).RegisterRoutes(r, authMW)
 
 	r.NoRoute(func(c *gin.Context) {
 		httpx.RespondError(c, http.StatusNotFound, "not_found", "Route tidak ditemukan.")

--- a/crm_be/cmd/api/membership_store.go
+++ b/crm_be/cmd/api/membership_store.go
@@ -6,17 +6,20 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/auditlog"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/auth"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/membership"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
 )
 
 // membershipStore is the composition root's implementation of
 // membership.Store. Its RefreshToken repository comes from
-// auth.NewRefreshTokenRevoker — internal/membership never imports
-// internal/auth; only this file (and internal/auth itself) knows both
-// packages exist (ADR-011).
+// auth.NewRefreshTokenRevoker and its OpenLead repository from
+// lead.NewOpenLeadRepository (added in #22) — internal/membership never
+// imports internal/auth or internal/lead; only this file (and those
+// packages themselves) know all three exist (ADR-011).
 type membershipStore struct {
 	pool *pgxpool.Pool
 }
@@ -40,5 +43,7 @@ func membershipReposFor(q db.Querier) membership.Repos {
 		Member:       membership.New(q),
 		Audit:        auditlog.New(q),
 		RefreshToken: auth.NewRefreshTokenRevoker(q),
+		OpenLead:     lead.NewOpenLeadRepository(q),
+		Activity:     activity.NewRecorder(q),
 	}
 }

--- a/crm_be/cmd/api/notification_store.go
+++ b/crm_be/cmd/api/notification_store.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/notification"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+)
+
+// notificationStore is the composition root's implementation of
+// notification.Store — same wiring pattern as every other _store.go.
+type notificationStore struct {
+	pool *pgxpool.Pool
+}
+
+func newNotificationStore(pool *pgxpool.Pool) notification.Store {
+	return &notificationStore{pool: pool}
+}
+
+func (s *notificationStore) InTx(ctx context.Context, fn func(notification.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(notificationReposFor(tx))
+	})
+}
+
+func (s *notificationStore) Repos() notification.Repos {
+	return notificationReposFor(s.pool)
+}
+
+func notificationReposFor(q db.Querier) notification.Repos {
+	return notification.Repos{
+		Notification: notification.New(q),
+	}
+}

--- a/crm_be/internal/lead/entity.go
+++ b/crm_be/internal/lead/entity.go
@@ -153,6 +153,16 @@ type UpdateStatusInput struct {
 	LostReason *string
 }
 
+// UpdateAssignmentInput is Usecase.UpdateAssignment's argument.
+// AssignedToMembershipID nil means unassign — unlike UpdateLeadInput's
+// fields, this one distinguishes "clear it" from "don't touch" because
+// there's no third state to confuse it with (TD §8:
+// {version, assigned_to_membership_id | null}, always present).
+type UpdateAssignmentInput struct {
+	Version                int
+	AssignedToMembershipID *uuid.UUID
+}
+
 // VersionConflictError carries the row's current state — TD §4's 409
 // body requirement ("body memuat keadaan terkini"). Same pattern as
 // auth.OrganizationSelectionError: a documented, narrow extension of the

--- a/crm_be/internal/lead/handler_http.go
+++ b/crm_be/internal/lead/handler_http.go
@@ -32,6 +32,7 @@ func (h *Handler) RegisterRoutes(r gin.IRouter, authMW gin.HandlerFunc) {
 	g.GET("/:id", h.get)
 	g.PATCH("/:id", h.update)
 	g.PATCH("/:id/status", h.updateStatus)
+	g.PATCH("/:id/assignment", h.updateAssignment)
 	g.DELETE("/:id", h.delete)
 }
 
@@ -193,6 +194,39 @@ func (h *Handler) updateStatus(c *gin.Context) {
 	}
 
 	updated, err := h.usecase.UpdateStatus(c.Request.Context(), t, id, UpdateStatusInput(req))
+	if err != nil {
+		respondLeadError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusOK, leadJSON(updated))
+}
+
+type updateAssignmentRequest struct {
+	Version                int     `json:"version"`
+	AssignedToMembershipID *string `json:"assigned_to_membership_id"`
+}
+
+func (h *Handler) updateAssignment(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	var req updateAssignmentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	in := UpdateAssignmentInput{Version: req.Version}
+	if assignee, err := parseUUIDPtr(req.AssignedToMembershipID); err == nil {
+		in.AssignedToMembershipID = assignee
+	}
+
+	updated, err := h.usecase.UpdateAssignment(c.Request.Context(), t, id, in)
 	if err != nil {
 		respondLeadError(c, err)
 		return

--- a/crm_be/internal/lead/handler_test.go
+++ b/crm_be/internal/lead/handler_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/notification"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/accesstoken"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
@@ -45,12 +46,12 @@ func newTestStore(pool *pgxpool.Pool) lead.Store { return &testStore{pool: pool}
 
 func (s *testStore) InTx(ctx context.Context, fn func(lead.Repos) error) error {
 	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
-		return fn(lead.Repos{Lead: lead.New(tx), Activity: activity.NewRecorder(tx)})
+		return fn(lead.Repos{Lead: lead.New(tx), Activity: activity.NewRecorder(tx), Notification: notification.NewNotifier(tx)})
 	})
 }
 
 func (s *testStore) Repos() lead.Repos {
-	return lead.Repos{Lead: lead.New(s.pool), Activity: activity.NewRecorder(s.pool)}
+	return lead.Repos{Lead: lead.New(s.pool), Activity: activity.NewRecorder(s.pool), Notification: notification.NewNotifier(s.pool)}
 }
 
 func newTestRouter(t *testing.T) (*gin.Engine, *pgxpool.Pool) {
@@ -397,6 +398,102 @@ func TestHandler_List_FilterAssignedToNone(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &body)
 	if body.Meta.Total != 1 || len(body.Data) != 1 || body.Data[0].Name != "Unassigned" {
 		t.Errorf("expected exactly 1 unassigned lead, got %+v", body)
+	}
+}
+
+// --- assignment tests (TD §11) ---
+
+func TestHandler_UpdateAssignment_ToColleague_CreatesActivityAndNotification(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	colleague := seedEmployeeMembership(t, ctx, pool, org)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Budi"}, nil)
+	id, version := extractIDAndVersion(t, created)
+
+	w := doJSON(r, http.MethodPatch, "/v1/leads/"+id+"/assignment", token,
+		map[string]any{"version": version, "assigned_to_membership_id": colleague.String()}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var activityCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM activities WHERE lead_id = $1 AND type = 'lead_assigned'`, id).Scan(&activityCount); err != nil {
+		t.Fatalf("query activities: %v", err)
+	}
+	if activityCount != 1 {
+		t.Errorf("expected 1 lead_assigned activity, got %d", activityCount)
+	}
+
+	var notifCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM notifications WHERE lead_id = $1 AND recipient_membership_id = $2`, id, colleague).Scan(&notifCount); err != nil {
+		t.Fatalf("query notifications: %v", err)
+	}
+	if notifCount != 1 {
+		t.Errorf("expected 1 notification for the colleague, got %d", notifCount)
+	}
+}
+
+func TestHandler_UpdateAssignment_ToSelf_NoNotification(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Budi"}, nil)
+	id, version := extractIDAndVersion(t, created)
+
+	w := doJSON(r, http.MethodPatch, "/v1/leads/"+id+"/assignment", token,
+		map[string]any{"version": version, "assigned_to_membership_id": membershipID.String()}, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var notifCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM notifications WHERE lead_id = $1`, id).Scan(&notifCount); err != nil {
+		t.Fatalf("query notifications: %v", err)
+	}
+	if notifCount != 0 {
+		t.Errorf("expected no notification for self-assignment, got %d", notifCount)
+	}
+}
+
+// TestHandler_UpdateAssignment_InvalidAssignee_Returns400 is the same
+// regression-test discipline as #20's ErrAssigneeNotFound fix — a
+// nonexistent membership must map to a clean 400, not a bare 500.
+func TestHandler_UpdateAssignment_InvalidAssignee_Returns400(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Budi"}, nil)
+	id, version := extractIDAndVersion(t, created)
+
+	bogus := uuid.Must(uuid.NewV7())
+	w := doJSON(r, http.MethodPatch, "/v1/leads/"+id+"/assignment", token,
+		map[string]any{"version": version, "assigned_to_membership_id": bogus.String()}, nil)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for a nonexistent assignee, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_UpdateAssignment_EmployeeForbidden(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+
+	created := doJSON(r, http.MethodPost, "/v1/leads", token, map[string]string{"name": "Budi"}, nil)
+	id, version := extractIDAndVersion(t, created)
+
+	employeeToken := bearerToken(t, uuid.Must(uuid.NewV7()), org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+	w := doJSON(r, http.MethodPatch, "/v1/leads/"+id+"/assignment", employeeToken,
+		map[string]any{"version": version, "assigned_to_membership_id": nil}, nil)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/crm_be/internal/lead/port.go
+++ b/crm_be/internal/lead/port.go
@@ -22,6 +22,7 @@ type Repository interface {
 	FindAllByOrg(ctx context.Context, t tenant.Context, filter ListFilter) ([]*Lead, int, error)
 	Update(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, in UpdateInput) (*Lead, error)
 	UpdateStatus(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, status string, lostReason *string) (*Lead, error)
+	UpdateAssignment(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, assignedTo *uuid.UUID) (*Lead, error)
 	Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error
 }
 
@@ -36,13 +37,22 @@ type ActivityRecorder interface {
 	Record(ctx context.Context, t tenant.Context, leadID uuid.UUID, activityType string, actorMembershipID *uuid.UUID, metadata map[string]any) error
 }
 
+// NotificationSender is declared locally per ADR-011, same shape as
+// notification.Notifier — lead needs only to send a notification, not
+// notification's full domain type. Satisfied by notification.NewNotifier's
+// return value at the composition root, same bridging pattern as
+// ActivityRecorder.
+type NotificationSender interface {
+	Notify(ctx context.Context, t tenant.Context, recipientMembershipID uuid.UUID, notifType string, leadID, taskID *uuid.UUID, title string, body *string) error
+}
+
 // Repos bundles what a single Usecase call needs. Activity was added in
 // #21 when lead events first needed cross-table atomicity with activity
-// rows (TD §10) — #20 wrote no activities at all, so there was nothing
-// to add before now.
+// rows (TD §10). Notification was added in #22 for assignment (TD §11).
 type Repos struct {
-	Lead     Repository
-	Activity ActivityRecorder
+	Lead         Repository
+	Activity     ActivityRecorder
+	Notification NotificationSender
 }
 
 // Store is the Unit of Work Usecase depends on — same shape as every
@@ -54,4 +64,19 @@ type Repos struct {
 type Store interface {
 	InTx(ctx context.Context, fn func(Repos) error) error
 	Repos() Repos
+}
+
+// OpenLeadRepository is lead's own interface matching membership's
+// locally-declared interface of the same shape — exists purely so the
+// composition root can hand membership.Repos.OpenLead a value
+// satisfying membership's own interface without membership importing
+// this package (ADR-011, same bridging pattern as
+// auth.RefreshTokenRevoker). NOT part of Repository above: lead's own
+// Usecase never calls these — only membership.Usecase.Deactivate does,
+// closing the Phase 1 obligation (TD §13) that a membership can't be
+// deactivated while it still owns open leads.
+type OpenLeadRepository interface {
+	CountOpen(ctx context.Context, t tenant.Context, membershipID uuid.UUID) (int, error)
+	UnassignOpen(ctx context.Context, t tenant.Context, membershipID uuid.UUID) ([]uuid.UUID, error)
+	ReassignOpen(ctx context.Context, t tenant.Context, membershipID, reassignTo uuid.UUID) ([]uuid.UUID, error)
 }

--- a/crm_be/internal/lead/repository_postgres.go
+++ b/crm_be/internal/lead/repository_postgres.go
@@ -32,6 +32,14 @@ func New(q db.Querier) Repository {
 	return &postgresRepository{q: q}
 }
 
+// NewOpenLeadRepository exposes the same concrete implementation as
+// New, typed through OpenLeadRepository — see that interface's doc
+// comment in port.go for why this exists (same pattern as
+// auth.NewRefreshTokenRevoker).
+func NewOpenLeadRepository(q db.Querier) OpenLeadRepository {
+	return &postgresRepository{q: q}
+}
+
 // Create allocates the next lead_number for t.OrganizationID and inserts
 // the row using the SAME r.q for both statements. The allocating
 // UPDATE ... RETURNING is a single atomic statement, so concurrent
@@ -281,6 +289,42 @@ func (r *postgresRepository) UpdateStatus(ctx context.Context, t tenant.Context,
 	return updated, nil
 }
 
+// UpdateAssignment mirrors UpdateStatus's exact shape, touching only
+// assigned_to_membership_id/version. A nil assignedTo clears it
+// (unassign). The employee-scope guard is kept for consistency with
+// every other mutating method here even though authz.ActionLeadAssign
+// already blocks Employee from ever reaching this — same precedent
+// Delete already set.
+func (r *postgresRepository) UpdateAssignment(ctx context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, assignedTo *uuid.UUID) (*Lead, error) {
+	const q = `
+		UPDATE leads
+		SET version = version + 1, assigned_to_membership_id = $5
+		WHERE id = $1 AND organization_id = $2 AND version = $3 AND deleted_at IS NULL
+		  AND (NOT $4 OR assigned_to_membership_id = $6)
+		RETURNING ` + leadColumns
+
+	row := r.q.QueryRow(ctx, q,
+		id, t.OrganizationID, expectedVersion, isEmployee(t),
+		assignedTo, membershipIDOrNil(t),
+	)
+	updated, err := scanLead(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		current, findErr := r.FindByID(ctx, t, id)
+		if findErr != nil {
+			return nil, findErr
+		}
+		return current, ErrVersionConflict
+	}
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" && pgErr.ConstraintName == assigneeFKConstraint {
+			return nil, ErrAssigneeNotFound
+		}
+		return nil, fmt.Errorf("lead: update assignment: %w", err)
+	}
+	return updated, nil
+}
+
 // Delete soft-deletes id within t's scope (Rule #18). No version check —
 // TD doesn't gate delete on optimistic locking the way it does field/status
 // updates; deleting an already-stale-looking row is still a safe delete.
@@ -298,6 +342,98 @@ func (r *postgresRepository) Delete(ctx context.Context, t tenant.Context, id uu
 		return httpx.ErrNotFound
 	}
 	return nil
+}
+
+// openLeadCondition is TD §13's definition of "lead terbuka": status
+// not in any of the four final states, and not soft-deleted (the
+// deleted_at check lives in each caller alongside this constant since
+// it's ANDed with other column references there).
+const openLeadCondition = `status NOT IN ('won','lost','unqualified','spam')`
+
+// CountOpen, UnassignOpen, and ReassignOpen back OpenLeadRepository —
+// membership.Usecase.Deactivate's only way to ask "does this membership
+// still own open leads" and act on the answer, without membership
+// importing this package (see OpenLeadRepository's doc comment in
+// port.go). None of these take an employee-scope guard: they operate on
+// ALL leads assigned to a specific membershipID regardless of who's
+// calling — the caller (membership) already gated this to Owner/Admin
+// via its own authz check before ever reaching here.
+
+func (r *postgresRepository) CountOpen(ctx context.Context, t tenant.Context, membershipID uuid.UUID) (int, error) {
+	const q = `
+		SELECT count(*) FROM leads
+		WHERE organization_id = $1 AND assigned_to_membership_id = $2 AND deleted_at IS NULL
+		  AND ` + openLeadCondition
+
+	var count int
+	if err := r.q.QueryRow(ctx, q, t.OrganizationID, membershipID).Scan(&count); err != nil {
+		return 0, fmt.Errorf("lead: count open: %w", err)
+	}
+	return count, nil
+}
+
+// UnassignOpen clears assigned_to_membership_id for every open lead
+// assigned to membershipID, returning their ids so the caller can log
+// one lead_unassigned activity per lead in the same transaction (TD
+// §13).
+func (r *postgresRepository) UnassignOpen(ctx context.Context, t tenant.Context, membershipID uuid.UUID) ([]uuid.UUID, error) {
+	const q = `
+		UPDATE leads SET version = version + 1, assigned_to_membership_id = NULL
+		WHERE organization_id = $1 AND assigned_to_membership_id = $2 AND deleted_at IS NULL
+		  AND ` + openLeadCondition + `
+		RETURNING id`
+
+	return scanLeadIDs(r.q.Query(ctx, q, t.OrganizationID, membershipID))
+}
+
+// ReassignOpen moves every open lead assigned to membershipID to
+// reassignTo, returning their ids for the same reason UnassignOpen
+// does. A reassignTo that isn't a real membership in this organization
+// violates fk_leads_assignee — mapped directly to *httpx.ValidationError
+// here rather than the ErrAssigneeNotFound sentinel Create/
+// UpdateAssignment use: those sentinels are caught and translated by
+// lead's OWN usecase, but this method is only ever called by
+// membership.Usecase.Deactivate through the OpenLeadRepository bridge,
+// which can't import lead to recognize a lead-specific sentinel
+// (ADR-011). httpx is the one neutral package both sides already
+// import, and httpx.MapError already knows how to turn a
+// *httpx.ValidationError into 400 with no extra code in membership.
+func (r *postgresRepository) ReassignOpen(ctx context.Context, t tenant.Context, membershipID, reassignTo uuid.UUID) ([]uuid.UUID, error) {
+	const q = `
+		UPDATE leads SET version = version + 1, assigned_to_membership_id = $3
+		WHERE organization_id = $1 AND assigned_to_membership_id = $2 AND deleted_at IS NULL
+		  AND ` + openLeadCondition + `
+		RETURNING id`
+
+	ids, err := scanLeadIDs(r.q.Query(ctx, q, t.OrganizationID, membershipID, reassignTo))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" && pgErr.ConstraintName == assigneeFKConstraint {
+			return nil, httpx.NewValidationError(httpx.ErrorDetail{Field: "reassign_to", Code: "not_found"})
+		}
+		return nil, err
+	}
+	return ids, nil
+}
+
+func scanLeadIDs(rows pgx.Rows, queryErr error) ([]uuid.UUID, error) {
+	if queryErr != nil {
+		return nil, fmt.Errorf("lead: query open leads: %w", queryErr)
+	}
+	defer rows.Close()
+
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("lead: scan open lead id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lead: query open leads: %w", err)
+	}
+	return ids, nil
 }
 
 func isEmployee(t tenant.Context) bool {

--- a/crm_be/internal/lead/usecase.go
+++ b/crm_be/internal/lead/usecase.go
@@ -251,6 +251,64 @@ func (u *Usecase) UpdateStatus(ctx context.Context, t tenant.Context, id uuid.UU
 	return updated, nil
 }
 
+// UpdateAssignment sets or clears id's assignee and records the
+// resulting activity (lead_assigned or lead_unassigned) atomically with
+// it (TD §11), plus a notification when assigning to someone other than
+// the actor — assigning to yourself is deliberately silent (TD §11:
+// "memberi tahu seseorang tentang tindakannya sendiri hanya menambah
+// bising").
+func (u *Usecase) UpdateAssignment(ctx context.Context, t tenant.Context, id uuid.UUID, in UpdateAssignmentInput) (*Lead, error) {
+	if err := authz.Require(t, authz.ActionLeadAssign); err != nil {
+		return nil, err
+	}
+
+	var updated *Lead
+	var conflict bool
+	txErr := u.store.InTx(ctx, func(r Repos) error {
+		current, err := r.Lead.FindByID(ctx, t, id)
+		if err != nil {
+			return err
+		}
+		fromAssignee := current.AssignedToMembershipID
+
+		result, err := r.Lead.UpdateAssignment(ctx, t, id, in.Version, in.AssignedToMembershipID)
+		if errors.Is(err, ErrVersionConflict) {
+			updated = result
+			conflict = true
+			return ErrVersionConflict
+		}
+		if err != nil {
+			return err
+		}
+		updated = result
+
+		if in.AssignedToMembershipID == nil {
+			return r.Activity.Record(ctx, t, id, "lead_unassigned", t.MembershipID, map[string]any{"from": fromAssignee})
+		}
+
+		newAssignee := *in.AssignedToMembershipID
+		if err := r.Activity.Record(ctx, t, id, "lead_assigned", t.MembershipID, map[string]any{"from": fromAssignee, "to": newAssignee}); err != nil {
+			return err
+		}
+
+		if t.MembershipID != nil && newAssignee == *t.MembershipID {
+			return nil // self-assignment — no notification
+		}
+		title := fmt.Sprintf("Lead #%d ditugaskan kepada Anda", updated.LeadNumber)
+		return r.Notification.Notify(ctx, t, newAssignee, "lead_assigned", &id, nil, title, &updated.Name)
+	})
+	if conflict {
+		return nil, &VersionConflictError{Current: updated}
+	}
+	if errors.Is(txErr, ErrAssigneeNotFound) {
+		return nil, httpx.NewValidationError(httpx.ErrorDetail{Field: "assigned_to_membership_id", Code: "not_found"})
+	}
+	if txErr != nil {
+		return nil, txErr
+	}
+	return updated, nil
+}
+
 func (u *Usecase) Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error {
 	if err := authz.Require(t, authz.ActionLeadDelete); err != nil {
 		return err

--- a/crm_be/internal/lead/usecase_unit_test.go
+++ b/crm_be/internal/lead/usecase_unit_test.go
@@ -109,6 +109,19 @@ func (f *fakeLeadRepo) UpdateStatus(_ context.Context, t tenant.Context, id uuid
 	return l, nil
 }
 
+func (f *fakeLeadRepo) UpdateAssignment(_ context.Context, t tenant.Context, id uuid.UUID, expectedVersion int, assignedTo *uuid.UUID) (*lead.Lead, error) {
+	l, err := f.FindByID(context.Background(), t, id)
+	if err != nil {
+		return nil, err
+	}
+	if l.Version != expectedVersion {
+		return l, lead.ErrVersionConflict
+	}
+	l.AssignedToMembershipID = assignedTo
+	l.Version++
+	return l, nil
+}
+
 func (f *fakeLeadRepo) Delete(_ context.Context, t tenant.Context, id uuid.UUID) error {
 	l, err := f.FindByID(context.Background(), t, id)
 	if err != nil {
@@ -143,14 +156,41 @@ func (f *fakeActivityRecorder) Record(_ context.Context, _ tenant.Context, leadI
 	return f.err
 }
 
+// recordedNotification captures one fakeNotificationSender.Notify call.
+type recordedNotification struct {
+	recipientMembershipID uuid.UUID
+	notifType             string
+	leadID                *uuid.UUID
+	taskID                *uuid.UUID
+	title                 string
+	body                  *string
+}
+
+// fakeNotificationSender lets tests assert UpdateAssignment calls
+// Notify (or doesn't, for self-assignment) with the right arguments.
+type fakeNotificationSender struct {
+	calls []recordedNotification
+}
+
+func (f *fakeNotificationSender) Notify(_ context.Context, _ tenant.Context, recipientMembershipID uuid.UUID, notifType string, leadID, taskID *uuid.UUID, title string, body *string) error {
+	f.calls = append(f.calls, recordedNotification{recipientMembershipID, notifType, leadID, taskID, title, body})
+	return nil
+}
+
 type fakeStore struct {
-	repos    lead.Repos
-	activity *fakeActivityRecorder
+	repos        lead.Repos
+	activity     *fakeActivityRecorder
+	notification *fakeNotificationSender
 }
 
 func newFakeStore() *fakeStore {
 	rec := &fakeActivityRecorder{}
-	return &fakeStore{repos: lead.Repos{Lead: newFakeLeadRepo(), Activity: rec}, activity: rec}
+	notif := &fakeNotificationSender{}
+	return &fakeStore{
+		repos:        lead.Repos{Lead: newFakeLeadRepo(), Activity: rec, Notification: notif},
+		activity:     rec,
+		notification: notif,
+	}
 }
 
 // newFakeStoreWithFailingActivity is newFakeStore, but Activity.Record
@@ -532,5 +572,123 @@ func TestUnit_UpdateStatus_ActivityRecordFailure_PropagatesError(t *testing.T) {
 	_, err := u.UpdateStatus(context.Background(), actor, created.ID, lead.UpdateStatusInput{Version: created.Version, Status: "contacted"})
 	if err == nil {
 		t.Fatal("expected UpdateStatus to fail when recording the activity fails")
+	}
+}
+
+// --- assignment tests (TD §11) ---
+
+func TestUnit_UpdateAssignment_EmployeeForbidden(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	org, ownerMembershipID := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+	owner := actorContext(org, ownerMembershipID, tenant.RoleOwner)
+	created, _, _ := u.Create(context.Background(), owner, lead.CreateLeadInput{Name: "Budi"})
+
+	employeeCtx := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+	someone := uuid.Must(uuid.NewV7())
+	_, err := u.UpdateAssignment(context.Background(), employeeCtx, created.ID, lead.UpdateAssignmentInput{Version: created.Version, AssignedToMembershipID: &someone})
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "forbidden" {
+		t.Fatalf("expected forbidden for employee assignment, got: %v", err)
+	}
+}
+
+func TestUnit_UpdateAssignment_ToOther_RecordsActivityAndNotifies(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+	store.activity.calls = nil // drop lead_created
+
+	assignee := uuid.Must(uuid.NewV7())
+	updated, err := u.UpdateAssignment(context.Background(), actor, created.ID, lead.UpdateAssignmentInput{Version: created.Version, AssignedToMembershipID: &assignee})
+	if err != nil {
+		t.Fatalf("update assignment: %v", err)
+	}
+	if updated.AssignedToMembershipID == nil || *updated.AssignedToMembershipID != assignee {
+		t.Errorf("expected assignee %s, got %v", assignee, updated.AssignedToMembershipID)
+	}
+
+	if len(store.activity.calls) != 1 || store.activity.calls[0].activityType != "lead_assigned" {
+		t.Fatalf("expected 1 lead_assigned activity, got %+v", store.activity.calls)
+	}
+	if store.activity.calls[0].metadata["to"] != assignee {
+		t.Errorf("expected metadata.to = %s, got %v", assignee, store.activity.calls[0].metadata)
+	}
+
+	if len(store.notification.calls) != 1 {
+		t.Fatalf("expected exactly 1 notification, got %d", len(store.notification.calls))
+	}
+	if store.notification.calls[0].recipientMembershipID != assignee {
+		t.Errorf("expected notification recipient %s, got %s", assignee, store.notification.calls[0].recipientMembershipID)
+	}
+}
+
+// TestUnit_UpdateAssignment_ToSelf_NoNotification is TD §11's explicit
+// rule: "memberi tahu seseorang tentang tindakannya sendiri hanya
+// menambah bising" — the activity still fires, but Notify must not be
+// called.
+func TestUnit_UpdateAssignment_ToSelf_NoNotification(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	org, ownerMembershipID := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+	owner := actorContext(org, ownerMembershipID, tenant.RoleOwner)
+	created, _, _ := u.Create(context.Background(), owner, lead.CreateLeadInput{Name: "Budi"})
+	store.activity.calls = nil
+
+	_, err := u.UpdateAssignment(context.Background(), owner, created.ID, lead.UpdateAssignmentInput{Version: created.Version, AssignedToMembershipID: &ownerMembershipID})
+	if err != nil {
+		t.Fatalf("update assignment: %v", err)
+	}
+
+	if len(store.activity.calls) != 1 || store.activity.calls[0].activityType != "lead_assigned" {
+		t.Fatalf("expected the lead_assigned activity to still fire, got %+v", store.activity.calls)
+	}
+	if len(store.notification.calls) != 0 {
+		t.Errorf("expected no notification for self-assignment, got %d", len(store.notification.calls))
+	}
+}
+
+func TestUnit_UpdateAssignment_Unassign_RecordsActivityNoNotification(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	assignee := uuid.Must(uuid.NewV7())
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi", AssignedToMembershipID: &assignee})
+	store.activity.calls = nil
+
+	updated, err := u.UpdateAssignment(context.Background(), actor, created.ID, lead.UpdateAssignmentInput{Version: created.Version, AssignedToMembershipID: nil})
+	if err != nil {
+		t.Fatalf("update assignment: %v", err)
+	}
+	if updated.AssignedToMembershipID != nil {
+		t.Error("expected assignment to be cleared")
+	}
+
+	if len(store.activity.calls) != 1 || store.activity.calls[0].activityType != "lead_unassigned" {
+		t.Fatalf("expected 1 lead_unassigned activity, got %+v", store.activity.calls)
+	}
+	fromPtr, ok := store.activity.calls[0].metadata["from"].(*uuid.UUID)
+	if !ok || fromPtr == nil || *fromPtr != assignee {
+		t.Errorf("expected metadata.from = %s, got %v", assignee, store.activity.calls[0].metadata)
+	}
+	if len(store.notification.calls) != 0 {
+		t.Errorf("expected no notification for unassignment, got %d", len(store.notification.calls))
+	}
+}
+
+func TestUnit_UpdateAssignment_StaleVersion_ReturnsVersionConflict(t *testing.T) {
+	store := newFakeStore()
+	u := lead.NewUsecase(store)
+	actor, _ := ownerActor()
+	created, _, _ := u.Create(context.Background(), actor, lead.CreateLeadInput{Name: "Budi"})
+
+	assignee := uuid.Must(uuid.NewV7())
+	_, err := u.UpdateAssignment(context.Background(), actor, created.ID, lead.UpdateAssignmentInput{Version: created.Version - 1, AssignedToMembershipID: &assignee})
+
+	var conflict *lead.VersionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected *lead.VersionConflictError, got: %v", err)
 	}
 }

--- a/crm_be/internal/membership/entity.go
+++ b/crm_be/internal/membership/entity.go
@@ -42,3 +42,13 @@ type UpdateRoleInput struct {
 	MembershipID uuid.UUID
 	NewRole      tenant.Role
 }
+
+// OpenLeadsError is Deactivate's default-path rejection (TD §13) —
+// carries the count for the 409 body ("body memuat jumlahnya"), which
+// httpx.DomainError can't express. Same envelope-extension pattern as
+// lead.VersionConflictError.
+type OpenLeadsError struct {
+	Count int
+}
+
+func (e *OpenLeadsError) Error() string { return "membership has open leads" }

--- a/crm_be/internal/membership/handler_http.go
+++ b/crm_be/internal/membership/handler_http.go
@@ -1,6 +1,8 @@
 package membership
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -89,12 +91,36 @@ func (h *Handler) deactivate(c *gin.Context) {
 		return
 	}
 
-	if err := h.usecase.Deactivate(c.Request.Context(), t, id); err != nil {
-		httpx.WriteError(c, err)
+	in := DeactivateInput{OnOpenLeads: c.DefaultQuery("on_open_leads", onOpenLeadsReject)}
+	if raw := c.Query("reassign_to"); raw != "" {
+		if reassignTo, err := uuid.Parse(raw); err == nil {
+			in.ReassignTo = &reassignTo
+		}
+	}
+
+	if err := h.usecase.Deactivate(c.Request.Context(), t, id, in); err != nil {
+		respondMembershipError(c, err)
 		return
 	}
 
 	c.Status(http.StatusNoContent)
+}
+
+// respondMembershipError type-switches for *OpenLeadsError before
+// falling through to the generic mapper — TD §13's 409 body carries the
+// open-lead count, which httpx.DomainError can't express (same pattern
+// as lead's respondLeadError).
+func respondMembershipError(c *gin.Context, err error) {
+	var openLeads *OpenLeadsError
+	if errors.As(err, &openLeads) {
+		c.JSON(http.StatusConflict, gin.H{"error": gin.H{
+			"code":            "membership_has_open_leads",
+			"message":         fmt.Sprintf("Membership ini masih memiliki %d lead terbuka.", openLeads.Count),
+			"open_lead_count": openLeads.Count,
+		}})
+		return
+	}
+	httpx.WriteError(c, err)
 }
 
 func isValidRole(role string) bool {

--- a/crm_be/internal/membership/handler_test.go
+++ b/crm_be/internal/membership/handler_test.go
@@ -1,0 +1,307 @@
+package membership_test
+
+// Integration tests (real Postgres via dbtest) for issue #22's closure
+// of the Phase 1 obligation (TD §13): DELETE /v1/memberships/{id} must
+// refuse by default while the target still owns open leads, and the
+// unassign/reassign escape hatches must be atomic with the deactivation
+// and refresh-token revocation #11 already wrote. This is the
+// Definition of Done's explicit atomicity requirement, proven against a
+// real transaction — not just asserted on a fake.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/auditlog"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/auth"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/membership"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/accesstoken"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const testJWTSecret = "membership-handler-test-jwt-secret-32b" // #nosec G101 -- test-only value, not a real credential
+
+type testClaimsParser struct{}
+
+func (testClaimsParser) ParseAccessToken(raw string) (*accesstoken.Claims, error) {
+	return accesstoken.Parse([]byte(testJWTSecret), raw)
+}
+
+// handlerTestStore wires the REAL auth.NewRefreshTokenRevoker, unlike
+// usecase_test.go's package-level testStore (which deliberately no-ops
+// it — that file only exercises membership's own SQL). This file's
+// whole point is proving refresh-token revocation is atomic with
+// deactivation against a real transaction, so it needs the real thing.
+type handlerTestStore struct{ pool *pgxpool.Pool }
+
+func newHandlerTestStore(pool *pgxpool.Pool) membership.Store { return &handlerTestStore{pool: pool} }
+
+func (s *handlerTestStore) InTx(ctx context.Context, fn func(membership.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error { return fn(handlerTestRepos(tx)) })
+}
+
+func (s *handlerTestStore) Repos() membership.Repos { return handlerTestRepos(s.pool) }
+
+func handlerTestRepos(q db.Querier) membership.Repos {
+	return membership.Repos{
+		Member:       membership.New(q),
+		Audit:        auditlog.New(q),
+		RefreshToken: auth.NewRefreshTokenRevoker(q),
+		OpenLead:     lead.NewOpenLeadRepository(q),
+		Activity:     activity.NewRecorder(q),
+	}
+}
+
+func newTestRouter(t *testing.T) (*gin.Engine, *pgxpool.Pool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pool := dbtest.NewPool(t)
+	u := membership.NewUsecase(newHandlerTestStore(pool))
+
+	r := gin.New()
+	membership.NewHandler(u).RegisterRoutes(r, authn.Middleware(testClaimsParser{}))
+	return r, pool
+}
+
+func bearerToken(t *testing.T, userID, orgID, membershipID uuid.UUID, role tenant.Role) string {
+	t.Helper()
+	tok, err := accesstoken.Issue([]byte(testJWTSecret), 15*time.Minute, userID, orgID, membershipID, role)
+	if err != nil {
+		t.Fatalf("mint access token: %v", err)
+	}
+	return tok
+}
+
+func doJSON(r *gin.Engine, method, path, bearer string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, bytes.NewReader(nil))
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// seedLead inserts a minimal lead row directly via SQL — membership
+// doesn't depend on internal/lead's domain type, so its tests build the
+// lead they need with a raw INSERT rather than importing lead.Repository
+// (same pattern activity's and task's tests already use).
+func seedLead(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, assignedTo uuid.UUID, status string) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	var q string
+	var args []any
+	if status == "lost" {
+		q = `INSERT INTO leads (id, organization_id, lead_number, name, source, assigned_to_membership_id, status, lost_reason)
+			VALUES ($1, $2, (SELECT next_lead_number FROM organizations WHERE id = $2), 'Test Lead', 'manual', $3, $4, 'other')`
+		args = []any{id, org, assignedTo, status}
+	} else {
+		q = `INSERT INTO leads (id, organization_id, lead_number, name, source, assigned_to_membership_id, status)
+			VALUES ($1, $2, (SELECT next_lead_number FROM organizations WHERE id = $2), 'Test Lead', 'manual', $3, $4)`
+		args = []any{id, org, assignedTo, status}
+	}
+	if _, err := pool.Exec(ctx, q, args...); err != nil {
+		t.Fatalf("seed lead: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE organizations SET next_lead_number = next_lead_number + 1 WHERE id = $1`, org); err != nil {
+		t.Fatalf("bump next_lead_number: %v", err)
+	}
+	return id
+}
+
+// seedRefreshToken inserts a minimal active refresh token for
+// membershipID, so tests can confirm it gets revoked.
+func seedRefreshToken(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org, membershipID uuid.UUID) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	const q = `
+		INSERT INTO refresh_tokens (id, organization_id, membership_id, token_hash, family_id, client, expires_at)
+		VALUES ($1, $2, $3, $4, $5, 'dashboard', now() + interval '30 days')`
+	if _, err := pool.Exec(ctx, q, id, org, membershipID, id.String(), uuid.Must(uuid.NewV7())); err != nil {
+		t.Fatalf("seed refresh token: %v", err)
+	}
+	return id
+}
+
+func TestHandler_Deactivate_OpenLeads_Reject_Returns409AndNothingChanges(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+	ownerUser := seedUser(t, ctx, pool, "reject-owner@example.com")
+	ownerMembershipID := seedMembership(t, ctx, pool, org, ownerUser, tenant.RoleOwner)
+	targetUser := seedUser(t, ctx, pool, "reject-target@example.com")
+	targetMembershipID := seedMembership(t, ctx, pool, org, targetUser, tenant.RoleEmployee)
+	token := bearerToken(t, ownerUser, org, ownerMembershipID, tenant.RoleOwner)
+
+	seedLead(t, ctx, pool, org, targetMembershipID, "new")
+	seedLead(t, ctx, pool, org, targetMembershipID, "contacted")
+	seedLead(t, ctx, pool, org, targetMembershipID, "won") // must NOT count as open
+	refreshTokenID := seedRefreshToken(t, ctx, pool, org, targetMembershipID)
+
+	w := doJSON(r, http.MethodDelete, "/v1/memberships/"+targetMembershipID.String(), token)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Error struct {
+			Code          string `json:"code"`
+			OpenLeadCount int    `json:"open_lead_count"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error.Code != "membership_has_open_leads" || body.Error.OpenLeadCount != 2 {
+		t.Fatalf("expected membership_has_open_leads with count 2 (won excluded), got %+v", body)
+	}
+
+	// Nothing changed — the whole transaction must have rolled back.
+	var deletedAt *string
+	if err := pool.QueryRow(ctx, `SELECT deleted_at::text FROM memberships WHERE id = $1`, targetMembershipID).Scan(&deletedAt); err != nil {
+		t.Fatalf("query membership: %v", err)
+	}
+	if deletedAt != nil {
+		t.Error("expected the membership to remain active after a rejected deactivation")
+	}
+
+	var revokedAt *string
+	if err := pool.QueryRow(ctx, `SELECT revoked_at::text FROM refresh_tokens WHERE id = $1`, refreshTokenID).Scan(&revokedAt); err != nil {
+		t.Fatalf("query refresh token: %v", err)
+	}
+	if revokedAt != nil {
+		t.Error("expected the refresh token to remain active after a rejected deactivation")
+	}
+}
+
+func TestHandler_Deactivate_OnOpenLeadsUnassign_AtomicAllOrNothing(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+	ownerUser := seedUser(t, ctx, pool, "unassign-owner@example.com")
+	ownerMembershipID := seedMembership(t, ctx, pool, org, ownerUser, tenant.RoleOwner)
+	targetUser := seedUser(t, ctx, pool, "unassign-target@example.com")
+	targetMembershipID := seedMembership(t, ctx, pool, org, targetUser, tenant.RoleEmployee)
+	token := bearerToken(t, ownerUser, org, ownerMembershipID, tenant.RoleOwner)
+
+	leadA := seedLead(t, ctx, pool, org, targetMembershipID, "new")
+	leadB := seedLead(t, ctx, pool, org, targetMembershipID, "qualified")
+	refreshTokenID := seedRefreshToken(t, ctx, pool, org, targetMembershipID)
+
+	w := doJSON(r, http.MethodDelete, "/v1/memberships/"+targetMembershipID.String()+"?on_open_leads=unassign", token)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	for _, leadID := range []uuid.UUID{leadA, leadB} {
+		var assignedTo *uuid.UUID
+		if err := pool.QueryRow(ctx, `SELECT assigned_to_membership_id FROM leads WHERE id = $1`, leadID).Scan(&assignedTo); err != nil {
+			t.Fatalf("query lead %s: %v", leadID, err)
+		}
+		if assignedTo != nil {
+			t.Errorf("expected lead %s to be unassigned, got %v", leadID, assignedTo)
+		}
+	}
+
+	var activityCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM activities WHERE lead_id IN ($1, $2) AND type = 'lead_unassigned'`, leadA, leadB).Scan(&activityCount); err != nil {
+		t.Fatalf("query activities: %v", err)
+	}
+	if activityCount != 2 {
+		t.Errorf("expected 2 lead_unassigned activities, got %d", activityCount)
+	}
+
+	var deletedAt *string
+	if err := pool.QueryRow(ctx, `SELECT deleted_at::text FROM memberships WHERE id = $1`, targetMembershipID).Scan(&deletedAt); err != nil {
+		t.Fatalf("query membership: %v", err)
+	}
+	if deletedAt == nil {
+		t.Error("expected the membership to be deactivated")
+	}
+
+	// Proves the "semuanya atau tidak sama sekali" atomicity claim
+	// against a REAL transaction: the same InTx call that unassigned
+	// the leads also deactivated the membership and revoked its
+	// refresh token.
+	var revokedAt *string
+	if err := pool.QueryRow(ctx, `SELECT revoked_at::text FROM refresh_tokens WHERE id = $1`, refreshTokenID).Scan(&revokedAt); err != nil {
+		t.Fatalf("query refresh token: %v", err)
+	}
+	if revokedAt == nil {
+		t.Error("expected the refresh token to be revoked atomically with the deactivation")
+	}
+}
+
+func TestHandler_Deactivate_OnOpenLeadsReassign_MovesLeadsAndLogsActivity(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+	ownerUser := seedUser(t, ctx, pool, "reassign-owner@example.com")
+	ownerMembershipID := seedMembership(t, ctx, pool, org, ownerUser, tenant.RoleOwner)
+	targetUser := seedUser(t, ctx, pool, "reassign-target@example.com")
+	targetMembershipID := seedMembership(t, ctx, pool, org, targetUser, tenant.RoleEmployee)
+	destUser := seedUser(t, ctx, pool, "reassign-dest@example.com")
+	destMembershipID := seedMembership(t, ctx, pool, org, destUser, tenant.RoleEmployee)
+	token := bearerToken(t, ownerUser, org, ownerMembershipID, tenant.RoleOwner)
+
+	leadA := seedLead(t, ctx, pool, org, targetMembershipID, "new")
+
+	w := doJSON(r, http.MethodDelete,
+		"/v1/memberships/"+targetMembershipID.String()+"?on_open_leads=reassign&reassign_to="+destMembershipID.String(), token)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var assignedTo uuid.UUID
+	if err := pool.QueryRow(ctx, `SELECT assigned_to_membership_id FROM leads WHERE id = $1`, leadA).Scan(&assignedTo); err != nil {
+		t.Fatalf("query lead: %v", err)
+	}
+	if assignedTo != destMembershipID {
+		t.Errorf("expected lead reassigned to %s, got %s", destMembershipID, assignedTo)
+	}
+
+	var activityCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM activities WHERE lead_id = $1 AND type = 'lead_assigned'`, leadA).Scan(&activityCount); err != nil {
+		t.Fatalf("query activities: %v", err)
+	}
+	if activityCount != 1 {
+		t.Errorf("expected 1 lead_assigned activity, got %d", activityCount)
+	}
+}
+
+func TestHandler_Deactivate_NoOpenLeads_SucceedsWithDefaultReject(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+	ownerUser := seedUser(t, ctx, pool, "noleads-owner@example.com")
+	ownerMembershipID := seedMembership(t, ctx, pool, org, ownerUser, tenant.RoleOwner)
+	targetUser := seedUser(t, ctx, pool, "noleads-target@example.com")
+	targetMembershipID := seedMembership(t, ctx, pool, org, targetUser, tenant.RoleEmployee)
+	token := bearerToken(t, ownerUser, org, ownerMembershipID, tenant.RoleOwner)
+
+	// Only final-status leads — none of these should count as "open".
+	seedLead(t, ctx, pool, org, targetMembershipID, "won")
+	seedLead(t, ctx, pool, org, targetMembershipID, "lost")
+	seedLead(t, ctx, pool, org, targetMembershipID, "unqualified")
+	seedLead(t, ctx, pool, org, targetMembershipID, "spam")
+
+	w := doJSON(r, http.MethodDelete, "/v1/memberships/"+targetMembershipID.String(), token)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 (no open leads should block), got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/crm_be/internal/membership/port.go
+++ b/crm_be/internal/membership/port.go
@@ -36,11 +36,34 @@ type RefreshTokenRepository interface {
 	RevokeAllByMembershipID(ctx context.Context, membershipID uuid.UUID) error
 }
 
+// OpenLeadRepository is declared locally per ADR-011 — membership needs
+// only to count/release/move a membership's open leads (TD §13's own
+// naming: "hitung, lepas, pindahkan"), not lead's full domain type.
+// Satisfied by lead.NewOpenLeadRepository's return value at the
+// composition root; this package never imports internal/lead, same as
+// it never imports internal/auth for RefreshTokenRepository above.
+type OpenLeadRepository interface {
+	CountOpen(ctx context.Context, t tenant.Context, membershipID uuid.UUID) (int, error)
+	UnassignOpen(ctx context.Context, t tenant.Context, membershipID uuid.UUID) ([]uuid.UUID, error)
+	ReassignOpen(ctx context.Context, t tenant.Context, membershipID, reassignTo uuid.UUID) ([]uuid.UUID, error)
+}
+
+// ActivityRecorder is declared locally per ADR-011, same shape as
+// lead's and task's own — satisfied by activity.NewRecorder's return
+// value at the composition root. Deactivation with unassign/reassign
+// logs one lead_assigned/lead_unassigned activity per affected lead
+// (TD §13), atomically with the deactivation itself.
+type ActivityRecorder interface {
+	Record(ctx context.Context, t tenant.Context, leadID uuid.UUID, activityType string, actorMembershipID *uuid.UUID, metadata map[string]any) error
+}
+
 // Repos bundles every repository a single Usecase call needs.
 type Repos struct {
 	Member       Repository
 	Audit        AuditRepository
 	RefreshToken RefreshTokenRepository
+	OpenLead     OpenLeadRepository
+	Activity     ActivityRecorder
 }
 
 // Store is the Unit of Work Usecase depends on — same shape as auth.Store.

--- a/crm_be/internal/membership/usecase.go
+++ b/crm_be/internal/membership/usecase.go
@@ -80,13 +80,47 @@ func (u *Usecase) UpdateRole(ctx context.Context, t tenant.Context, in UpdateRol
 	return nil
 }
 
+// DeactivateInput carries the on_open_leads decision (TD §13) — closing
+// the Phase 1 obligation that a membership can't be deactivated while
+// it still owns open leads without an explicit choice about what
+// happens to them.
+type DeactivateInput struct {
+	// OnOpenLeads is "reject" (default, when empty), "unassign", or
+	// "reassign". Anything else is a validation error.
+	OnOpenLeads string
+	// ReassignTo is required when OnOpenLeads is "reassign", ignored
+	// otherwise.
+	ReassignTo *uuid.UUID
+}
+
+const (
+	onOpenLeadsReject   = "reject"
+	onOpenLeadsUnassign = "unassign"
+	onOpenLeadsReassign = "reassign"
+)
+
 // Deactivate soft-deletes a membership and revokes every refresh token
 // issued for it in the same transaction (freeze §2.3 rule #2 — without
 // this, someone who just lost access keeps working sessions until their
-// access token happens to expire).
-func (u *Usecase) Deactivate(ctx context.Context, t tenant.Context, targetID uuid.UUID) error {
+// access token happens to expire). Since #22, the same transaction also
+// settles what happens to leads still assigned to targetID (TD §13):
+// by default the whole deactivation is refused while any are open,
+// closing the obligation freeze 2.3 and 01-auth-organization/td.md §17
+// left open since Phase 1.
+func (u *Usecase) Deactivate(ctx context.Context, t tenant.Context, targetID uuid.UUID, in DeactivateInput) error {
 	if err := authz.Require(t, authz.ActionMembershipDeactivate); err != nil {
 		return err
+	}
+
+	onOpenLeads := in.OnOpenLeads
+	if onOpenLeads == "" {
+		onOpenLeads = onOpenLeadsReject
+	}
+	if onOpenLeads != onOpenLeadsReject && onOpenLeads != onOpenLeadsUnassign && onOpenLeads != onOpenLeadsReassign {
+		return httpx.NewValidationError(httpx.ErrorDetail{Field: "on_open_leads", Code: "invalid_value"})
+	}
+	if onOpenLeads == onOpenLeadsReassign && in.ReassignTo == nil {
+		return httpx.NewValidationError(httpx.ErrorDetail{Field: "reassign_to", Code: "required"})
 	}
 
 	target, err := u.store.Repos().Member.FindByID(ctx, t, targetID)
@@ -113,6 +147,37 @@ func (u *Usecase) Deactivate(ctx context.Context, t tenant.Context, targetID uui
 	}
 
 	return u.store.InTx(ctx, func(r Repos) error {
+		switch onOpenLeads {
+		case onOpenLeadsReject:
+			count, err := r.OpenLead.CountOpen(ctx, t, targetID)
+			if err != nil {
+				return err
+			}
+			if count > 0 {
+				return &OpenLeadsError{Count: count}
+			}
+		case onOpenLeadsUnassign:
+			leadIDs, err := r.OpenLead.UnassignOpen(ctx, t, targetID)
+			if err != nil {
+				return err
+			}
+			for _, leadID := range leadIDs {
+				if err := r.Activity.Record(ctx, t, leadID, "lead_unassigned", t.MembershipID, map[string]any{"from": targetID}); err != nil {
+					return err
+				}
+			}
+		case onOpenLeadsReassign:
+			leadIDs, err := r.OpenLead.ReassignOpen(ctx, t, targetID, *in.ReassignTo)
+			if err != nil {
+				return err
+			}
+			for _, leadID := range leadIDs {
+				if err := r.Activity.Record(ctx, t, leadID, "lead_assigned", t.MembershipID, map[string]any{"from": targetID, "to": *in.ReassignTo}); err != nil {
+					return err
+				}
+			}
+		}
+
 		if err := r.Member.Deactivate(ctx, t, targetID); err != nil {
 			return err
 		}

--- a/crm_be/internal/membership/usecase_test.go
+++ b/crm_be/internal/membership/usecase_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/auditlog"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/membership"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
@@ -48,6 +50,8 @@ func testRepos(q db.Querier) membership.Repos {
 		Member:       membership.New(q),
 		Audit:        auditlog.New(q),
 		RefreshToken: noopRefreshTokenRepo{},
+		OpenLead:     lead.NewOpenLeadRepository(q),
+		Activity:     activity.NewRecorder(q),
 	}
 }
 
@@ -112,7 +116,7 @@ func TestUsecase_Deactivate_SoftDeletesAgainstRealPostgres(t *testing.T) {
 	targetMembershipID := seedMembership(t, ctx, pool, org, targetUser, tenant.RoleEmployee)
 
 	actor := tenant.Context{OrganizationID: org, PrincipalType: tenant.PrincipalUser, MembershipID: &ownerMembershipID, Role: tenant.RoleOwner}
-	if err := u.Deactivate(ctx, actor, targetMembershipID); err != nil {
+	if err := u.Deactivate(ctx, actor, targetMembershipID, membership.DeactivateInput{}); err != nil {
 		t.Fatalf("deactivate: %v", err)
 	}
 
@@ -143,7 +147,7 @@ func TestUsecase_Deactivate_LastOwner_Returns409AgainstRealPostgres(t *testing.T
 	ownerMembershipID := seedMembership(t, ctx, pool, org, owner, tenant.RoleOwner)
 
 	actor := tenant.Context{OrganizationID: org, PrincipalType: tenant.PrincipalUser, MembershipID: &ownerMembershipID, Role: tenant.RoleOwner}
-	err := u.Deactivate(ctx, actor, ownerMembershipID)
+	err := u.Deactivate(ctx, actor, ownerMembershipID, membership.DeactivateInput{})
 	if err == nil {
 		t.Fatal("expected an error deactivating the last owner")
 	}

--- a/crm_be/internal/membership/usecase_unit_test.go
+++ b/crm_be/internal/membership/usecase_unit_test.go
@@ -108,14 +108,66 @@ func (f *fakeRefreshTokenRepo) RevokeAllByMembershipID(_ context.Context, member
 	return nil
 }
 
-type fakeStore struct{ repos membership.Repos }
+// fakeOpenLeadRepo lets tests control how many open leads a membership
+// "owns" and assert which of Unassign/Reassign got called with what.
+type fakeOpenLeadRepo struct {
+	openCount     int
+	unassignCalls []uuid.UUID
+	reassignCalls [][2]uuid.UUID // [membershipID, reassignTo]
+	openLeadIDs   []uuid.UUID
+	reassignErr   error
+}
+
+func (f *fakeOpenLeadRepo) CountOpen(_ context.Context, _ tenant.Context, _ uuid.UUID) (int, error) {
+	return f.openCount, nil
+}
+
+func (f *fakeOpenLeadRepo) UnassignOpen(_ context.Context, _ tenant.Context, membershipID uuid.UUID) ([]uuid.UUID, error) {
+	f.unassignCalls = append(f.unassignCalls, membershipID)
+	return f.openLeadIDs, nil
+}
+
+func (f *fakeOpenLeadRepo) ReassignOpen(_ context.Context, _ tenant.Context, membershipID, reassignTo uuid.UUID) ([]uuid.UUID, error) {
+	f.reassignCalls = append(f.reassignCalls, [2]uuid.UUID{membershipID, reassignTo})
+	if f.reassignErr != nil {
+		return nil, f.reassignErr
+	}
+	return f.openLeadIDs, nil
+}
+
+type recordedMembershipActivity struct {
+	leadID       uuid.UUID
+	activityType string
+	metadata     map[string]any
+}
+
+type fakeMembershipActivityRecorder struct{ calls []recordedMembershipActivity }
+
+func (f *fakeMembershipActivityRecorder) Record(_ context.Context, _ tenant.Context, leadID uuid.UUID, activityType string, _ *uuid.UUID, metadata map[string]any) error {
+	f.calls = append(f.calls, recordedMembershipActivity{leadID, activityType, metadata})
+	return nil
+}
+
+type fakeStore struct {
+	repos    membership.Repos
+	openLead *fakeOpenLeadRepo
+	activity *fakeMembershipActivityRecorder
+}
 
 func newFakeStore() *fakeStore {
-	return &fakeStore{repos: membership.Repos{
-		Member:       newFakeRepo(),
-		Audit:        &fakeAuditRepo{},
-		RefreshToken: &fakeRefreshTokenRepo{},
-	}}
+	openLead := &fakeOpenLeadRepo{}
+	act := &fakeMembershipActivityRecorder{}
+	return &fakeStore{
+		repos: membership.Repos{
+			Member:       newFakeRepo(),
+			Audit:        &fakeAuditRepo{},
+			RefreshToken: &fakeRefreshTokenRepo{},
+			OpenLead:     openLead,
+			Activity:     act,
+		},
+		openLead: openLead,
+		activity: act,
+	}
 }
 
 func (s *fakeStore) InTx(_ context.Context, fn func(membership.Repos) error) error {
@@ -251,7 +303,7 @@ func TestUnit_Deactivate_LastOwner_Returns409(t *testing.T) {
 	orgID := uuid.Must(uuid.NewV7())
 	ownerID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
 
-	err := u.Deactivate(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), ownerID)
+	err := u.Deactivate(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), ownerID, membership.DeactivateInput{})
 
 	var derr *httpx.DomainError
 	if !errors.As(err, &derr) || derr.Code != "last_owner_cannot_be_removed" {
@@ -268,7 +320,7 @@ func TestUnit_Deactivate_NotLastOwner_Succeeds(t *testing.T) {
 	owner1 := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
 	seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner) // second owner
 
-	err := u.Deactivate(context.Background(), actorContext(orgID, owner1, tenant.RoleOwner), owner1)
+	err := u.Deactivate(context.Background(), actorContext(orgID, owner1, tenant.RoleOwner), owner1, membership.DeactivateInput{})
 	if err != nil {
 		t.Fatalf("expected deactivation to succeed with a second owner present, got: %v", err)
 	}
@@ -284,7 +336,7 @@ func TestUnit_Deactivate_RevokesRefreshTokens(t *testing.T) {
 	ownerID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
 	targetID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
 
-	if err := u.Deactivate(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), targetID); err != nil {
+	if err := u.Deactivate(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), targetID, membership.DeactivateInput{}); err != nil {
 		t.Fatalf("deactivate: %v", err)
 	}
 
@@ -307,10 +359,157 @@ func TestUnit_Deactivate_AdminCannotTouchOwner(t *testing.T) {
 	ownerID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
 	seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner) // second owner, irrelevant here
 
-	err := u.Deactivate(context.Background(), actorContext(orgID, adminID, tenant.RoleAdmin), ownerID)
+	err := u.Deactivate(context.Background(), actorContext(orgID, adminID, tenant.RoleAdmin), ownerID, membership.DeactivateInput{})
 
 	var derr *httpx.DomainError
 	if !errors.As(err, &derr) || derr.Code != "forbidden" {
 		t.Fatalf("expected forbidden for admin deactivating owner, got: %v", err)
+	}
+}
+
+// --- on_open_leads tests (TD §13) ---
+
+// TestUnit_Deactivate_OpenLeads_Reject_BlocksAndDoesNotDeactivate is the
+// default path's core guarantee: the whole transaction aborts before
+// Member.Deactivate ever runs — provable on the fake by asserting the
+// membership is still active afterward.
+func TestUnit_Deactivate_OpenLeads_Reject_BlocksAndDoesNotDeactivate(t *testing.T) {
+	store := newFakeStore()
+	store.openLead.openCount = 2
+	u := membership.NewUsecase(store)
+	orgID := uuid.Must(uuid.NewV7())
+	ownerID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+	targetID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	err := u.Deactivate(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), targetID, membership.DeactivateInput{})
+
+	var openLeads *membership.OpenLeadsError
+	if !errors.As(err, &openLeads) || openLeads.Count != 2 {
+		t.Fatalf("expected *OpenLeadsError{Count: 2}, got: %v", err)
+	}
+
+	found, findErr := store.repos.Member.FindByID(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), targetID)
+	if findErr != nil {
+		t.Fatalf("find target: %v", findErr)
+	}
+	if found.DeletedAt != nil {
+		t.Error("expected the membership to remain active after a rejected deactivation")
+	}
+	if len(store.activity.calls) != 0 {
+		t.Errorf("expected no activity recorded on the rejected path, got %d", len(store.activity.calls))
+	}
+}
+
+// TestUnit_Deactivate_OpenLeads_DefaultIsReject proves an empty
+// OnOpenLeads behaves identically to explicit "reject" — the zero value
+// of DeactivateInput must be the safe default.
+func TestUnit_Deactivate_OpenLeads_DefaultIsReject(t *testing.T) {
+	store := newFakeStore()
+	store.openLead.openCount = 1
+	u := membership.NewUsecase(store)
+	orgID := uuid.Must(uuid.NewV7())
+	ownerID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+	targetID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	err := u.Deactivate(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), targetID, membership.DeactivateInput{OnOpenLeads: ""})
+
+	var openLeads *membership.OpenLeadsError
+	if !errors.As(err, &openLeads) {
+		t.Fatalf("expected empty OnOpenLeads to default to reject, got: %v", err)
+	}
+}
+
+func TestUnit_Deactivate_OpenLeads_Unassign_RecordsOneActivityPerLead(t *testing.T) {
+	store := newFakeStore()
+	leadA, leadB := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+	store.openLead.openLeadIDs = []uuid.UUID{leadA, leadB}
+	u := membership.NewUsecase(store)
+	orgID := uuid.Must(uuid.NewV7())
+	ownerID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+	targetID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	err := u.Deactivate(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), targetID,
+		membership.DeactivateInput{OnOpenLeads: "unassign"})
+	if err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+
+	if len(store.openLead.unassignCalls) != 1 || store.openLead.unassignCalls[0] != targetID {
+		t.Fatalf("expected UnassignOpen called once with %s, got %v", targetID, store.openLead.unassignCalls)
+	}
+	if len(store.activity.calls) != 2 {
+		t.Fatalf("expected 2 lead_unassigned activities, got %d", len(store.activity.calls))
+	}
+	for _, call := range store.activity.calls {
+		if call.activityType != "lead_unassigned" || call.metadata["from"] != targetID {
+			t.Errorf("expected lead_unassigned with from=%s, got %+v", targetID, call)
+		}
+	}
+
+	// FindByID filters out deleted rows, so check the underlying fake
+	// directly — a deactivated membership is expected to disappear from
+	// FindByID by design (Rule #6-adjacent: it's just gone, not an error).
+	stored := store.repos.Member.(*fakeRepo).byID[targetID]
+	if stored.DeletedAt == nil {
+		t.Error("expected the membership to be deactivated on the unassign path")
+	}
+}
+
+func TestUnit_Deactivate_OpenLeads_Reassign_RecordsLeadAssigned(t *testing.T) {
+	store := newFakeStore()
+	leadA := uuid.Must(uuid.NewV7())
+	store.openLead.openLeadIDs = []uuid.UUID{leadA}
+	u := membership.NewUsecase(store)
+	orgID := uuid.Must(uuid.NewV7())
+	ownerID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+	targetID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+	reassignTo := uuid.Must(uuid.NewV7())
+
+	err := u.Deactivate(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), targetID,
+		membership.DeactivateInput{OnOpenLeads: "reassign", ReassignTo: &reassignTo})
+	if err != nil {
+		t.Fatalf("deactivate: %v", err)
+	}
+
+	if len(store.openLead.reassignCalls) != 1 || store.openLead.reassignCalls[0] != [2]uuid.UUID{targetID, reassignTo} {
+		t.Fatalf("expected ReassignOpen called once with (%s, %s), got %v", targetID, reassignTo, store.openLead.reassignCalls)
+	}
+	if len(store.activity.calls) != 1 || store.activity.calls[0].activityType != "lead_assigned" {
+		t.Fatalf("expected 1 lead_assigned activity, got %+v", store.activity.calls)
+	}
+	if store.activity.calls[0].metadata["from"] != targetID || store.activity.calls[0].metadata["to"] != reassignTo {
+		t.Errorf("expected metadata {from: %s, to: %s}, got %v", targetID, reassignTo, store.activity.calls[0].metadata)
+	}
+}
+
+func TestUnit_Deactivate_OpenLeads_Reassign_RequiresReassignTo(t *testing.T) {
+	store := newFakeStore()
+	u := membership.NewUsecase(store)
+	orgID := uuid.Must(uuid.NewV7())
+	ownerID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+	targetID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	err := u.Deactivate(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), targetID,
+		membership.DeactivateInput{OnOpenLeads: "reassign"})
+
+	var verr *httpx.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected ValidationError for reassign without reassign_to, got: %v", err)
+	}
+}
+
+func TestUnit_Deactivate_OpenLeads_InvalidValue_Rejected(t *testing.T) {
+	store := newFakeStore()
+	u := membership.NewUsecase(store)
+	orgID := uuid.Must(uuid.NewV7())
+	ownerID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+	targetID := seedMember(store, orgID, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	err := u.Deactivate(context.Background(), actorContext(orgID, ownerID, tenant.RoleOwner), targetID,
+		membership.DeactivateInput{OnOpenLeads: "delete-them-all"})
+
+	var verr *httpx.ValidationError
+	if !errors.As(err, &verr) {
+		t.Fatalf("expected ValidationError for an invalid on_open_leads value, got: %v", err)
 	}
 }

--- a/crm_be/internal/notification/entity.go
+++ b/crm_be/internal/notification/entity.go
@@ -1,0 +1,26 @@
+// Package notification is the delivery mechanism other domains (lead,
+// eventually task) use to tell a member something happened. It is
+// deliberately the one resource in this codebase where even Owner/Admin
+// get no broader access than any other role — a notification belongs to
+// exactly one recipient, full stop (TD §8). See
+// docs/phases/02-crm-core/td.md §2, §8, §11.
+package notification
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Notification struct {
+	ID                    uuid.UUID
+	OrganizationID        uuid.UUID
+	RecipientMembershipID uuid.UUID
+	Type                  string
+	LeadID                *uuid.UUID
+	TaskID                *uuid.UUID
+	Title                 string
+	Body                  *string
+	ReadAt                *time.Time
+	CreatedAt             time.Time
+}

--- a/crm_be/internal/notification/handler_http.go
+++ b/crm_be/internal/notification/handler_http.go
@@ -1,0 +1,83 @@
+package notification
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+)
+
+type Handler struct {
+	usecase *Usecase
+}
+
+func NewHandler(usecase *Usecase) *Handler {
+	return &Handler{usecase: usecase}
+}
+
+func (h *Handler) RegisterRoutes(r gin.IRouter, authMW gin.HandlerFunc) {
+	g := r.Group("/v1/notifications")
+	g.Use(authMW)
+	g.GET("", h.list)
+	g.POST("/:id/read", h.markRead)
+	g.POST("/read-all", h.markAllRead)
+}
+
+func (h *Handler) list(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+	unreadOnly := c.Query("unread") == "true"
+
+	notifications, err := h.usecase.List(c.Request.Context(), t, unreadOnly)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+
+	out := make([]gin.H, 0, len(notifications))
+	for _, n := range notifications {
+		out = append(out, notificationJSON(n))
+	}
+	httpx.OK(c, http.StatusOK, out)
+}
+
+func (h *Handler) markRead(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	if err := h.usecase.MarkRead(c.Request.Context(), t, id); err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) markAllRead(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	if err := h.usecase.MarkAllRead(c.Request.Context(), t); err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func notificationJSON(n *Notification) gin.H {
+	return gin.H{
+		"id":         n.ID,
+		"type":       n.Type,
+		"lead_id":    n.LeadID,
+		"task_id":    n.TaskID,
+		"title":      n.Title,
+		"body":       n.Body,
+		"read_at":    n.ReadAt,
+		"created_at": n.CreatedAt,
+	}
+}

--- a/crm_be/internal/notification/handler_test.go
+++ b/crm_be/internal/notification/handler_test.go
@@ -1,0 +1,190 @@
+package notification_test
+
+// Integration tests (real Postgres via dbtest) for issue #22's
+// notification HTTP layer.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/notification"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/accesstoken"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const testJWTSecret = "notification-handler-test-jwt-secret-32b" // #nosec G101 -- test-only value, not a real credential
+
+type testClaimsParser struct{}
+
+func (testClaimsParser) ParseAccessToken(raw string) (*accesstoken.Claims, error) {
+	return accesstoken.Parse([]byte(testJWTSecret), raw)
+}
+
+type testStore struct{ pool *pgxpool.Pool }
+
+func newTestStore(pool *pgxpool.Pool) notification.Store { return &testStore{pool: pool} }
+
+func (s *testStore) InTx(ctx context.Context, fn func(notification.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(notification.Repos{Notification: notification.New(tx)})
+	})
+}
+
+func (s *testStore) Repos() notification.Repos {
+	return notification.Repos{Notification: notification.New(s.pool)}
+}
+
+func newTestRouter(t *testing.T) (*gin.Engine, *pgxpool.Pool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pool := dbtest.NewPool(t)
+	u := notification.NewUsecase(newTestStore(pool))
+
+	r := gin.New()
+	notification.NewHandler(u).RegisterRoutes(r, authn.Middleware(testClaimsParser{}))
+	return r, pool
+}
+
+func bearerToken(t *testing.T, userID, orgID, membershipID uuid.UUID, role tenant.Role) string {
+	t.Helper()
+	tok, err := accesstoken.Issue([]byte(testJWTSecret), 15*time.Minute, userID, orgID, membershipID, role)
+	if err != nil {
+		t.Fatalf("mint access token: %v", err)
+	}
+	return tok
+}
+
+func doJSON(r *gin.Engine, method, path, bearer string, body any) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(method, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func seedOrgAndOwner(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (org, user, membership uuid.UUID) {
+	t.Helper()
+	org = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, org); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	user = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Owner')`, user, user.String()+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	membership = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'owner')`, membership, org, user); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	return org, user, membership
+}
+
+func seedNotification(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org, recipient uuid.UUID, title string) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	const q = `INSERT INTO notifications (id, organization_id, recipient_membership_id, type, title) VALUES ($1, $2, $3, 'lead_assigned', $4)`
+	if _, err := pool.Exec(ctx, q, id, org, recipient, title); err != nil {
+		t.Fatalf("seed notification: %v", err)
+	}
+	return id
+}
+
+func TestHandler_List_UnreadFilter(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	seedNotification(t, ctx, pool, org, membershipID, "hello")
+
+	w := doJSON(r, http.MethodGet, "/v1/notifications", token, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	if len(body.Data) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(body.Data))
+	}
+
+	w2 := doJSON(r, http.MethodPost, "/v1/notifications/"+body.Data[0].ID+"/read", token, nil)
+	if w2.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w2.Code, w2.Body.String())
+	}
+
+	w3 := doJSON(r, http.MethodGet, "/v1/notifications?unread=true", token, nil)
+	var body3 struct {
+		Data []any `json:"data"`
+	}
+	_ = json.Unmarshal(w3.Body.Bytes(), &body3)
+	if len(body3.Data) != 0 {
+		t.Errorf("expected 0 unread after marking read, got %d", len(body3.Data))
+	}
+}
+
+func TestHandler_MarkRead_OtherPersonsNotification_Returns404(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, _, _ := seedOrgAndOwner(t, ctx, pool)
+
+	ownerUser := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Other')`, ownerUser, ownerUser.String()+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	otherMembership := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'owner')`, otherMembership, org, ownerUser); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	notifID := seedNotification(t, ctx, pool, org, otherMembership, "not yours")
+
+	me := uuid.Must(uuid.NewV7())
+	myToken := bearerToken(t, me, org, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+
+	w := doJSON(r, http.MethodPost, "/v1/notifications/"+notifID.String()+"/read", myToken, nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_MarkAllRead(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	seedNotification(t, ctx, pool, org, membershipID, "one")
+	seedNotification(t, ctx, pool, org, membershipID, "two")
+
+	w := doJSON(r, http.MethodPost, "/v1/notifications/read-all", token, nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w2 := doJSON(r, http.MethodGet, "/v1/notifications?unread=true", token, nil)
+	var body struct {
+		Data []any `json:"data"`
+	}
+	_ = json.Unmarshal(w2.Body.Bytes(), &body)
+	if len(body.Data) != 0 {
+		t.Errorf("expected 0 unread after read-all, got %d", len(body.Data))
+	}
+}

--- a/crm_be/internal/notification/port.go
+++ b/crm_be/internal/notification/port.go
@@ -1,0 +1,44 @@
+package notification
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Repository is what notification's own Usecase calls — deliberately
+// missing a Create method: nothing in this package's own API creates a
+// notification (TD §8's endpoint table has no POST /v1/notifications).
+// Creation only happens through Notifier below, from another domain's
+// transaction.
+type Repository interface {
+	FindAllByRecipient(ctx context.Context, t tenant.Context, unreadOnly bool) ([]*Notification, error)
+	MarkRead(ctx context.Context, t tenant.Context, id uuid.UUID) error
+	MarkAllRead(ctx context.Context, t tenant.Context) error
+}
+
+// Notifier is the narrow surface other domains (lead, eventually task)
+// need to create a notification from inside their own Store.InTx —
+// expressed with only primitive/shared types so a consumer's own
+// locally-declared NotificationSender interface (ADR-011) is satisfied
+// structurally without importing this package. Same bridging role as
+// activity.Recorder.
+type Notifier interface {
+	Notify(ctx context.Context, t tenant.Context, recipientMembershipID uuid.UUID, notifType string, leadID, taskID *uuid.UUID, title string, body *string) error
+}
+
+// Repos bundles what a single Usecase call needs — one field today,
+// same shape as every other domain's Unit of Work even though
+// notification's own usecase never itself needs a multi-repository
+// transaction (kept for composition-root wiring consistency).
+type Repos struct {
+	Notification Repository
+}
+
+// Store is the Unit of Work Usecase depends on.
+type Store interface {
+	InTx(ctx context.Context, fn func(Repos) error) error
+	Repos() Repos
+}

--- a/crm_be/internal/notification/repository_postgres.go
+++ b/crm_be/internal/notification/repository_postgres.go
@@ -1,0 +1,147 @@
+package notification
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+type postgresRepository struct {
+	q db.Querier
+}
+
+func New(q db.Querier) Repository {
+	return &postgresRepository{q: q}
+}
+
+// NewNotifier exposes the same concrete implementation as New, typed
+// through Notifier — see that interface's doc comment in port.go for
+// why this exists (same pattern as auth.NewRefreshTokenRevoker).
+func NewNotifier(q db.Querier) Notifier {
+	return &postgresRepository{q: q}
+}
+
+// Notify inserts one notification for recipientMembershipID. The
+// caller is trusted to have already validated the recipient belongs to
+// this organization — lead's assignment flow only calls this after its
+// own fk_leads_assignee check on the SAME membership id has already
+// succeeded, so a second check here would be redundant, not defensive.
+func (r *postgresRepository) Notify(ctx context.Context, t tenant.Context, recipientMembershipID uuid.UUID, notifType string, leadID, taskID *uuid.UUID, title string, body *string) error {
+	id := uuid.Must(uuid.NewV7())
+	const q = `
+		INSERT INTO notifications (id, organization_id, recipient_membership_id, type, lead_id, task_id, title, body)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+	if _, err := r.q.Exec(ctx, q, id, t.OrganizationID, recipientMembershipID, notifType, leadID, taskID, title, body); err != nil {
+		return fmt.Errorf("notification: notify: %w", err)
+	}
+	return nil
+}
+
+// FindAllByRecipient is UNCONDITIONALLY scoped to t.MembershipID,
+// regardless of role — this is the one resource in the codebase where
+// even Owner/Admin get no broader access (TD §8): a notification
+// belongs to exactly one recipient.
+func (r *postgresRepository) FindAllByRecipient(ctx context.Context, t tenant.Context, unreadOnly bool) ([]*Notification, error) {
+	q := `
+		SELECT ` + notificationColumns + `
+		FROM notifications
+		WHERE organization_id = $1 AND recipient_membership_id = $2`
+	if unreadOnly {
+		q += ` AND read_at IS NULL`
+	}
+	q += ` ORDER BY created_at DESC`
+
+	rows, err := r.q.Query(ctx, q, t.OrganizationID, membershipIDOrNil(t))
+	if err != nil {
+		return nil, fmt.Errorf("notification: find all by recipient: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Notification
+	for rows.Next() {
+		n, err := scanNotification(rows)
+		if err != nil {
+			return nil, fmt.Errorf("notification: scan: %w", err)
+		}
+		out = append(out, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("notification: find all by recipient: %w", err)
+	}
+	return out, nil
+}
+
+// MarkRead treats an already-read notification as success, not an
+// error — the client's intent ("I've seen this") is already satisfied.
+// Zero rows affected is ambiguous (already read vs. doesn't exist vs.
+// belongs to someone else), resolved by a follow-up existence check
+// scoped the same way FindAllByRecipient is.
+func (r *postgresRepository) MarkRead(ctx context.Context, t tenant.Context, id uuid.UUID) error {
+	const q = `
+		UPDATE notifications SET read_at = now()
+		WHERE id = $1 AND organization_id = $2 AND recipient_membership_id = $3 AND read_at IS NULL`
+	tag, err := r.q.Exec(ctx, q, id, t.OrganizationID, membershipIDOrNil(t))
+	if err != nil {
+		return fmt.Errorf("notification: mark read: %w", err)
+	}
+	if tag.RowsAffected() > 0 {
+		return nil
+	}
+
+	const existsQ = `
+		SELECT EXISTS (
+			SELECT 1 FROM notifications
+			WHERE id = $1 AND organization_id = $2 AND recipient_membership_id = $3
+		)`
+	var exists bool
+	if err := r.q.QueryRow(ctx, existsQ, id, t.OrganizationID, membershipIDOrNil(t)).Scan(&exists); err != nil {
+		return fmt.Errorf("notification: mark read: check existence: %w", err)
+	}
+	if !exists {
+		return httpx.ErrNotFound
+	}
+	return nil
+}
+
+// MarkAllRead is a plain UPDATE — zero rows affected (nothing unread)
+// is a legitimate no-op, not an error.
+func (r *postgresRepository) MarkAllRead(ctx context.Context, t tenant.Context) error {
+	const q = `
+		UPDATE notifications SET read_at = now()
+		WHERE organization_id = $1 AND recipient_membership_id = $2 AND read_at IS NULL`
+	if _, err := r.q.Exec(ctx, q, t.OrganizationID, membershipIDOrNil(t)); err != nil {
+		return fmt.Errorf("notification: mark all read: %w", err)
+	}
+	return nil
+}
+
+func membershipIDOrNil(t tenant.Context) uuid.UUID {
+	if t.MembershipID == nil {
+		return uuid.UUID{}
+	}
+	return *t.MembershipID
+}
+
+const notificationColumns = `
+	id, organization_id, recipient_membership_id, type, lead_id, task_id, title, body, read_at, created_at`
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanNotification(row rowScanner) (*Notification, error) {
+	var n Notification
+	err := row.Scan(
+		&n.ID, &n.OrganizationID, &n.RecipientMembershipID, &n.Type, &n.LeadID, &n.TaskID,
+		&n.Title, &n.Body, &n.ReadAt, &n.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &n, nil
+}

--- a/crm_be/internal/notification/repository_test.go
+++ b/crm_be/internal/notification/repository_test.go
@@ -1,0 +1,170 @@
+package notification_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/notification"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// TestRepository_CrossRecipientIsolation is TD §8's core requirement:
+// "tidak ada endpoint yang bisa membaca notifikasi orang lain, terlepas
+// dari role" — proven here even for Owner, which gets no broader access
+// to notifications the way it does to leads.
+func TestRepository_CrossRecipientIsolation(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := notification.New(pool)
+	notifier := notification.NewNotifier(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	membershipA := seedMembership(t, ctx, pool, org, "a@example.com", tenant.RoleOwner)
+	membershipB := seedMembership(t, ctx, pool, org, "b@example.com", tenant.RoleOwner)
+
+	if err := notifier.Notify(ctx, tenant.Context{OrganizationID: org}, membershipA, "lead_assigned", nil, nil, "for A", nil); err != nil {
+		t.Fatalf("notify A: %v", err)
+	}
+
+	listA, err := repo.FindAllByRecipient(ctx, tenant.Context{OrganizationID: org, MembershipID: &membershipA}, false)
+	if err != nil {
+		t.Fatalf("find all for A: %v", err)
+	}
+	if len(listA) != 1 {
+		t.Fatalf("expected A to see 1 notification, got %d", len(listA))
+	}
+
+	listB, err := repo.FindAllByRecipient(ctx, tenant.Context{OrganizationID: org, MembershipID: &membershipB}, false)
+	if err != nil {
+		t.Fatalf("find all for B: %v", err)
+	}
+	if len(listB) != 0 {
+		t.Fatalf("expected B to see 0 notifications (not A's), got %d", len(listB))
+	}
+
+	if err := repo.MarkRead(ctx, tenant.Context{OrganizationID: org, MembershipID: &membershipB}, listA[0].ID); !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound when B tries to mark A's notification read, got: %v", err)
+	}
+}
+
+func TestRepository_FindAllByRecipient_UnreadOnly(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := notification.New(pool)
+	notifier := notification.NewNotifier(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	membershipID := seedMembership(t, ctx, pool, org, "unread@example.com", tenant.RoleOwner)
+	tenantCtx := tenant.Context{OrganizationID: org, MembershipID: &membershipID}
+
+	if err := notifier.Notify(ctx, tenant.Context{OrganizationID: org}, membershipID, "lead_assigned", nil, nil, "one", nil); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if err := notifier.Notify(ctx, tenant.Context{OrganizationID: org}, membershipID, "lead_assigned", nil, nil, "two", nil); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+
+	all, err := repo.FindAllByRecipient(ctx, tenantCtx, false)
+	if err != nil {
+		t.Fatalf("find all: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 notifications, got %d", len(all))
+	}
+
+	if err := repo.MarkRead(ctx, tenantCtx, all[0].ID); err != nil {
+		t.Fatalf("mark read: %v", err)
+	}
+
+	unread, err := repo.FindAllByRecipient(ctx, tenantCtx, true)
+	if err != nil {
+		t.Fatalf("find unread: %v", err)
+	}
+	if len(unread) != 1 {
+		t.Fatalf("expected 1 unread notification, got %d", len(unread))
+	}
+}
+
+func TestRepository_MarkRead_AlreadyRead_IsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := notification.New(pool)
+	notifier := notification.NewNotifier(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	membershipID := seedMembership(t, ctx, pool, org, "idempotent@example.com", tenant.RoleOwner)
+	tenantCtx := tenant.Context{OrganizationID: org, MembershipID: &membershipID}
+
+	if err := notifier.Notify(ctx, tenant.Context{OrganizationID: org}, membershipID, "lead_assigned", nil, nil, "x", nil); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	list, err := repo.FindAllByRecipient(ctx, tenantCtx, false)
+	if err != nil || len(list) != 1 {
+		t.Fatalf("find all: %v, %d", err, len(list))
+	}
+
+	if err := repo.MarkRead(ctx, tenantCtx, list[0].ID); err != nil {
+		t.Fatalf("first mark read: %v", err)
+	}
+	if err := repo.MarkRead(ctx, tenantCtx, list[0].ID); err != nil {
+		t.Fatalf("expected re-marking read to succeed, got: %v", err)
+	}
+}
+
+func TestRepository_MarkAllRead_OnlyAffectsRecipientsOwn(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := notification.New(pool)
+	notifier := notification.NewNotifier(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	membershipA := seedMembership(t, ctx, pool, org, "markall-a@example.com", tenant.RoleOwner)
+	membershipB := seedMembership(t, ctx, pool, org, "markall-b@example.com", tenant.RoleOwner)
+
+	if err := notifier.Notify(ctx, tenant.Context{OrganizationID: org}, membershipA, "lead_assigned", nil, nil, "a", nil); err != nil {
+		t.Fatalf("notify a: %v", err)
+	}
+	if err := notifier.Notify(ctx, tenant.Context{OrganizationID: org}, membershipB, "lead_assigned", nil, nil, "b", nil); err != nil {
+		t.Fatalf("notify b: %v", err)
+	}
+
+	if err := repo.MarkAllRead(ctx, tenant.Context{OrganizationID: org, MembershipID: &membershipA}); err != nil {
+		t.Fatalf("mark all read: %v", err)
+	}
+
+	unreadB, err := repo.FindAllByRecipient(ctx, tenant.Context{OrganizationID: org, MembershipID: &membershipB}, true)
+	if err != nil {
+		t.Fatalf("find unread b: %v", err)
+	}
+	if len(unreadB) != 1 {
+		t.Errorf("expected B's notification to remain unread, got %d unread", len(unreadB))
+	}
+}
+
+func seedOrganization(t *testing.T, ctx context.Context, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, id); err != nil {
+		t.Fatalf("failed to seed organization: %v", err)
+	}
+	return id
+}
+
+func seedMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, email string, role tenant.Role) uuid.UUID {
+	t.Helper()
+	userID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Test User')`, userID, email); err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+	membershipID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, $4)`, membershipID, org, userID, role); err != nil {
+		t.Fatalf("failed to seed membership: %v", err)
+	}
+	return membershipID
+}

--- a/crm_be/internal/notification/usecase.go
+++ b/crm_be/internal/notification/usecase.go
@@ -1,0 +1,34 @@
+package notification
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Usecase depends only on Store (port.go), never on *pgxpool.Pool or
+// pgx.Tx directly (ADR-011). No authz.Require calls anywhere in this
+// package: every method is inherently self-scoped by t.MembershipID in
+// the repository — there's no role-based permission question to ask,
+// same as GET /v1/me needing no coarse gate.
+type Usecase struct {
+	store Store
+}
+
+func NewUsecase(store Store) *Usecase {
+	return &Usecase{store: store}
+}
+
+func (u *Usecase) List(ctx context.Context, t tenant.Context, unreadOnly bool) ([]*Notification, error) {
+	return u.store.Repos().Notification.FindAllByRecipient(ctx, t, unreadOnly)
+}
+
+func (u *Usecase) MarkRead(ctx context.Context, t tenant.Context, id uuid.UUID) error {
+	return u.store.Repos().Notification.MarkRead(ctx, t, id)
+}
+
+func (u *Usecase) MarkAllRead(ctx context.Context, t tenant.Context) error {
+	return u.store.Repos().Notification.MarkAllRead(ctx, t)
+}

--- a/crm_be/internal/notification/usecase_unit_test.go
+++ b/crm_be/internal/notification/usecase_unit_test.go
@@ -1,0 +1,174 @@
+package notification_test
+
+// TestUnit_* tests prove Usecase is decoupled from PostgreSQL (ADR-011) —
+// fake Store, no Docker. Run in isolation with:
+//
+//	go test ./internal/notification/... -run TestUnit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/notification"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// --- fakes ---
+
+type fakeNotificationRepo struct {
+	byID map[uuid.UUID]*notification.Notification
+}
+
+func newFakeNotificationRepo() *fakeNotificationRepo {
+	return &fakeNotificationRepo{byID: map[uuid.UUID]*notification.Notification{}}
+}
+
+func (f *fakeNotificationRepo) FindAllByRecipient(_ context.Context, t tenant.Context, unreadOnly bool) ([]*notification.Notification, error) {
+	var out []*notification.Notification
+	for _, n := range f.byID {
+		if n.OrganizationID != t.OrganizationID || (t.MembershipID == nil || n.RecipientMembershipID != *t.MembershipID) {
+			continue
+		}
+		if unreadOnly && n.ReadAt != nil {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+func (f *fakeNotificationRepo) MarkRead(_ context.Context, t tenant.Context, id uuid.UUID) error {
+	n, ok := f.byID[id]
+	if !ok || n.OrganizationID != t.OrganizationID || t.MembershipID == nil || n.RecipientMembershipID != *t.MembershipID {
+		return httpx.ErrNotFound
+	}
+	if n.ReadAt == nil {
+		now := n.CreatedAt
+		n.ReadAt = &now
+	}
+	return nil
+}
+
+func (f *fakeNotificationRepo) MarkAllRead(_ context.Context, t tenant.Context) error {
+	for _, n := range f.byID {
+		if n.OrganizationID == t.OrganizationID && t.MembershipID != nil && n.RecipientMembershipID == *t.MembershipID && n.ReadAt == nil {
+			now := n.CreatedAt
+			n.ReadAt = &now
+		}
+	}
+	return nil
+}
+
+type fakeStore struct{ repo *fakeNotificationRepo }
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{repo: newFakeNotificationRepo()}
+}
+
+func (s *fakeStore) InTx(_ context.Context, fn func(notification.Repos) error) error {
+	return fn(notification.Repos{Notification: s.repo})
+}
+func (s *fakeStore) Repos() notification.Repos {
+	return notification.Repos{Notification: s.repo}
+}
+
+func actorContext(orgID, membershipID uuid.UUID) tenant.Context {
+	return tenant.Context{OrganizationID: orgID, PrincipalType: tenant.PrincipalUser, MembershipID: &membershipID, Role: tenant.RoleOwner}
+}
+
+// --- tests ---
+
+func TestUnit_List_OnlyOwnNotifications(t *testing.T) {
+	store := newFakeStore()
+	u := notification.NewUsecase(store)
+	org := uuid.Must(uuid.NewV7())
+	me, other := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+
+	store.repo.byID[uuid.Must(uuid.NewV7())] = &notification.Notification{ID: uuid.Must(uuid.NewV7()), OrganizationID: org, RecipientMembershipID: me, Type: "lead_assigned", Title: "mine"}
+	store.repo.byID[uuid.Must(uuid.NewV7())] = &notification.Notification{ID: uuid.Must(uuid.NewV7()), OrganizationID: org, RecipientMembershipID: other, Type: "lead_assigned", Title: "not mine"}
+
+	list, err := u.List(context.Background(), actorContext(org, me), false)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 || list[0].Title != "mine" {
+		t.Fatalf("expected only the recipient's own notification, got %+v", list)
+	}
+}
+
+func TestUnit_List_UnreadOnlyFilter(t *testing.T) {
+	store := newFakeStore()
+	u := notification.NewUsecase(store)
+	org, me := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+
+	unread := &notification.Notification{ID: uuid.Must(uuid.NewV7()), OrganizationID: org, RecipientMembershipID: me, Type: "lead_assigned", Title: "unread"}
+	store.repo.byID[unread.ID] = unread
+
+	read := &notification.Notification{ID: uuid.Must(uuid.NewV7()), OrganizationID: org, RecipientMembershipID: me, Type: "lead_assigned", Title: "read"}
+	store.repo.byID[read.ID] = read
+	if err := u.MarkRead(context.Background(), actorContext(org, me), read.ID); err != nil {
+		t.Fatalf("mark read: %v", err)
+	}
+
+	list, err := u.List(context.Background(), actorContext(org, me), true)
+	if err != nil {
+		t.Fatalf("list unread: %v", err)
+	}
+	if len(list) != 1 || list[0].Title != "unread" {
+		t.Fatalf("expected only the unread notification, got %+v", list)
+	}
+}
+
+func TestUnit_MarkRead_AlreadyRead_IsIdempotent(t *testing.T) {
+	store := newFakeStore()
+	u := notification.NewUsecase(store)
+	org, me := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+
+	n := &notification.Notification{ID: uuid.Must(uuid.NewV7()), OrganizationID: org, RecipientMembershipID: me, Type: "lead_assigned", Title: "x"}
+	store.repo.byID[n.ID] = n
+
+	if err := u.MarkRead(context.Background(), actorContext(org, me), n.ID); err != nil {
+		t.Fatalf("first mark read: %v", err)
+	}
+	if err := u.MarkRead(context.Background(), actorContext(org, me), n.ID); err != nil {
+		t.Fatalf("expected marking an already-read notification read again to succeed, got: %v", err)
+	}
+}
+
+func TestUnit_MarkRead_NotOwnNotification_ReturnsNotFound(t *testing.T) {
+	store := newFakeStore()
+	u := notification.NewUsecase(store)
+	org, owner, other := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+
+	n := &notification.Notification{ID: uuid.Must(uuid.NewV7()), OrganizationID: org, RecipientMembershipID: owner, Type: "lead_assigned", Title: "x"}
+	store.repo.byID[n.ID] = n
+
+	err := u.MarkRead(context.Background(), actorContext(org, other), n.ID)
+	if err != httpx.ErrNotFound {
+		t.Fatalf("expected httpx.ErrNotFound, got: %v", err)
+	}
+}
+
+func TestUnit_MarkAllRead_MarksOnlyOwnUnread(t *testing.T) {
+	store := newFakeStore()
+	u := notification.NewUsecase(store)
+	org, me, other := uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7())
+
+	mine := &notification.Notification{ID: uuid.Must(uuid.NewV7()), OrganizationID: org, RecipientMembershipID: me, Type: "lead_assigned", Title: "mine"}
+	store.repo.byID[mine.ID] = mine
+	theirs := &notification.Notification{ID: uuid.Must(uuid.NewV7()), OrganizationID: org, RecipientMembershipID: other, Type: "lead_assigned", Title: "theirs"}
+	store.repo.byID[theirs.ID] = theirs
+
+	if err := u.MarkAllRead(context.Background(), actorContext(org, me)); err != nil {
+		t.Fatalf("mark all read: %v", err)
+	}
+	if mine.ReadAt == nil {
+		t.Error("expected my notification to be marked read")
+	}
+	if theirs.ReadAt != nil {
+		t.Error("expected another recipient's notification to remain unread")
+	}
+}

--- a/crm_be/internal/shared/authz/authz.go
+++ b/crm_be/internal/shared/authz/authz.go
@@ -34,16 +34,18 @@ const (
 	ActionInvitationList       Action = "invitation.list"
 	ActionInvitationRevoke     Action = "invitation.revoke"
 
-	// Lead actions cover only what issue #20 ships — list/read share one
-	// action (identical permissions at every role); lead.assign and
-	// lead.convert land with #22/#23. Employee's read/update access is
-	// further restricted to leads assigned to them, enforced in
-	// internal/lead's repository (Rule: authz answers "this class of
-	// action at all", not "which rows").
+	// Lead actions — list/read share one action (identical permissions
+	// at every role); lead.convert lands with #23. Employee's read/
+	// update access is further restricted to leads assigned to them,
+	// enforced in internal/lead's repository (Rule: authz answers "this
+	// class of action at all", not "which rows").
 	ActionLeadCreate Action = "lead.create"
 	ActionLeadRead   Action = "lead.read"
 	ActionLeadUpdate Action = "lead.update"
 	ActionLeadDelete Action = "lead.delete"
+	// ActionLeadAssign is Owner/Admin/Manager only, same shape as
+	// ActionLeadDelete — TD §9's matrix denies Employee both.
+	ActionLeadAssign Action = "lead.assign"
 
 	// Activity and task actions cover only what issue #21 ships.
 	// Employee access is further restricted in the repository to leads
@@ -81,6 +83,7 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionLeadRead:             true,
 		ActionLeadUpdate:           true,
 		ActionLeadDelete:           true,
+		ActionLeadAssign:           true,
 		ActionActivityCreate:       true,
 		ActionActivityList:         true,
 		ActionTaskCreate:           true,
@@ -100,6 +103,7 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionLeadRead:             true,
 		ActionLeadUpdate:           true,
 		ActionLeadDelete:           true,
+		ActionLeadAssign:           true,
 		ActionActivityCreate:       true,
 		ActionActivityList:         true,
 		ActionTaskCreate:           true,
@@ -115,6 +119,7 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionLeadUpdate:     true,
 		// ActionLeadDelete deliberately absent — matrix gives delete to
 		// Owner/Admin only.
+		ActionLeadAssign:     true,
 		ActionActivityCreate: true,
 		ActionActivityList:   true,
 		ActionTaskCreate:     true,

--- a/crm_be/internal/shared/authz/authz_test.go
+++ b/crm_be/internal/shared/authz/authz_test.go
@@ -25,6 +25,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleOwner, authz.ActionLeadRead, true},
 		{tenant.RoleOwner, authz.ActionLeadUpdate, true},
 		{tenant.RoleOwner, authz.ActionLeadDelete, true},
+		{tenant.RoleOwner, authz.ActionLeadAssign, true},
 		{tenant.RoleOwner, authz.ActionActivityCreate, true},
 		{tenant.RoleOwner, authz.ActionActivityList, true},
 		{tenant.RoleOwner, authz.ActionTaskCreate, true},
@@ -43,6 +44,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleAdmin, authz.ActionLeadRead, true},
 		{tenant.RoleAdmin, authz.ActionLeadUpdate, true},
 		{tenant.RoleAdmin, authz.ActionLeadDelete, true},
+		{tenant.RoleAdmin, authz.ActionLeadAssign, true},
 		{tenant.RoleAdmin, authz.ActionActivityCreate, true},
 		{tenant.RoleAdmin, authz.ActionActivityList, true},
 		{tenant.RoleAdmin, authz.ActionTaskCreate, true},
@@ -61,6 +63,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleManager, authz.ActionLeadRead, true},
 		{tenant.RoleManager, authz.ActionLeadUpdate, true},
 		{tenant.RoleManager, authz.ActionLeadDelete, false},
+		{tenant.RoleManager, authz.ActionLeadAssign, true},
 		{tenant.RoleManager, authz.ActionActivityCreate, true},
 		{tenant.RoleManager, authz.ActionActivityList, true},
 		{tenant.RoleManager, authz.ActionTaskCreate, true},
@@ -79,6 +82,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleEmployee, authz.ActionLeadRead, true}, // repository further restricts to own leads
 		{tenant.RoleEmployee, authz.ActionLeadUpdate, true},
 		{tenant.RoleEmployee, authz.ActionLeadDelete, false},
+		{tenant.RoleEmployee, authz.ActionLeadAssign, false},
 		{tenant.RoleEmployee, authz.ActionActivityCreate, true}, // repository further restricts to own leads
 		{tenant.RoleEmployee, authz.ActionActivityList, true},
 		{tenant.RoleEmployee, authz.ActionTaskCreate, true},

--- a/crm_be/internal/shared/db/migrate_test.go
+++ b/crm_be/internal/shared/db/migrate_test.go
@@ -139,6 +139,43 @@ func TestMigrationRoundTrip_0003CrmCore(t *testing.T) {
 	restoreLatest(t, sqlDB)
 }
 
+func TestMigrationRoundTrip_0004Notifications(t *testing.T) {
+	sqlDB := openGooseDB(t)
+
+	// Land on exactly version 3 first, so UpTo(4) below is a real
+	// migration of 0004 alone rather than a no-op against an
+	// already-fully-migrated shared container.
+	if err := goose.DownTo(sqlDB, ".", 3); err != nil {
+		t.Fatalf("goose down to 3 failed: %v", err)
+	}
+	if tableExists(t, sqlDB, "notifications") {
+		t.Fatal("expected notifications to be absent before migrating to version 4")
+	}
+
+	if err := goose.UpTo(sqlDB, ".", 4); err != nil {
+		t.Fatalf("goose up to 4 failed: %v", err)
+	}
+	if !tableExists(t, sqlDB, "notifications") {
+		t.Error("expected notifications to exist after migrating to version 4")
+	}
+
+	if err := goose.DownTo(sqlDB, ".", 3); err != nil {
+		t.Fatalf("goose down to 3 failed: %v", err)
+	}
+	if tableExists(t, sqlDB, "notifications") {
+		t.Error("expected notifications to be gone after rolling back to version 3")
+	}
+	// 0003's tables must survive rolling back 0004 — down only undoes its
+	// own migration, not everything beneath it.
+	for _, table := range crmCoreTables {
+		if !tableExists(t, sqlDB, table) {
+			t.Errorf("expected table %q (from 0003) to survive rolling back 0004", table)
+		}
+	}
+
+	restoreLatest(t, sqlDB)
+}
+
 var identityTables = []string{
 	"organizations", "users", "memberships", "subscriptions",
 	"invitations", "email_verification_tokens", "password_reset_tokens",

--- a/crm_be/migrations/0004_notifications.sql
+++ b/crm_be/migrations/0004_notifications.sql
@@ -1,0 +1,41 @@
+-- Phase 2 — CRM Core. Split from 0003 per freeze bagian 8.4.
+-- Spec: docs/phases/02-crm-core/td.md §2. Column shapes below are copied
+-- from that spec, not re-derived.
+
+-- +goose Up
+
+-- notifications — tanpa updated_at, tanpa deleted_at: notifikasi dibaca
+-- (read_at), tidak dihapus. Bukan entity bisnis yang dikelola pengguna.
+CREATE TABLE notifications (
+    id                      uuid PRIMARY KEY,
+    organization_id         uuid NOT NULL REFERENCES organizations (id),
+    recipient_membership_id uuid NOT NULL,
+    type                    text NOT NULL,
+    lead_id                 uuid,
+    task_id                 uuid,
+    title                   text NOT NULL,
+    body                    text,
+    read_at                 timestamptz,
+    created_at              timestamptz NOT NULL DEFAULT now(),
+
+    -- task_assigned adalah perluasan kecil yang disengaja terhadap freeze
+    -- A3 — biayanya satu nilai enum plus satu call site yang mekanismenya
+    -- sudah identik. Tidak dipicu di issue ini (hanya lead_assigned);
+    -- disiapkan agar migration tidak perlu diubah lagi saat dipakai.
+    CONSTRAINT ck_notifications_type CHECK (type IN ('lead_assigned','task_assigned')),
+    CONSTRAINT uq_notifications_id_org UNIQUE (id, organization_id),
+
+    CONSTRAINT fk_notifications_recipient
+        FOREIGN KEY (recipient_membership_id, organization_id) REFERENCES memberships (id, organization_id),
+    CONSTRAINT fk_notifications_lead
+        FOREIGN KEY (lead_id, organization_id) REFERENCES leads (id, organization_id),
+    CONSTRAINT fk_notifications_task
+        FOREIGN KEY (task_id, organization_id) REFERENCES tasks (id, organization_id)
+);
+
+CREATE INDEX ix_notifications_recipient_unread
+    ON notifications (organization_id, recipient_membership_id, created_at DESC)
+    WHERE read_at IS NULL;
+
+-- +goose Down
+DROP TABLE IF EXISTS notifications;

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 24 Agustus 2026 — Issue #21 selesai
-**Phase sekarang:** Phase 2 — CRM Core (3/5 issue selesai)
+**Last updated:** 24 Agustus 2026 — Issue #22 selesai
+**Phase sekarang:** Phase 2 — CRM Core (4/5 issue selesai)
 
 ---
 
@@ -32,6 +32,7 @@
 | **Issue #19 — Schema 0003, repository lead, alokasi `lead_number`, optimistic locking** | — | 2 | Migration `0003_crm_core` (`leads`, `customers`, `activities`, `tasks` + `organizations.next_lead_number`). `internal/lead` — repository murni (`entity.go`+`repository_postgres.go`, tanpa `port.go`/usecase — pola `membership` pra-#11). Alokasi `lead_number` berurutan per organization dan optimistic locking `version`, **dibuktikan di bawah konkurensi nyata** (20 goroutine bersamaan). Visibilitas employee ditegakkan di repository. Klaim awal soal kebutuhan `db.InTx` sempat berlebihan di komentar kode — diuji langsung sebelum commit, ternyata test konkurensi tidak membuktikannya; ditulis test terpisah (`TestCreate_FailedInsertInsideInTx_DoesNotBurnLeadNumber`) yang benar-benar membuktikan. Test katalog (dari #8) otomatis mencakup keempat tabel baru **tanpa perubahan**. |
 | **Issue #20 — Lead CRUD, transisi status, filter, pagination, idempotency, E.164** | — | 2 | `internal/lead` naik jadi domain penuh (`port/usecase/handler_http.go`, `Repository` jadi interface — migrasi yang sama seperti `membership` di #11). `POST/GET/PATCH/DELETE /v1/leads`, `PATCH /v1/leads/{id}/status`. `internal/shared/phone.ToE164` (Indonesia-first). Idempotency-Key dideteksi lewat unique-violation database, **dibuktikan dengan 10 POST bersamaan → tepat 1 lead**. Optimistic locking `409` membawa keadaan terkini di body. Dua `Action` RBAC baru (`lead.create/read/update/delete`). **Bug nyata ditemukan lewat test yang salah pakai** (assignee tak valid → 500 diam-diam) — diperbaiki jadi `400` bersih + test regresi. Satu penyimpangan TD didokumentasikan (keluar dari `lost` belum bisa "satu langkah tepat" tanpa riwayat dari #21). 34 test baru di `internal/lead`, semuanya lolos tanpa perubahan asersi lama. |
 | **Issue #21 — Activity append-only + auto-log, dan Task** | — | 2 | `internal/activity` dan `internal/task` baru — dua domain penuh. `ActivityRecorder` dideklarasikan konsumen (`lead`, `task`), dijembatani `activity.NewRecorder(q)` di composition root — pola `auth.RefreshTokenRevoker` (#11). `lead_created`, `status_changed` (`metadata={from,to}`), `task_created`, `task_completed` ditulis **di dalam `Store.InTx` yang sama** dengan pemicunya — `lead.Usecase.UpdateStatus` kini juga dibungkus `InTx`. `GET/POST /v1/leads/{id}/activities` (append-only — **tidak ada** `PATCH`/`DELETE`, diverifikasi lewat daftar route sungguhan). Tipe sistem dari client → `422`. `internal/task`: visibilitas employee lewat kepemilikan **lead**, bukan assignee task sendiri — dibuktikan test khusus. jsonb pertama yang benar-benar ditulis di codebase ini (`activities.metadata`), diverifikasi round-trip langsung terhadap Postgres asli. Atomisitas dibuktikan dua lapis: fake (unit) dan transaksi Postgres sungguhan (`repository_atomicity_test.go`, membuktikan rollback nyata + `lead_number` tidak "terbakar"). Satu bug desain (visibilitas `task.FindAllByLead`) ketahuan dan diperbaiki sebelum commit. Enam `Action` RBAC baru. Smoke test manual end-to-end lolos seluruh acceptance criteria. |
+| **Issue #22 — Assignment, notification (`0004`), penutupan kewajiban penonaktifan membership** | — | 2 | Migration `0004_notifications`. `internal/notification` baru — satu-satunya resource di codebase ini tanpa akses lebih luas untuk Owner/Admin, selalu di-scope ke `t.MembershipID`. `PATCH /v1/leads/{id}/assignment` — activity `lead_assigned`/`lead_unassigned` **dan** notification (kecuali assign ke diri sendiri) dalam satu `Store.InTx`. **Menutup kewajiban warisan Phase 1**: `DELETE /v1/memberships/{id}` menolak default (`409 membership_has_open_leads`) bila masih ada lead terbuka; `?on_open_leads=unassign\|reassign` sebagai jalan keluar, atomik dengan pencabutan refresh token yang sudah ada sejak #11 — **dibuktikan lewat test Postgres sungguhan**, bukan hanya fake (`internal/membership/handler_test.go`, baru). `internal/lead.OpenLeadRepository` (bridge terpisah, bukan bagian `Repository`) dipakai `internal/membership` lewat interface lokalnya sendiri — `membership` tetap tidak pernah mengimpor `lead`. Satu batu sandungan arsitektural nyata: sentinel error domain (`lead.ErrAssigneeNotFound`) tidak bisa dikenali lintas paket tanpa melanggar ADR-011 — diselesaikan dengan mengembalikan `*httpx.ValidationError` langsung dari bridge method itu sendiri. Satu `Action` RBAC baru (`lead.assign`). Smoke test manual end-to-end lolos, termasuk verifikasi refresh token benar-benar mati via `/v1/auth/refresh`. |
 
 ---
 
@@ -43,13 +44,14 @@ _(kosong)_
 
 ## Berikutnya
 
-**Issue #22 — Assignment, notification (`0004`), penutupan kewajiban penonaktifan membership**
+**Issue #23 — Customer, konversi dari lead, kasus `lead` pada harness isolasi tenant**
 
-- Cakupan & acceptance: [issue #22](https://github.com/Pravasta/jualin-crm/issues/22)
-- TD: `docs/phases/02-crm-core/td.md` §2, §8, §11, §13
-- `internal/lead/port.go`'s `Repos` kemungkinan menambah field lagi (mis. `Notification`) — assignment menulis `lead_assigned`/`lead_unassigned` (activity) **dan** notification dalam satu `Store.InTx` (TD §11).
-- Menutup kewajiban warisan Phase 1 (`docs/phases/01-auth-organization/td.md` §17): `DELETE /v1/memberships/{id}` menolak default bila ada lead terbuka — `internal/membership` akan butuh interface sempit ke `lead` (`OpenLeadRepository`), didekralasikan `membership`, diimplementasikan `lead`, dirakit di composition root — pola yang sama `auth.RefreshTokenRevoker`/`activity.Recorder` sudah pakai dua kali.
-- Berurutan: #19 (selesai) → #20 (selesai) → #21 (selesai) → #22 → #23. Rincian di `docs/phases/02-crm-core/issues.md`.
+- Cakupan & acceptance: [issue #23](https://github.com/Pravasta/jualin-crm/issues/23)
+- TD: `docs/phases/02-crm-core/td.md` §1.2, §8, §12, §16, §18
+- **Penutup Phase 2.** `internal/lead/port.go`'s `Repos` kemungkinan menambah field lagi untuk menulis `customers` + activity `lead_converted` dalam satu transaksi (TD §12).
+- `cmd/api/tenant_isolation_test.go`'s `[]isolationCase` bertambah entri `lead`/`task`/`customer`/`activity` — **sengaja ditutup di sini**, bukan sejak #19, supaya mencakup seluruh endpoint Phase 2 sekaligus (lihat `issues.md`).
+- Setelah #23 selesai: `docs/architecture/authorization.md` matriks diperbarui (menjadi nyata, bukan lagi "belum berlaku") mencakup seluruh `Action` yang ditambahkan #20–#23; `multi-tenancy.md` lapis 4 kasus #1 dan #4 jadi ✅; `STATUS.md` mencatat Phase 2 selesai + utang teknis (retensi `idempotency_key`, retensi `notifications`); Phase 3 (Owner Dashboard) dibuka.
+- Berurutan: #19 (selesai) → #20 (selesai) → #21 (selesai) → #22 (selesai) → #23. Rincian di `docs/phases/02-crm-core/issues.md`.
 
 ---
 

--- a/docs/phases/02-crm-core/notes.md
+++ b/docs/phases/02-crm-core/notes.md
@@ -159,3 +159,50 @@ Seluruh acceptance criteria issue #21 terpenuhi. Kasus 404 employee (activity & 
 - **Pola visibilitas-eksplisit-lalu-404 vs filter-diam-diam** sekarang punya preseden jelas: gunakan yang pertama untuk "satu resource spesifik milik satu lead" (`FindByID`, `FindAllByLead`), gunakan yang kedua untuk "daftar lintas-lead yang boleh menyempit" (`FindAllByOrg`). Jangan pakai `buildXWhere` yang sama untuk keduanya tanpa mikir ulang — itu persis kesalahan yang tertangkap di atas.
 - **`docs/architecture/authorization.md`'s matrix belum diperbarui** — tetap ditunda ke #23 seperti sudah dicatat di TD §9, sekarang dengan `activity.*`/`task.*` (termasuk `task.read` yang tidak ada di TD literal) sebagai baris tambahan yang perlu masuk saat itu.
 - **`internal/task`'s `Complete` tidak menolak menyelesaikan task yang sudah `done`** — pada `version` yang benar, memanggil `complete` lagi hanya menimpa ulang `completed_at`/`completed_by` tanpa error. Tidak diuji acceptance criteria manapun; disebutkan di sini supaya bukan kejutan bila suatu saat dianggap perlu perilaku berbeda.
+
+---
+
+## #22 — Assignment, notification (`0004`), penutupan kewajiban penonaktifan membership
+
+### Keputusan implementasi
+
+- **`internal/notification` baru, paket domain penuh** — satu-satunya resource di codebase ini di mana **Owner/Admin pun tidak dapat akses lebih luas** dari role lain: setiap query di-scope tanpa syarat ke `recipient_membership_id = t.MembershipID`, tanpa cabang `isEmployee`. Tidak ada `authz.Require` di `notification.Usecase` sama sekali — tidak ada pertanyaan berbasis role untuk dijawab, sama seperti `GET /v1/me`.
+- **`Repository` milik `notification.Usecase` sengaja tanpa `Create`** — tidak ada `POST /v1/notifications` di TD §8. Pembuatan notifikasi hanya lewat `Notifier` (bridge lintas paket), dipasang di `lead.Repos.Notification` lewat `notification.NewNotifier(q)` — pola yang sama `activity.Recorder` pakai, instansi ketiga dari pola `auth.RefreshTokenRevoker` di #11.
+- **`internal/lead` mendapat `OpenLeadRepository` (bridge terpisah, BUKAN bagian dari `Repository`)** — `CountOpen`/`UnassignOpen`/`ReassignOpen`, dipakai eksklusif oleh `membership.Usecase.Deactivate` lewat interface lokal `membership` sendiri (`OpenLeadRepository`, bentuk identik, dideklarasikan independen). `internal/membership` tetap tidak pernah mengimpor `internal/lead` — persis seperti tidak pernah mengimpor `internal/auth` untuk `RefreshTokenRepository`.
+- **Batu sandungan nyata: sentinel error lintas paket tidak bisa dikenali tanpa impor domain** — rencana awal `ReassignOpen` mengembalikan `lead.ErrAssigneeNotFound` saat `reassign_to` tidak valid (pelanggaran `fk_leads_assignee`), persis pola `Create`/`UpdateAssignment`. Tapi `membership.Usecase` **tidak bisa** melakukan `errors.Is` terhadap sentinel itu tanpa mengimpor `internal/lead` — melanggar ADR-011 tepat di titik yang seharusnya dicegah oleh interface bridge. Diperbaiki dengan mengembalikan `*httpx.ValidationError` **langsung dari `ReassignOpen`** (bukan sentinel domain `lead`) — `internal/shared/httpx` adalah satu-satunya paket netral yang **kedua sisi** sudah impor, dan `httpx.MapError` sudah tahu memetakannya ke `400` tanpa kode tambahan apa pun di `membership`. Pelajaran: method yang HANYA melayani sebagai bridge lintas paket (bukan dipakai usecase paket asalnya sendiri) adalah lapis yang tepat untuk menghasilkan sinyal yang sudah bisa dikenali pemanggil — beda dengan `Create`/`UpdateAssignment` yang sentinel-nya diterjemahkan oleh usecase **di paket yang sama**.
+- **`fromAssignee := current.AssignedToMembershipID` ditangkap sebelum `UpdateAssignment` dipanggil** — disiplin yang sama persis dengan `fromStatus` di `UpdateStatus` (#21), sekarang diterapkan proaktif di `UpdateAssignment` sejak awal (bukan ditemukan lewat test yang gagal seperti sebelumnya) karena polanya sudah dikenal.
+- **Assign ke diri sendiri tetap menulis activity `lead_assigned`, hanya notifikasi yang dilewati** — TD §11 eksplisit hanya menyebut notifikasi ("memberi tahu... menambah bising"), bukan activity. Timeline lead tetap mencatat siapa yang mengambil alih, meski aktor dan penerima adalah orang yang sama.
+- **`task_assigned` sengaja tidak dipicu di issue ini** — nilai enum `ck_notifications_type` sudah menyediakannya (keputusan skema TD §2), tapi tidak ada acceptance criteria issue #22 yang mensyaratkan notifikasi saat task di-assign. Dicatat eksplisit sebagai keputusan cakupan, bukan kelalaian — TD §2 sendiri menyebut ini "perluasan kecil yang disengaja", disiapkan untuk dipakai nanti.
+
+### Verifikasi
+
+```
+go build ./...                              → bersih
+go vet ./...                                → bersih
+golangci-lint run                           → 0 issues
+gofmt -l .                                  → bersih
+go test -race -count=1 ./... (2x)           → semua PASS
+
+DOCKER_HOST=unix:///nonexistent/docker.sock \
+  go test ./internal/... -run TestUnit -count=1
+                                             → PASS tanpa Docker (notification, lead, membership, + semua paket lama)
+
+go list -deps ./cmd/api | grep docker       → kosong
+```
+
+**Test atomisitas (wajib di Definition of Done)**: `internal/membership/handler_test.go` (baru) membuktikan klaim "semuanya atau tidak sama sekali" terhadap transaksi Postgres sungguhan, bukan hanya fake — `on_open_leads=unassign` dengan dua lead terbuka: kedua lead terlepas, dua activity `lead_unassigned` tercatat, membership nonaktif, **dan** refresh token yang sudah ada sebelumnya benar-benar `revoked_at`-nya terisi, semuanya diverifikasi lewat `SELECT` langsung setelah satu panggilan HTTP. Jalur `reject` dibuktikan sebaliknya: `409` dengan jumlah lead terbuka yang benar (mengecualikan lead berstatus `won`), membership **tetap aktif**, refresh token **tetap** tidak revoked — transaksi benar-benar batal, bukan hanya response error yang dikembalikan lebih dulu.
+
+**Smoke test manual** (`docker compose up --build`): register+verify+login owner → undang & terima undangan seorang employee (kolega) → `POST /v1/leads` → `PATCH /assignment` ke kolega → `GET activities` menunjukkan `lead_assigned` dengan `metadata={from:null,to:<kolega>}` → `GET /v1/notifications?unread=true` (sebagai kolega) → tepat satu notifikasi `lead_assigned` dengan title `"Lead #1 ditugaskan kepada Anda"` → `POST .../read` → `204`, hilang dari daftar unread → `PATCH /assignment` ke diri sendiri (owner) → **tidak ada** notifikasi baru → assign ulang lead ke kolega → `DELETE /v1/memberships/{kolega}` tanpa parameter → `409 membership_has_open_leads` dengan `open_lead_count: 1` → `DELETE ...?on_open_leads=unassign` → `204`, lead kembali `assigned_to_membership_id: null` → refresh token kolega (dengan cookie asli + header CSRF yang benar) → `401 invalid_credentials`, membuktikan sesi benar-benar mati. Catatan: `GET /v1/me` dengan access token JWT kolega yang **belum kedaluwarsa** tetap `200` setelah deactivation — ini bukan bug, access token JWT stateless tidak bisa dicabut instan, hanya refresh token opaque yang dicabut; ini konsisten dengan desain sejak #10.
+
+Seluruh acceptance criteria issue #22 terpenuhi. Jalur `reassign` diverifikasi otomatis lewat test Postgres (`TestHandler_Deactivate_OnOpenLeadsReassign_MovesLeadsAndLogsActivity`), tidak diulang manual.
+
+### Utang teknis
+
+- Tidak ada item baru dari issue ini sendiri.
+
+### Catatan untuk session berikutnya
+
+- **`internal/lead/port.go`'s `Repos{Lead, Activity, Notification}` sekarang tiga field.** #23 (konversi ke Customer) kemungkinan menambah field lagi untuk menulis `customers` + activity `lead_converted` dalam satu transaksi.
+- **Pola "sentinel domain diterjemahkan di usecase paket sendiri, tapi bridge lintas paket menerjemahkan langsung ke `httpx`"** sekarang punya satu contoh konkret (`lead.ReassignOpen`). Berlaku untuk bridge serupa yang akan datang — kapan pun sebuah method HANYA melayani sebagai jembatan `OpenLeadRepository`-style, jangan berasumsi errors.Is sentinel domain bisa dikenali pemanggil.
+- **`docs/architecture/authorization.md`'s matrix masih belum diperbarui** — tetap ditunda ke #23 (penutup Phase 2), sekarang bertambah `lead.assign` dan seluruh baris `activity.*`/`task.*` dari #21 yang juga belum masuk.
+- **Retensi `notifications` belum ada** — sama seperti `idempotency_key` (dicatat di `## #20`), TD tidak menyebut kebijakan retensi untuk notifikasi lama, dan Phase 2 tidak punya scheduler untuk membersihkannya. Tidak mendesak di volume MVP; dicatat di sini agar tidak terlupa saat volume bertambah.


### PR DESCRIPTION
## Summary

Fourth issue of Phase 2. Three related pieces around "who owns this lead, and who gets told about it":

- **Manual lead assignment** — `PATCH /v1/leads/{id}/assignment`. Atomic with an activity entry (`lead_assigned`/`lead_unassigned`, `metadata={from,to}`) and, when assigning to someone other than the actor, a notification. Self-assignment still logs the activity but skips the notification (TD §11: "memberi tahu seseorang tentang tindakannya sendiri hanya menambah bising").
- **`internal/notification`** (new domain, migration `0004`) — `GET/POST /v1/notifications*`. The one resource in this codebase where even Owner/Admin get no broader access than any other role: every query is unconditionally scoped to the caller's own membership, no `isEmployee`-style branch at all.
- **Closes a Phase 1 obligation** left open since #11 (`01-auth-organization/td.md` §17, freeze 2.3): `DELETE /v1/memberships/{id}` now defaults to rejecting (`409 membership_has_open_leads`, with the count) while the target still owns open leads. `?on_open_leads=unassign|reassign` are explicit escape hatches, atomic with the deactivation and refresh-token revocation `#11` already wrote — proven against a **real Postgres transaction**, not just a fake, in a new `internal/membership/handler_test.go`.

## Notable design points

- **`internal/lead` gains `OpenLeadRepository`** (count/unassign/reassign open leads) — a bridge separate from `lead`'s own `Repository` interface (lead's own usecase never calls it). `internal/membership` consumes it through its own locally-declared interface of identical shape, never importing `internal/lead` directly — same ADR-011 bridging pattern `auth.RefreshTokenRevoker` established in #11, now a third instance (`activity.Recorder` was the second).
- **A real cross-package boundary issue caught before commit**: the original plan had `ReassignOpen` return `lead.ErrAssigneeNotFound` on an invalid `reassign_to`, mirroring `Create`/`UpdateAssignment`. But `membership.Usecase` can't `errors.Is` against a sentinel it can't import without violating ADR-011. Fixed by having `ReassignOpen` — since it exists *only* to serve `membership`, not `lead`'s own usecase — return `*httpx.ValidationError` directly. `internal/shared/httpx` is the one neutral package both sides already import, and `httpx.MapError` already knows how to turn that into a clean `400`.
- **`internal/notification`'s `Repository` interface has no `Create`** — nothing in its own API creates a notification (no `POST /v1/notifications` in the endpoint table). Creation only happens through `Notifier`, the same bridging shape `activity.Recorder` uses, wired into `lead.Repos.Notification`.

## Test plan

- [x] `go build/vet ./...`, `gofmt -l .` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./... -race -count=1` — green, run twice for flakiness
- [x] `DOCKER_HOST=<bogus> go test ./internal/... -run TestUnit` — business logic confirmed Docker-free
- [x] `go list -deps ./cmd/api | grep docker` — production binary confirmed testcontainers-free
- [x] `TestMigrationRoundTrip_0004Notifications` — up/down round-trip, prior tables survive rollback
- [x] Atomicity proven against a real transaction (`internal/membership/handler_test.go`): `on_open_leads=unassign` with two open leads → both unassigned, two `lead_unassigned` activities, membership deactivated, **and** a prior refresh token is confirmed `revoked_at`-set, all via direct `SELECT` after one HTTP call. `reject` path proven the opposite: `409` with the correct count (excluding a `won` lead), membership **still active**, refresh token **still** unrevoked — the whole transaction actually rolled back.
- [x] Manual `docker compose up` smoke test: register owner → invite + accept a colleague → create a lead → assign to colleague → activity shows `lead_assigned` with correct `metadata` → colleague sees exactly one unread notification with the right title/body → mark read → disappears from `?unread=true` → assign to self → no new notification → deactivate with an open lead, no param → `409` with correct count → retry with `?on_open_leads=unassign` → `204`, lead unassigned → colleague's refresh token confirmed dead via `/v1/auth/refresh` (`401`). `reassign` path verified via the automated Postgres tests rather than repeated manually.

Refs #22