### PR TITLE
feat(customer): add lead conversion, close Phase 2 tenant isolation harness

### DIFF
--- a/crm_be/cmd/api/customer_store.go
+++ b/crm_be/cmd/api/customer_store.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/customer"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+)
+
+// customerStore is the composition root's implementation of
+// customer.Store — same wiring pattern as every other _store.go. Its
+// Activity repository comes from activity.NewRecorder, same as
+// lead/task/membership.
+type customerStore struct {
+	pool *pgxpool.Pool
+}
+
+func newCustomerStore(pool *pgxpool.Pool) customer.Store {
+	return &customerStore{pool: pool}
+}
+
+func (s *customerStore) InTx(ctx context.Context, fn func(customer.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(customerReposFor(tx))
+	})
+}
+
+func (s *customerStore) Repos() customer.Repos {
+	return customerReposFor(s.pool)
+}
+
+func customerReposFor(q db.Querier) customer.Repos {
+	return customer.Repos{
+		Customer: customer.New(q),
+		Activity: activity.NewRecorder(q),
+	}
+}

--- a/crm_be/cmd/api/main.go
+++ b/crm_be/cmd/api/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/auth"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/customer"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/invitation"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/membership"
@@ -119,6 +120,9 @@ func newRouter(log *slog.Logger, pool *pgxpool.Pool, cfg *config.Config) *gin.En
 
 	notificationUsecase := notification.NewUsecase(newNotificationStore(pool))
 	notification.NewHandler(notificationUsecase).RegisterRoutes(r, authMW)
+
+	customerUsecase := customer.NewUsecase(newCustomerStore(pool))
+	customer.NewHandler(customerUsecase).RegisterRoutes(r, authMW)
 
 	r.NoRoute(func(c *gin.Context) {
 		httpx.RespondError(c, http.StatusNotFound, "not_found", "Route tidak ditemukan.")

--- a/crm_be/cmd/api/tenant_isolation_test.go
+++ b/crm_be/cmd/api/tenant_isolation_test.go
@@ -151,6 +151,15 @@ func TestTenantIsolation_CrossOrgMutatingByID_Returns404(t *testing.T) {
 		t.Fatalf("seed invitation in org B: %v", err)
 	}
 
+	// Phase 2 resources — activates lapis 4 case #1 (cross-org GET-by-id;
+	// no domain before Phase 2 had a real one — membership only ever
+	// exposed list, not get-by-id) alongside case #2 (mutate), which the
+	// three cases above already cover for Phase 1's resources.
+	leadB := seedIsolationLead(t, pool, orgB, "new")
+	wonLeadB := seedIsolationLead(t, pool, orgB, "won")
+	taskB := seedIsolationTask(t, pool, orgB, leadB)
+	customerB := seedIsolationCustomer(t, pool, orgB, wonLeadB)
+
 	cases := []isolationCase{
 		{
 			name:   "PATCH /v1/memberships/{id} on another org's membership",
@@ -168,12 +177,69 @@ func TestTenantIsolation_CrossOrgMutatingByID_Returns404(t *testing.T) {
 			method: http.MethodDelete,
 			path:   func(id uuid.UUID) string { return "/v1/invitations/" + id.String() },
 		},
+		{
+			name:   "GET /v1/leads/{id} on another org's lead",
+			method: http.MethodGet,
+			path:   func(id uuid.UUID) string { return "/v1/leads/" + id.String() },
+		},
+		{
+			name:   "PATCH /v1/leads/{id} on another org's lead",
+			method: http.MethodPatch,
+			path:   func(id uuid.UUID) string { return "/v1/leads/" + id.String() },
+			body:   map[string]any{"version": 1, "name": "Hijacked"},
+		},
+		{
+			name:   "DELETE /v1/leads/{id} on another org's lead",
+			method: http.MethodDelete,
+			path:   func(id uuid.UUID) string { return "/v1/leads/" + id.String() },
+		},
+		{
+			name:   "GET /v1/leads/{id}/activities on another org's lead",
+			method: http.MethodGet,
+			path:   func(id uuid.UUID) string { return "/v1/leads/" + id.String() + "/activities" },
+		},
+		{
+			name:   "PATCH /v1/tasks/{id} on another org's task",
+			method: http.MethodPatch,
+			path:   func(id uuid.UUID) string { return "/v1/tasks/" + id.String() },
+			body:   map[string]any{"version": 1, "title": "Hijacked"},
+		},
+		{
+			name:   "DELETE /v1/tasks/{id} on another org's task",
+			method: http.MethodDelete,
+			path:   func(id uuid.UUID) string { return "/v1/tasks/" + id.String() },
+		},
+		{
+			name:   "GET /v1/customers/{id} on another org's customer",
+			method: http.MethodGet,
+			path:   func(id uuid.UUID) string { return "/v1/customers/" + id.String() },
+		},
+		{
+			name:   "PATCH /v1/customers/{id} on another org's customer",
+			method: http.MethodPatch,
+			path:   func(id uuid.UUID) string { return "/v1/customers/" + id.String() },
+			body:   map[string]any{"name": "Hijacked"},
+		},
+		{
+			name:   "DELETE /v1/customers/{id} on another org's customer",
+			method: http.MethodDelete,
+			path:   func(id uuid.UUID) string { return "/v1/customers/" + id.String() },
+		},
 	}
 
 	targetIDs := map[string]uuid.UUID{
 		"PATCH /v1/memberships/{id} on another org's membership":  targetMembershipB,
 		"DELETE /v1/memberships/{id} on another org's membership": targetMembershipB,
 		"DELETE /v1/invitations/{id} on another org's invitation": invB.ID,
+		"GET /v1/leads/{id} on another org's lead":                leadB,
+		"PATCH /v1/leads/{id} on another org's lead":              leadB,
+		"DELETE /v1/leads/{id} on another org's lead":             leadB,
+		"GET /v1/leads/{id}/activities on another org's lead":     leadB,
+		"PATCH /v1/tasks/{id} on another org's task":              taskB,
+		"DELETE /v1/tasks/{id} on another org's task":             taskB,
+		"GET /v1/customers/{id} on another org's customer":        customerB,
+		"PATCH /v1/customers/{id} on another org's customer":      customerB,
+		"DELETE /v1/customers/{id} on another org's customer":     customerB,
 	}
 
 	for _, tc := range cases {
@@ -184,6 +250,50 @@ func TestTenantIsolation_CrossOrgMutatingByID_Returns404(t *testing.T) {
 			}
 		})
 	}
+}
+
+// seedIsolationLead inserts a minimal lead row directly via SQL — this
+// file doesn't import internal/lead's repository beyond what's already
+// wired into newRouter, and status is easiest to set directly since
+// lead.Repository.Create always defaults to 'new'.
+func seedIsolationLead(t *testing.T, pool *pgxpool.Pool, org uuid.UUID, status string) uuid.UUID {
+	t.Helper()
+	ctx := t.Context()
+	id := uuid.Must(uuid.NewV7())
+	const q = `
+		INSERT INTO leads (id, organization_id, lead_number, name, source, status)
+		VALUES ($1, $2, (SELECT next_lead_number FROM organizations WHERE id = $2), 'Isolation Test Lead', 'manual', $3)`
+	if _, err := pool.Exec(ctx, q, id, org, status); err != nil {
+		t.Fatalf("seed isolation lead: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE organizations SET next_lead_number = next_lead_number + 1 WHERE id = $1`, org); err != nil {
+		t.Fatalf("bump next_lead_number: %v", err)
+	}
+	return id
+}
+
+func seedIsolationTask(t *testing.T, pool *pgxpool.Pool, org, leadID uuid.UUID) uuid.UUID {
+	t.Helper()
+	ctx := t.Context()
+	id := uuid.Must(uuid.NewV7())
+	const q = `INSERT INTO tasks (id, organization_id, lead_id, title) VALUES ($1, $2, $3, 'Isolation Test Task')`
+	if _, err := pool.Exec(ctx, q, id, org, leadID); err != nil {
+		t.Fatalf("seed isolation task: %v", err)
+	}
+	return id
+}
+
+func seedIsolationCustomer(t *testing.T, pool *pgxpool.Pool, org, wonLeadID uuid.UUID) uuid.UUID {
+	t.Helper()
+	ctx := t.Context()
+	id := uuid.Must(uuid.NewV7())
+	const q = `
+		INSERT INTO customers (id, organization_id, name, converted_from_lead_id)
+		VALUES ($1, $2, 'Isolation Test Customer', $3)`
+	if _, err := pool.Exec(ctx, q, id, org, wonLeadID); err != nil {
+		t.Fatalf("seed isolation customer: %v", err)
+	}
+	return id
 }
 
 // TestTenantIsolation_MultiMembership_OnlySeesActiveOrgInToken is

--- a/crm_be/internal/customer/entity.go
+++ b/crm_be/internal/customer/entity.go
@@ -1,0 +1,64 @@
+// Package customer is what a lead becomes after an explicit conversion
+// (B9 — never automatic, freeze 2.4 aturan 5). Data is copied from the
+// originating lead at conversion time, not referenced — editing a
+// customer never changes the lead it came from. See
+// docs/phases/02-crm-core/td.md §1.2, §12.
+package customer
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Customer struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+
+	Name      string
+	Email     *string
+	Phone     *string
+	PhoneE164 *string
+	Company   *string
+	Notes     *string
+
+	ConvertedFromLeadID     uuid.UUID
+	ConvertedByMembershipID *uuid.UUID
+	ConvertedAt             time.Time
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time
+}
+
+// UpdateInput is the mutable-field subset PATCH /v1/customers/{id}
+// exposes — nil means "don't touch", same limitation as
+// lead.UpdateInput. No Version field: customers aren't edited from
+// offline mobile (TD §8), so there's no write conflict to detect.
+type UpdateInput struct {
+	Name    *string
+	Email   *string
+	Phone   *string
+	Company *string
+	Notes   *string
+}
+
+// ListFilter is FindAllByOrg's argument.
+type ListFilter struct {
+	Query   string
+	Page    int
+	PerPage int
+}
+
+// ErrLeadNotWon is Convert's signal that the lead exists (and is
+// visible to the caller) but isn't status=won — the repository can't
+// tell this apart from "lead doesn't exist" by row count alone, so it
+// resolves the ambiguity itself and returns this distinct sentinel.
+var ErrLeadNotWon = errors.New("customer: lead not won")
+
+// ErrAlreadyConverted is Convert's signal that uq_customers_org_lead
+// was violated — detected via the unique-violation, never a
+// SELECT-then-INSERT, same database-constraint-as-source-of-truth
+// pattern as lead.ErrIdempotencyKeyExists.
+var ErrAlreadyConverted = errors.New("customer: lead already converted")

--- a/crm_be/internal/customer/handler_http.go
+++ b/crm_be/internal/customer/handler_http.go
@@ -1,0 +1,158 @@
+package customer
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+)
+
+type Handler struct {
+	usecase *Usecase
+}
+
+func NewHandler(usecase *Usecase) *Handler {
+	return &Handler{usecase: usecase}
+}
+
+// RegisterRoutes mounts a SECOND group at /v1/leads (same :id wildcard
+// discipline activity/task already established there) for the convert
+// action, plus /v1/customers for plain CRUD.
+func (h *Handler) RegisterRoutes(r gin.IRouter, authMW gin.HandlerFunc) {
+	leads := r.Group("/v1/leads")
+	leads.Use(authMW)
+	leads.POST("/:id/convert", h.convert)
+
+	customers := r.Group("/v1/customers")
+	customers.Use(authMW)
+	customers.GET("", h.list)
+	customers.GET("/:id", h.get)
+	customers.PATCH("/:id", h.update)
+	customers.DELETE("/:id", h.delete)
+}
+
+func (h *Handler) convert(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	leadID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	created, err := h.usecase.Convert(c.Request.Context(), t, leadID)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusCreated, customerJSON(created))
+}
+
+func (h *Handler) get(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	found, err := h.usecase.Get(c.Request.Context(), t, id)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusOK, customerJSON(found))
+}
+
+func (h *Handler) list(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	in := ListInput{Query: c.Query("q")}
+	if page, err := strconv.Atoi(c.Query("page")); err == nil {
+		in.Page = page
+	}
+	if perPage, err := strconv.Atoi(c.Query("per_page")); err == nil {
+		in.PerPage = perPage
+	}
+
+	customers, meta, err := h.usecase.List(c.Request.Context(), t, in)
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+
+	out := make([]gin.H, 0, len(customers))
+	for _, cu := range customers {
+		out = append(out, customerJSON(cu))
+	}
+	httpx.List(c, out, meta)
+}
+
+type updateRequest struct {
+	Name    *string `json:"name"`
+	Email   *string `json:"email"`
+	Phone   *string `json:"phone"`
+	Company *string `json:"company"`
+	Notes   *string `json:"notes"`
+}
+
+func (h *Handler) update(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	var req updateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	updated, err := h.usecase.Update(c.Request.Context(), t, id, UpdateCustomerInput(req))
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusOK, customerJSON(updated))
+}
+
+func (h *Handler) delete(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpx.WriteError(c, httpx.ErrNotFound)
+		return
+	}
+
+	if err := h.usecase.Delete(c.Request.Context(), t, id); err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func customerJSON(cu *Customer) gin.H {
+	return gin.H{
+		"id":                         cu.ID,
+		"name":                       cu.Name,
+		"email":                      cu.Email,
+		"phone":                      cu.Phone,
+		"phone_e164":                 cu.PhoneE164,
+		"company":                    cu.Company,
+		"notes":                      cu.Notes,
+		"converted_from_lead_id":     cu.ConvertedFromLeadID,
+		"converted_by_membership_id": cu.ConvertedByMembershipID,
+		"converted_at":               cu.ConvertedAt,
+		"created_at":                 cu.CreatedAt,
+		"updated_at":                 cu.UpdatedAt,
+	}
+}

--- a/crm_be/internal/customer/handler_test.go
+++ b/crm_be/internal/customer/handler_test.go
@@ -1,0 +1,260 @@
+package customer_test
+
+// Integration tests (real Postgres via dbtest) for issue #23's
+// conversion + customer HTTP layer.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/activity"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/customer"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/accesstoken"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const testJWTSecret = "customer-handler-test-jwt-secret-32byt" // #nosec G101 -- test-only value, not a real credential
+
+type testClaimsParser struct{}
+
+func (testClaimsParser) ParseAccessToken(raw string) (*accesstoken.Claims, error) {
+	return accesstoken.Parse([]byte(testJWTSecret), raw)
+}
+
+type testStore struct{ pool *pgxpool.Pool }
+
+func newTestStore(pool *pgxpool.Pool) customer.Store { return &testStore{pool: pool} }
+
+func (s *testStore) InTx(ctx context.Context, fn func(customer.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(customer.Repos{Customer: customer.New(tx), Activity: activity.NewRecorder(tx)})
+	})
+}
+
+func (s *testStore) Repos() customer.Repos {
+	return customer.Repos{Customer: customer.New(s.pool), Activity: activity.NewRecorder(s.pool)}
+}
+
+func newTestRouter(t *testing.T) (*gin.Engine, *pgxpool.Pool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pool := dbtest.NewPool(t)
+	u := customer.NewUsecase(newTestStore(pool))
+
+	r := gin.New()
+	customer.NewHandler(u).RegisterRoutes(r, authn.Middleware(testClaimsParser{}))
+	return r, pool
+}
+
+func bearerToken(t *testing.T, userID, orgID, membershipID uuid.UUID, role tenant.Role) string {
+	t.Helper()
+	tok, err := accesstoken.Issue([]byte(testJWTSecret), 15*time.Minute, userID, orgID, membershipID, role)
+	if err != nil {
+		t.Fatalf("mint access token: %v", err)
+	}
+	return tok
+}
+
+func doJSON(r *gin.Engine, method, path, bearer string, body any) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(method, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func seedOrgAndOwner(t *testing.T, ctx context.Context, pool *pgxpool.Pool) (org, user, membership uuid.UUID) {
+	t.Helper()
+	org = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, org); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	user = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Owner')`, user, user.String()+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	membership = uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'owner')`, membership, org, user); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	return org, user, membership
+}
+
+func seedEmployeeMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID) uuid.UUID {
+	t.Helper()
+	userID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Employee')`, userID, userID.String()+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	membershipID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'employee')`, membershipID, org, userID); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	return membershipID
+}
+
+// seedLead (email param) and seedOrganization are defined in
+// repository_test.go (same package) and reused here.
+
+func extractID(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Data struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Data.ID
+}
+
+func TestHandler_Convert_WonLead_Returns201(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil, "won", "Budi Santoso", nil)
+
+	w := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/convert", token, nil)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Data struct {
+			Name                string `json:"name"`
+			ConvertedFromLeadID string `json:"converted_from_lead_id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.Name != "Budi Santoso" || body.Data.ConvertedFromLeadID != leadID.String() {
+		t.Errorf("expected customer copied from lead, got %+v", body.Data)
+	}
+
+	var activityCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM activities WHERE lead_id = $1 AND type = 'lead_converted'`, leadID).Scan(&activityCount); err != nil {
+		t.Fatalf("query activities: %v", err)
+	}
+	if activityCount != 1 {
+		t.Errorf("expected 1 lead_converted activity, got %d", activityCount)
+	}
+
+	var leadStatus string
+	if err := pool.QueryRow(ctx, `SELECT status FROM leads WHERE id = $1`, leadID).Scan(&leadStatus); err != nil {
+		t.Fatalf("query lead: %v", err)
+	}
+	if leadStatus != "won" {
+		t.Errorf("expected lead to remain won, got %q", leadStatus)
+	}
+}
+
+func TestHandler_Convert_NotWon_Returns422(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil, "new", "Budi", nil)
+
+	w := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/convert", token, nil)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Convert_Twice_Returns409(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil, "won", "Budi", nil)
+
+	first := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/convert", token, nil)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first convert failed: %d: %s", first.Code, first.Body.String())
+	}
+
+	w := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/convert", token, nil)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandler_Update_DoesNotChangeOriginatingLead is the literal
+// acceptance criterion: "mengubah nama customer tidak mengubah lead
+// asalnya" — data is copied, not referenced.
+func TestHandler_Update_DoesNotChangeOriginatingLead(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, userID, membershipID := seedOrgAndOwner(t, ctx, pool)
+	token := bearerToken(t, userID, org, membershipID, tenant.RoleOwner)
+	leadID := seedLead(t, ctx, pool, org, nil, "won", "Original Name", nil)
+
+	converted := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/convert", token, nil)
+	customerID := extractID(t, converted)
+
+	w := doJSON(r, http.MethodPatch, "/v1/customers/"+customerID, token, map[string]string{"name": "Renamed Customer"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var leadName string
+	if err := pool.QueryRow(ctx, `SELECT name FROM leads WHERE id = $1`, leadID).Scan(&leadName); err != nil {
+		t.Fatalf("query lead: %v", err)
+	}
+	if leadName != "Original Name" {
+		t.Errorf("expected the lead's name to be unchanged, got %q", leadName)
+	}
+}
+
+func TestHandler_Employee_ReadCustomerFromOtherEmployeesLead_Returns404(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, ownerUser, ownerMembership := seedOrgAndOwner(t, ctx, pool)
+	ownerToken := bearerToken(t, ownerUser, org, ownerMembership, tenant.RoleOwner)
+
+	otherEmployee := seedEmployeeMembership(t, ctx, pool, org)
+	leadID := seedLead(t, ctx, pool, org, &otherEmployee, "won", "Budi", nil)
+	converted := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/convert", ownerToken, nil)
+	customerID := extractID(t, converted)
+
+	me := uuid.Must(uuid.NewV7())
+	myToken := bearerToken(t, me, org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	w := doJSON(r, http.MethodGet, "/v1/customers/"+customerID, myToken, nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Convert_ManagerForbidden(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org, _, _ := seedOrgAndOwner(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil, "won", "Budi", nil)
+
+	managerToken := bearerToken(t, uuid.Must(uuid.NewV7()), org, uuid.Must(uuid.NewV7()), tenant.RoleManager)
+	w := doJSON(r, http.MethodPost, "/v1/leads/"+leadID.String()+"/convert", managerToken, nil)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/crm_be/internal/customer/port.go
+++ b/crm_be/internal/customer/port.go
@@ -1,0 +1,43 @@
+package customer
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Repository is customer's own table interface — postgresRepository
+// (repository_postgres.go) satisfies it, but Usecase depends only on
+// this interface (ADR-011).
+type Repository interface {
+	Convert(ctx context.Context, t tenant.Context, leadID uuid.UUID, convertedByMembershipID *uuid.UUID) (*Customer, error)
+	FindByID(ctx context.Context, t tenant.Context, id uuid.UUID) (*Customer, error)
+	FindAllByOrg(ctx context.Context, t tenant.Context, filter ListFilter) ([]*Customer, int, error)
+	Update(ctx context.Context, t tenant.Context, id uuid.UUID, in UpdateInput) (*Customer, error)
+	Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error
+}
+
+// ActivityRecorder is declared locally per ADR-011 — same three-line
+// shape lead's, task's, and membership's own local interfaces already
+// use, independently declared each time rather than shared (ADR-011:
+// the interface belongs to the consumer). Satisfied by
+// activity.NewRecorder's return value at the composition root.
+type ActivityRecorder interface {
+	Record(ctx context.Context, t tenant.Context, leadID uuid.UUID, activityType string, actorMembershipID *uuid.UUID, metadata map[string]any) error
+}
+
+// Repos bundles what a single Usecase call needs.
+type Repos struct {
+	Customer Repository
+	Activity ActivityRecorder
+}
+
+// Store is the Unit of Work Usecase depends on — required because
+// Convert writes a customer row and an activity row atomically (TD
+// §12).
+type Store interface {
+	InTx(ctx context.Context, fn func(Repos) error) error
+	Repos() Repos
+}

--- a/crm_be/internal/customer/repository_postgres.go
+++ b/crm_be/internal/customer/repository_postgres.go
@@ -1,0 +1,250 @@
+package customer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const alreadyConvertedConstraint = "uq_customers_org_lead"
+
+type postgresRepository struct {
+	q db.Querier
+}
+
+func New(q db.Querier) Repository {
+	return &postgresRepository{q: q}
+}
+
+// Convert copies leadID's contact fields into a new customer row in one
+// statement — INSERT ... SELECT FROM leads, scoped to status='won' —
+// rather than reading the lead in Go first and passing its fields back
+// down: this package has direct db.Querier access to the SAME database
+// leads lives in, so there's no need for a Go-level bridge into
+// internal/lead (the trick activity/task already use for lead
+// visibility checks).
+//
+// Zero rows is ambiguous between "lead not visible" and "lead visible
+// but not won" — resolved by a follow-up existence-only check, same
+// disambiguation shape as every optimistic-locking zero-row case
+// elsewhere in this codebase. A unique violation on
+// uq_customers_org_lead means this lead was already converted.
+func (r *postgresRepository) Convert(ctx context.Context, t tenant.Context, leadID uuid.UUID, convertedByMembershipID *uuid.UUID) (*Customer, error) {
+	const q = `
+		INSERT INTO customers (
+			id, organization_id, name, email, phone, phone_e164, company, notes,
+			converted_from_lead_id, converted_by_membership_id
+		)
+		SELECT $1, $2, name, email, phone, phone_e164, company, notes, id, $3
+		FROM leads
+		WHERE id = $4 AND organization_id = $2 AND deleted_at IS NULL AND status = 'won'
+		RETURNING ` + customerColumns
+
+	id := uuid.Must(uuid.NewV7())
+	row := r.q.QueryRow(ctx, q, id, t.OrganizationID, convertedByMembershipID, leadID)
+	created, err := scanCustomer(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		visible, visErr := r.leadVisible(ctx, t, leadID)
+		if visErr != nil {
+			return nil, visErr
+		}
+		if !visible {
+			return nil, httpx.ErrNotFound
+		}
+		return nil, ErrLeadNotWon
+	}
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == alreadyConvertedConstraint {
+			return nil, ErrAlreadyConverted
+		}
+		return nil, fmt.Errorf("customer: convert: %w", err)
+	}
+	return created, nil
+}
+
+func (r *postgresRepository) leadVisible(ctx context.Context, t tenant.Context, leadID uuid.UUID) (bool, error) {
+	const q = `SELECT EXISTS (SELECT 1 FROM leads WHERE id = $1 AND organization_id = $2 AND deleted_at IS NULL)`
+	var visible bool
+	if err := r.q.QueryRow(ctx, q, leadID, t.OrganizationID).Scan(&visible); err != nil {
+		return false, fmt.Errorf("customer: check lead visibility: %w", err)
+	}
+	return visible, nil
+}
+
+// FindByID scopes Employee visibility through the ORIGINATING lead's
+// assignment (TD §9 footnote: "customer dari lead itu"), not any field
+// on customers itself — customers has no assigned_to_membership_id.
+func (r *postgresRepository) FindByID(ctx context.Context, t tenant.Context, id uuid.UUID) (*Customer, error) {
+	const q = `
+		SELECT ` + customerColumns + `
+		FROM customers c
+		WHERE c.id = $1 AND c.organization_id = $2 AND c.deleted_at IS NULL
+		  AND (NOT $3 OR EXISTS (
+		      SELECT 1 FROM leads l WHERE l.id = c.converted_from_lead_id AND l.organization_id = $2
+		        AND l.assigned_to_membership_id = $4
+		  ))`
+
+	row := r.q.QueryRow(ctx, q, id, t.OrganizationID, isEmployee(t), membershipIDOrNil(t))
+	found, err := scanCustomer(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, httpx.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("customer: find by id: %w", err)
+	}
+	return found, nil
+}
+
+func (r *postgresRepository) FindAllByOrg(ctx context.Context, t tenant.Context, filter ListFilter) ([]*Customer, int, error) {
+	conditions := []string{"c.organization_id = $1", "c.deleted_at IS NULL"}
+	args := []any{t.OrganizationID}
+
+	arg := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	if isEmployee(t) {
+		conditions = append(conditions, fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM leads l WHERE l.id = c.converted_from_lead_id AND l.organization_id = $1 AND l.assigned_to_membership_id = %s)",
+			arg(membershipIDOrNil(t))))
+	}
+	if filter.Query != "" {
+		p := arg("%" + filter.Query + "%")
+		conditions = append(conditions, fmt.Sprintf("(c.name ILIKE %s OR c.email ILIKE %s OR c.phone_e164 ILIKE %s)", p, p, p))
+	}
+
+	where := strings.Join(conditions, " AND ")
+
+	var total int
+	countQ := "SELECT count(*) FROM customers c WHERE " + where
+	if err := r.q.QueryRow(ctx, countQ, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("customer: count: %w", err)
+	}
+
+	perPage := filter.PerPage
+	offset := (filter.Page - 1) * perPage
+	listQ := "SELECT " + customerColumns + " FROM customers c WHERE " + where +
+		" ORDER BY c.created_at DESC LIMIT " + arg(perPage) + " OFFSET " + arg(offset)
+
+	rows, err := r.q.Query(ctx, listQ, args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("customer: find all by org: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Customer
+	for rows.Next() {
+		c, err := scanCustomer(rows)
+		if err != nil {
+			return nil, 0, fmt.Errorf("customer: scan: %w", err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("customer: find all by org: %w", err)
+	}
+	return out, total, nil
+}
+
+// Update touches only general fields — no version column exists on
+// customers (TD §8: not edited from offline mobile, so no write
+// conflict to detect), so zero rows affected is a plain 404, not a
+// conflict to disambiguate.
+func (r *postgresRepository) Update(ctx context.Context, t tenant.Context, id uuid.UUID, in UpdateInput) (*Customer, error) {
+	const q = `
+		UPDATE customers c
+		SET name    = COALESCE($4, name),
+		    email   = COALESCE($5, email),
+		    phone   = COALESCE($6, phone),
+		    company = COALESCE($7, company),
+		    notes   = COALESCE($8, notes)
+		WHERE c.id = $1 AND c.organization_id = $2 AND c.deleted_at IS NULL
+		  AND (NOT $3 OR EXISTS (
+		      SELECT 1 FROM leads l WHERE l.id = c.converted_from_lead_id AND l.organization_id = $2
+		        AND l.assigned_to_membership_id = $9
+		  ))
+		RETURNING ` + customerColumns
+
+	row := r.q.QueryRow(ctx, q,
+		id, t.OrganizationID, isEmployee(t),
+		in.Name, in.Email, in.Phone, in.Company, in.Notes,
+		membershipIDOrNil(t),
+	)
+	updated, err := scanCustomer(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, httpx.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("customer: update: %w", err)
+	}
+	return updated, nil
+}
+
+func (r *postgresRepository) Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error {
+	const q = `
+		UPDATE customers c SET deleted_at = now()
+		WHERE c.id = $1 AND c.organization_id = $2 AND c.deleted_at IS NULL
+		  AND (NOT $3 OR EXISTS (
+		      SELECT 1 FROM leads l WHERE l.id = c.converted_from_lead_id AND l.organization_id = $2
+		        AND l.assigned_to_membership_id = $4
+		  ))`
+
+	tag, err := r.q.Exec(ctx, q, id, t.OrganizationID, isEmployee(t), membershipIDOrNil(t))
+	if err != nil {
+		return fmt.Errorf("customer: delete: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return httpx.ErrNotFound
+	}
+	return nil
+}
+
+func isEmployee(t tenant.Context) bool {
+	return t.Role == tenant.RoleEmployee
+}
+
+func membershipIDOrNil(t tenant.Context) uuid.UUID {
+	if t.MembershipID == nil {
+		return uuid.UUID{}
+	}
+	return *t.MembershipID
+}
+
+// customerColumns is deliberately UNALIASED — Convert's RETURNING
+// clause has no "c" alias in scope (INSERT never aliases its target
+// table), while the SELECT/UPDATE/DELETE queries below alias customers
+// as "c" only for their WHERE/EXISTS clauses; Postgres resolves these
+// bare column names against the sole customers reference in either
+// context without ambiguity.
+const customerColumns = `
+	id, organization_id, name, email, phone, phone_e164, company, notes,
+	converted_from_lead_id, converted_by_membership_id, converted_at,
+	created_at, updated_at, deleted_at`
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanCustomer(row rowScanner) (*Customer, error) {
+	var c Customer
+	err := row.Scan(
+		&c.ID, &c.OrganizationID, &c.Name, &c.Email, &c.Phone, &c.PhoneE164, &c.Company, &c.Notes,
+		&c.ConvertedFromLeadID, &c.ConvertedByMembershipID, &c.ConvertedAt,
+		&c.CreatedAt, &c.UpdatedAt, &c.DeletedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}

--- a/crm_be/internal/customer/repository_test.go
+++ b/crm_be/internal/customer/repository_test.go
@@ -1,0 +1,212 @@
+package customer_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/customer"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+func TestRepository_Convert_CopiesFieldsAndLeavesLeadUnchanged(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := customer.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil, "won", "Budi Santoso", ptr("budi@example.com"))
+	converter := seedMembership(t, ctx, pool, org, "converter@example.com", tenant.RoleOwner)
+
+	created, err := repo.Convert(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, leadID, &converter)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if created.Name != "Budi Santoso" {
+		t.Errorf("expected name copied from lead, got %q", created.Name)
+	}
+	if created.Email == nil || *created.Email != "budi@example.com" {
+		t.Errorf("expected email copied from lead, got %v", created.Email)
+	}
+	if created.ConvertedFromLeadID != leadID {
+		t.Errorf("expected converted_from_lead_id %s, got %s", leadID, created.ConvertedFromLeadID)
+	}
+
+	// The lead itself must be untouched — still won, still present.
+	var leadStatus string
+	if err := pool.QueryRow(ctx, `SELECT status FROM leads WHERE id = $1`, leadID).Scan(&leadStatus); err != nil {
+		t.Fatalf("query lead: %v", err)
+	}
+	if leadStatus != "won" {
+		t.Errorf("expected lead to remain won, got %q", leadStatus)
+	}
+}
+
+func TestRepository_Convert_NotWon_Returns422Sentinel(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := customer.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil, "new", "Budi", nil)
+
+	_, err := repo.Convert(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, leadID, nil)
+	if !errors.Is(err, customer.ErrLeadNotWon) {
+		t.Fatalf("expected customer.ErrLeadNotWon, got: %v", err)
+	}
+}
+
+func TestRepository_Convert_LeadNotVisible_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := customer.New(pool)
+
+	orgA := seedOrganization(t, ctx, pool)
+	orgB := seedOrganization(t, ctx, pool)
+	leadInB := seedLead(t, ctx, pool, orgB, nil, "won", "Budi", nil)
+
+	_, err := repo.Convert(ctx, tenant.Context{OrganizationID: orgA, Role: tenant.RoleOwner}, leadInB, nil)
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound, got: %v", err)
+	}
+}
+
+// TestRepository_Convert_Twice_BlockedByDatabaseConstraint proves
+// uq_customers_org_lead genuinely blocks a second conversion at the
+// database level, not just a check the usecase happens to perform once.
+func TestRepository_Convert_Twice_BlockedByDatabaseConstraint(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := customer.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil, "won", "Budi", nil)
+	tenantCtx := tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}
+
+	if _, err := repo.Convert(ctx, tenantCtx, leadID, nil); err != nil {
+		t.Fatalf("first convert: %v", err)
+	}
+
+	_, err := repo.Convert(ctx, tenantCtx, leadID, nil)
+	if !errors.Is(err, customer.ErrAlreadyConverted) {
+		t.Fatalf("expected customer.ErrAlreadyConverted, got: %v", err)
+	}
+
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM customers WHERE converted_from_lead_id = $1`, leadID).Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 customer row for this lead, got %d", count)
+	}
+}
+
+func TestRepository_Update_DoesNotChangeOriginatingLead(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := customer.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadID := seedLead(t, ctx, pool, org, nil, "won", "Original Name", nil)
+	tenantCtx := tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}
+
+	created, err := repo.Convert(ctx, tenantCtx, leadID, nil)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	newName := "Updated Customer Name"
+	updated, err := repo.Update(ctx, tenantCtx, created.ID, customer.UpdateInput{Name: &newName})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Name != newName {
+		t.Errorf("expected customer name updated, got %q", updated.Name)
+	}
+
+	var leadName string
+	if err := pool.QueryRow(ctx, `SELECT name FROM leads WHERE id = $1`, leadID).Scan(&leadName); err != nil {
+		t.Fatalf("query lead: %v", err)
+	}
+	if leadName != "Original Name" {
+		t.Errorf("expected the lead's name to be untouched, got %q", leadName)
+	}
+}
+
+func TestRepository_Employee_VisibilityIsThroughOriginatingLead(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := customer.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	leadOwner := seedMembership(t, ctx, pool, org, "lead-owner@example.com", tenant.RoleEmployee)
+	stranger := seedMembership(t, ctx, pool, org, "stranger@example.com", tenant.RoleEmployee)
+	leadID := seedLead(t, ctx, pool, org, &leadOwner, "won", "Budi", nil)
+
+	created, err := repo.Convert(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}, leadID, nil)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	if _, err := repo.FindByID(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleEmployee, MembershipID: &leadOwner}, created.ID); err != nil {
+		t.Errorf("expected the lead owner to see the customer, got: %v", err)
+	}
+	if _, err := repo.FindByID(ctx, tenant.Context{OrganizationID: org, Role: tenant.RoleEmployee, MembershipID: &stranger}, created.ID); !errors.Is(err, httpx.ErrNotFound) {
+		t.Errorf("expected httpx.ErrNotFound for an unrelated employee, got: %v", err)
+	}
+}
+
+func ptr(s string) *string { return &s }
+
+func seedOrganization(t *testing.T, ctx context.Context, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, id); err != nil {
+		t.Fatalf("failed to seed organization: %v", err)
+	}
+	return id
+}
+
+func seedMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, email string, role tenant.Role) uuid.UUID {
+	t.Helper()
+	userID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Test User')`, userID, email); err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+	membershipID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, $4)`, membershipID, org, userID, role); err != nil {
+		t.Fatalf("failed to seed membership: %v", err)
+	}
+	return membershipID
+}
+
+// seedLead inserts a lead row directly via SQL — internal/customer
+// doesn't depend on internal/lead, so its tests build the lead they
+// need with a raw INSERT (same pattern activity's/task's tests use).
+func seedLead(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, assignedTo *uuid.UUID, status, name string, email *string) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	var q string
+	var args []any
+	if status == "lost" {
+		q = `INSERT INTO leads (id, organization_id, lead_number, name, email, source, assigned_to_membership_id, status, lost_reason)
+			VALUES ($1, $2, (SELECT next_lead_number FROM organizations WHERE id = $2), $3, $4, 'manual', $5, $6, 'other')`
+		args = []any{id, org, name, email, assignedTo, status}
+	} else {
+		q = `INSERT INTO leads (id, organization_id, lead_number, name, email, source, assigned_to_membership_id, status)
+			VALUES ($1, $2, (SELECT next_lead_number FROM organizations WHERE id = $2), $3, $4, 'manual', $5, $6)`
+		args = []any{id, org, name, email, assignedTo, status}
+	}
+	if _, err := pool.Exec(ctx, q, args...); err != nil {
+		t.Fatalf("failed to seed lead: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE organizations SET next_lead_number = next_lead_number + 1 WHERE id = $1`, org); err != nil {
+		t.Fatalf("failed to bump next_lead_number: %v", err)
+	}
+	return id
+}

--- a/crm_be/internal/customer/usecase.go
+++ b/crm_be/internal/customer/usecase.go
@@ -1,0 +1,164 @@
+package customer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authz"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const (
+	defaultPerPage = 25
+	maxPerPage     = 100
+)
+
+// Usecase depends only on Store (port.go), never on *pgxpool.Pool or
+// pgx.Tx directly (ADR-011).
+type Usecase struct {
+	store Store
+}
+
+func NewUsecase(store Store) *Usecase {
+	return &Usecase{store: store}
+}
+
+// Convert creates a customer from leadID and records lead_converted in
+// the SAME transaction (TD §10/§12) — the lead itself is never
+// modified or deleted; converted_from_lead_id is its only link.
+func (u *Usecase) Convert(ctx context.Context, t tenant.Context, leadID uuid.UUID) (*Customer, error) {
+	if err := authz.Require(t, authz.ActionLeadConvert); err != nil {
+		return nil, err
+	}
+
+	var created *Customer
+	txErr := u.store.InTx(ctx, func(r Repos) error {
+		c, err := r.Customer.Convert(ctx, t, leadID, t.MembershipID)
+		if err != nil {
+			return err
+		}
+		created = c
+		return r.Activity.Record(ctx, t, leadID, "lead_converted", t.MembershipID, map[string]any{"customer_id": c.ID})
+	})
+	if errors.Is(txErr, ErrLeadNotWon) {
+		return nil, invalidStatusTransitionError()
+	}
+	if errors.Is(txErr, ErrAlreadyConverted) {
+		return nil, alreadyConvertedError()
+	}
+	if errors.Is(txErr, httpx.ErrNotFound) {
+		return nil, httpx.ErrNotFound
+	}
+	if txErr != nil {
+		return nil, fmt.Errorf("customer: convert: %w", txErr)
+	}
+	return created, nil
+}
+
+func (u *Usecase) Get(ctx context.Context, t tenant.Context, id uuid.UUID) (*Customer, error) {
+	if err := authz.Require(t, authz.ActionCustomerRead); err != nil {
+		return nil, err
+	}
+	found, err := u.store.Repos().Customer.FindByID(ctx, t, id)
+	if err != nil {
+		return nil, err
+	}
+	return found, nil
+}
+
+// ListInput is List's argument — raw query-param values; List clamps
+// Page/PerPage before delegating to the repository.
+type ListInput struct {
+	Query   string
+	Page    int
+	PerPage int
+}
+
+func (u *Usecase) List(ctx context.Context, t tenant.Context, in ListInput) ([]*Customer, httpx.Meta, error) {
+	if err := authz.Require(t, authz.ActionCustomerRead); err != nil {
+		return nil, httpx.Meta{}, err
+	}
+
+	page := in.Page
+	if page < 1 {
+		page = 1
+	}
+	perPage := in.PerPage
+	if perPage <= 0 {
+		perPage = defaultPerPage
+	} else if perPage > maxPerPage {
+		perPage = maxPerPage
+	}
+
+	filter := ListFilter{Query: in.Query, Page: page, PerPage: perPage}
+	customers, total, err := u.store.Repos().Customer.FindAllByOrg(ctx, t, filter)
+	if err != nil {
+		return nil, httpx.Meta{}, fmt.Errorf("customer: list: %w", err)
+	}
+	return customers, httpx.Meta{Page: page, PerPage: perPage, Total: total}, nil
+}
+
+// UpdateCustomerInput is Usecase.Update's argument.
+type UpdateCustomerInput struct {
+	Name    *string
+	Email   *string
+	Phone   *string
+	Company *string
+	Notes   *string
+}
+
+func (u *Usecase) Update(ctx context.Context, t tenant.Context, id uuid.UUID, in UpdateCustomerInput) (*Customer, error) {
+	if err := authz.Require(t, authz.ActionCustomerUpdate); err != nil {
+		return nil, err
+	}
+
+	repoIn := UpdateInput{
+		Name: in.Name, Email: normalizeEmail(in.Email), Phone: in.Phone, Company: in.Company, Notes: in.Notes,
+	}
+	updated, err := u.store.Repos().Customer.Update(ctx, t, id, repoIn)
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func (u *Usecase) Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error {
+	if err := authz.Require(t, authz.ActionCustomerDelete); err != nil {
+		return err
+	}
+	return u.store.Repos().Customer.Delete(ctx, t, id)
+}
+
+func normalizeEmail(email *string) *string {
+	if email == nil {
+		return nil
+	}
+	lower := strings.ToLower(strings.TrimSpace(*email))
+	return &lower
+}
+
+// invalidStatusTransitionError reuses lead's exact code — converting a
+// non-won lead is, at its core, the same "state doesn't allow this
+// action" shape TD §5 already catalogued; TD §14 doesn't list a
+// separate code for this case.
+func invalidStatusTransitionError() error {
+	return &httpx.DomainError{
+		Status:  http.StatusUnprocessableEntity,
+		Code:    "invalid_status_transition",
+		Message: "Lead harus berstatus won untuk dikonversi.",
+	}
+}
+
+func alreadyConvertedError() error {
+	return &httpx.DomainError{
+		Status:  http.StatusConflict,
+		Code:    "lead_already_converted",
+		Message: "Lead ini sudah pernah dikonversi menjadi customer.",
+	}
+}

--- a/crm_be/internal/customer/usecase_unit_test.go
+++ b/crm_be/internal/customer/usecase_unit_test.go
@@ -1,0 +1,296 @@
+package customer_test
+
+// TestUnit_* tests prove Usecase is decoupled from PostgreSQL (ADR-011) —
+// fake Store, no Docker. Run in isolation with:
+//
+//	go test ./internal/customer/... -run TestUnit
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/customer"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// --- fakes ---
+
+type fakeCustomerRepo struct {
+	byID             map[uuid.UUID]*customer.Customer
+	convertedLeadIDs map[uuid.UUID]bool
+	leadStatus       map[uuid.UUID]string // simulates lead visibility+status for Convert
+}
+
+func newFakeCustomerRepo() *fakeCustomerRepo {
+	return &fakeCustomerRepo{
+		byID:             map[uuid.UUID]*customer.Customer{},
+		convertedLeadIDs: map[uuid.UUID]bool{},
+		leadStatus:       map[uuid.UUID]string{},
+	}
+}
+
+func (f *fakeCustomerRepo) Convert(_ context.Context, t tenant.Context, leadID uuid.UUID, convertedBy *uuid.UUID) (*customer.Customer, error) {
+	status, exists := f.leadStatus[leadID]
+	if !exists {
+		return nil, httpx.ErrNotFound
+	}
+	if status != "won" {
+		return nil, customer.ErrLeadNotWon
+	}
+	if f.convertedLeadIDs[leadID] {
+		return nil, customer.ErrAlreadyConverted
+	}
+	c := &customer.Customer{
+		ID: uuid.Must(uuid.NewV7()), OrganizationID: t.OrganizationID, Name: "Converted",
+		ConvertedFromLeadID: leadID, ConvertedByMembershipID: convertedBy,
+	}
+	f.byID[c.ID] = c
+	f.convertedLeadIDs[leadID] = true
+	return c, nil
+}
+
+func (f *fakeCustomerRepo) FindByID(_ context.Context, t tenant.Context, id uuid.UUID) (*customer.Customer, error) {
+	c, ok := f.byID[id]
+	if !ok || c.OrganizationID != t.OrganizationID || c.DeletedAt != nil {
+		return nil, httpx.ErrNotFound
+	}
+	return c, nil
+}
+
+func (f *fakeCustomerRepo) FindAllByOrg(_ context.Context, t tenant.Context, _ customer.ListFilter) ([]*customer.Customer, int, error) {
+	var out []*customer.Customer
+	for _, c := range f.byID {
+		if c.OrganizationID == t.OrganizationID && c.DeletedAt == nil {
+			out = append(out, c)
+		}
+	}
+	return out, len(out), nil
+}
+
+func (f *fakeCustomerRepo) Update(_ context.Context, t tenant.Context, id uuid.UUID, in customer.UpdateInput) (*customer.Customer, error) {
+	c, err := f.FindByID(context.Background(), t, id)
+	if err != nil {
+		return nil, err
+	}
+	if in.Name != nil {
+		c.Name = *in.Name
+	}
+	if in.Email != nil {
+		c.Email = in.Email
+	}
+	return c, nil
+}
+
+func (f *fakeCustomerRepo) Delete(_ context.Context, t tenant.Context, id uuid.UUID) error {
+	c, err := f.FindByID(context.Background(), t, id)
+	if err != nil {
+		return err
+	}
+	now := c.CreatedAt
+	c.DeletedAt = &now
+	return nil
+}
+
+type recordedActivity struct {
+	leadID       uuid.UUID
+	activityType string
+	metadata     map[string]any
+}
+
+type fakeActivityRecorder struct{ calls []recordedActivity }
+
+func (f *fakeActivityRecorder) Record(_ context.Context, _ tenant.Context, leadID uuid.UUID, activityType string, _ *uuid.UUID, metadata map[string]any) error {
+	f.calls = append(f.calls, recordedActivity{leadID, activityType, metadata})
+	return nil
+}
+
+type fakeStore struct {
+	repo     *fakeCustomerRepo
+	activity *fakeActivityRecorder
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{repo: newFakeCustomerRepo(), activity: &fakeActivityRecorder{}}
+}
+
+func (s *fakeStore) InTx(_ context.Context, fn func(customer.Repos) error) error {
+	return fn(customer.Repos{Customer: s.repo, Activity: s.activity})
+}
+func (s *fakeStore) Repos() customer.Repos {
+	return customer.Repos{Customer: s.repo, Activity: s.activity}
+}
+
+func actorContext(orgID, membershipID uuid.UUID, role tenant.Role) tenant.Context {
+	return tenant.Context{OrganizationID: orgID, PrincipalType: tenant.PrincipalUser, MembershipID: &membershipID, Role: role}
+}
+
+func ownerActor() (tenant.Context, uuid.UUID) {
+	org := uuid.Must(uuid.NewV7())
+	return actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleOwner), org
+}
+
+// --- tests ---
+
+func TestUnit_Convert_EmployeeForbidden(t *testing.T) {
+	store := newFakeStore()
+	u := customer.NewUsecase(store)
+	org := uuid.Must(uuid.NewV7())
+	leadID := uuid.Must(uuid.NewV7())
+	store.repo.leadStatus[leadID] = "won"
+
+	employeeCtx := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+	_, err := u.Convert(context.Background(), employeeCtx, leadID)
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "forbidden" {
+		t.Fatalf("expected forbidden, got: %v", err)
+	}
+}
+
+func TestUnit_Convert_ManagerForbidden(t *testing.T) {
+	store := newFakeStore()
+	u := customer.NewUsecase(store)
+	org := uuid.Must(uuid.NewV7())
+	leadID := uuid.Must(uuid.NewV7())
+	store.repo.leadStatus[leadID] = "won"
+
+	managerCtx := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleManager)
+	_, err := u.Convert(context.Background(), managerCtx, leadID)
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "forbidden" {
+		t.Fatalf("expected forbidden for manager convert, got: %v", err)
+	}
+}
+
+func TestUnit_Convert_Won_Succeeds_RecordsActivity(t *testing.T) {
+	store := newFakeStore()
+	u := customer.NewUsecase(store)
+	actor, _ := ownerActor()
+	leadID := uuid.Must(uuid.NewV7())
+	store.repo.leadStatus[leadID] = "won"
+
+	created, err := u.Convert(context.Background(), actor, leadID)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if created.ConvertedFromLeadID != leadID {
+		t.Errorf("expected converted_from_lead_id %s, got %s", leadID, created.ConvertedFromLeadID)
+	}
+
+	if len(store.activity.calls) != 1 || store.activity.calls[0].activityType != "lead_converted" {
+		t.Fatalf("expected 1 lead_converted activity, got %+v", store.activity.calls)
+	}
+	if store.activity.calls[0].metadata["customer_id"] != created.ID {
+		t.Errorf("expected metadata.customer_id = %s, got %v", created.ID, store.activity.calls[0].metadata)
+	}
+}
+
+func TestUnit_Convert_NotWon_Returns422(t *testing.T) {
+	store := newFakeStore()
+	u := customer.NewUsecase(store)
+	actor, _ := ownerActor()
+	leadID := uuid.Must(uuid.NewV7())
+	store.repo.leadStatus[leadID] = "new"
+
+	_, err := u.Convert(context.Background(), actor, leadID)
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "invalid_status_transition" {
+		t.Fatalf("expected invalid_status_transition, got: %v", err)
+	}
+}
+
+func TestUnit_Convert_Twice_Returns409(t *testing.T) {
+	store := newFakeStore()
+	u := customer.NewUsecase(store)
+	actor, _ := ownerActor()
+	leadID := uuid.Must(uuid.NewV7())
+	store.repo.leadStatus[leadID] = "won"
+
+	if _, err := u.Convert(context.Background(), actor, leadID); err != nil {
+		t.Fatalf("first convert: %v", err)
+	}
+
+	_, err := u.Convert(context.Background(), actor, leadID)
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "lead_already_converted" {
+		t.Fatalf("expected lead_already_converted, got: %v", err)
+	}
+}
+
+func TestUnit_Convert_LeadNotFound_Returns404(t *testing.T) {
+	store := newFakeStore()
+	u := customer.NewUsecase(store)
+	actor, _ := ownerActor()
+
+	_, err := u.Convert(context.Background(), actor, uuid.Must(uuid.NewV7()))
+	if !errors.Is(err, httpx.ErrNotFound) {
+		t.Fatalf("expected httpx.ErrNotFound, got: %v", err)
+	}
+}
+
+func TestUnit_Update_ManagerForbidden(t *testing.T) {
+	store := newFakeStore()
+	u := customer.NewUsecase(store)
+	actor, org := ownerActor()
+	leadID := uuid.Must(uuid.NewV7())
+	store.repo.leadStatus[leadID] = "won"
+	created, err := u.Convert(context.Background(), actor, leadID)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	newName := "New Name"
+	managerCtx := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleManager)
+	_, err = u.Update(context.Background(), managerCtx, created.ID, customer.UpdateCustomerInput{Name: &newName})
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "forbidden" {
+		t.Fatalf("expected forbidden for manager update, got: %v", err)
+	}
+}
+
+func TestUnit_Delete_ManagerForbidden(t *testing.T) {
+	store := newFakeStore()
+	u := customer.NewUsecase(store)
+	actor, org := ownerActor()
+	leadID := uuid.Must(uuid.NewV7())
+	store.repo.leadStatus[leadID] = "won"
+	created, err := u.Convert(context.Background(), actor, leadID)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	managerCtx := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleManager)
+	err = u.Delete(context.Background(), managerCtx, created.ID)
+
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "forbidden" {
+		t.Fatalf("expected forbidden for manager delete, got: %v", err)
+	}
+}
+
+func TestUnit_Get_EmployeeAllowed(t *testing.T) {
+	store := newFakeStore()
+	u := customer.NewUsecase(store)
+	actor, org := ownerActor()
+	leadID := uuid.Must(uuid.NewV7())
+	store.repo.leadStatus[leadID] = "won"
+	created, err := u.Convert(context.Background(), actor, leadID)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	employeeCtx := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+	// The fake repo doesn't enforce lead-based scoping (that's proven
+	// against real Postgres in repository_test.go) — this only proves
+	// the authz gate itself allows Employee through to the repository.
+	if _, err := u.Get(context.Background(), employeeCtx, created.ID); err != nil {
+		t.Fatalf("expected employee read to be authz-allowed, got: %v", err)
+	}
+}

--- a/crm_be/internal/shared/authz/authz.go
+++ b/crm_be/internal/shared/authz/authz.go
@@ -46,6 +46,10 @@ const (
 	// ActionLeadAssign is Owner/Admin/Manager only, same shape as
 	// ActionLeadDelete — TD §9's matrix denies Employee both.
 	ActionLeadAssign Action = "lead.assign"
+	// ActionLeadConvert is Owner/Admin only — narrower than
+	// ActionLeadDelete, which Manager also lacks but Employee's
+	// exclusion is shared.
+	ActionLeadConvert Action = "lead.convert"
 
 	// Activity and task actions cover only what issue #21 ships.
 	// Employee access is further restricted in the repository to leads
@@ -66,6 +70,17 @@ const (
 	// NOT get, even repo-restricted — TD §9's matrix draws that line
 	// explicitly.
 	ActionTaskDelete Action = "task.delete"
+
+	// Customer actions cover only what issue #23 ships. ActionCustomerRead
+	// mirrors ActionLeadRead's shape (list+get share one action, Employee
+	// repo-restricted through the originating lead's assignment).
+	// ActionCustomerUpdate/Delete are Owner/Admin only — notably
+	// narrower than lead.update/delete, which Manager also has: TD §9's
+	// matrix draws this line deliberately, post-conversion editing is
+	// more restricted than pre-conversion.
+	ActionCustomerRead   Action = "customer.read"
+	ActionCustomerUpdate Action = "customer.update"
+	ActionCustomerDelete Action = "customer.delete"
 )
 
 // permissions mirrors docs/architecture/authorization.md's matrix
@@ -84,6 +99,7 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionLeadUpdate:           true,
 		ActionLeadDelete:           true,
 		ActionLeadAssign:           true,
+		ActionLeadConvert:          true,
 		ActionActivityCreate:       true,
 		ActionActivityList:         true,
 		ActionTaskCreate:           true,
@@ -91,6 +107,9 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionTaskUpdate:           true,
 		ActionTaskComplete:         true,
 		ActionTaskDelete:           true,
+		ActionCustomerRead:         true,
+		ActionCustomerUpdate:       true,
+		ActionCustomerDelete:       true,
 	},
 	tenant.RoleAdmin: {
 		ActionMembershipList:       true,
@@ -104,6 +123,7 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionLeadUpdate:           true,
 		ActionLeadDelete:           true,
 		ActionLeadAssign:           true,
+		ActionLeadConvert:          true,
 		ActionActivityCreate:       true,
 		ActionActivityList:         true,
 		ActionTaskCreate:           true,
@@ -111,6 +131,9 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionTaskUpdate:           true,
 		ActionTaskComplete:         true,
 		ActionTaskDelete:           true,
+		ActionCustomerRead:         true,
+		ActionCustomerUpdate:       true,
+		ActionCustomerDelete:       true,
 	},
 	tenant.RoleManager: {
 		ActionMembershipList: true,
@@ -119,7 +142,8 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionLeadUpdate:     true,
 		// ActionLeadDelete deliberately absent — matrix gives delete to
 		// Owner/Admin only.
-		ActionLeadAssign:     true,
+		ActionLeadAssign: true,
+		// ActionLeadConvert deliberately absent — Owner/Admin only.
 		ActionActivityCreate: true,
 		ActionActivityList:   true,
 		ActionTaskCreate:     true,
@@ -127,6 +151,9 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionTaskUpdate:     true,
 		ActionTaskComplete:   true,
 		ActionTaskDelete:     true,
+		ActionCustomerRead:   true,
+		// ActionCustomerUpdate/Delete deliberately absent — Owner/Admin
+		// only, narrower than Manager's lead.update/delete access.
 	},
 	tenant.RoleEmployee: {
 		// Read/update granted here; the repository further restricts
@@ -141,6 +168,10 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionTaskComplete:   true,
 		// ActionTaskDelete deliberately absent — TD §9's matrix denies
 		// Employee this one, unlike every other activity/task action.
+		ActionCustomerRead: true,
+		// ActionCustomerUpdate/Delete/ActionLeadConvert deliberately
+		// absent — Employee gets read-only, repo-restricted to
+		// customers converted from leads assigned to them.
 	},
 }
 

--- a/crm_be/internal/shared/authz/authz_test.go
+++ b/crm_be/internal/shared/authz/authz_test.go
@@ -26,6 +26,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleOwner, authz.ActionLeadUpdate, true},
 		{tenant.RoleOwner, authz.ActionLeadDelete, true},
 		{tenant.RoleOwner, authz.ActionLeadAssign, true},
+		{tenant.RoleOwner, authz.ActionLeadConvert, true},
 		{tenant.RoleOwner, authz.ActionActivityCreate, true},
 		{tenant.RoleOwner, authz.ActionActivityList, true},
 		{tenant.RoleOwner, authz.ActionTaskCreate, true},
@@ -33,6 +34,9 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleOwner, authz.ActionTaskUpdate, true},
 		{tenant.RoleOwner, authz.ActionTaskComplete, true},
 		{tenant.RoleOwner, authz.ActionTaskDelete, true},
+		{tenant.RoleOwner, authz.ActionCustomerRead, true},
+		{tenant.RoleOwner, authz.ActionCustomerUpdate, true},
+		{tenant.RoleOwner, authz.ActionCustomerDelete, true},
 
 		{tenant.RoleAdmin, authz.ActionMembershipList, true},
 		{tenant.RoleAdmin, authz.ActionMembershipUpdateRole, true},
@@ -45,6 +49,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleAdmin, authz.ActionLeadUpdate, true},
 		{tenant.RoleAdmin, authz.ActionLeadDelete, true},
 		{tenant.RoleAdmin, authz.ActionLeadAssign, true},
+		{tenant.RoleAdmin, authz.ActionLeadConvert, true},
 		{tenant.RoleAdmin, authz.ActionActivityCreate, true},
 		{tenant.RoleAdmin, authz.ActionActivityList, true},
 		{tenant.RoleAdmin, authz.ActionTaskCreate, true},
@@ -52,6 +57,9 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleAdmin, authz.ActionTaskUpdate, true},
 		{tenant.RoleAdmin, authz.ActionTaskComplete, true},
 		{tenant.RoleAdmin, authz.ActionTaskDelete, true},
+		{tenant.RoleAdmin, authz.ActionCustomerRead, true},
+		{tenant.RoleAdmin, authz.ActionCustomerUpdate, true},
+		{tenant.RoleAdmin, authz.ActionCustomerDelete, true},
 
 		{tenant.RoleManager, authz.ActionMembershipList, true},
 		{tenant.RoleManager, authz.ActionMembershipUpdateRole, false},
@@ -64,6 +72,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleManager, authz.ActionLeadUpdate, true},
 		{tenant.RoleManager, authz.ActionLeadDelete, false},
 		{tenant.RoleManager, authz.ActionLeadAssign, true},
+		{tenant.RoleManager, authz.ActionLeadConvert, false},
 		{tenant.RoleManager, authz.ActionActivityCreate, true},
 		{tenant.RoleManager, authz.ActionActivityList, true},
 		{tenant.RoleManager, authz.ActionTaskCreate, true},
@@ -71,6 +80,9 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleManager, authz.ActionTaskUpdate, true},
 		{tenant.RoleManager, authz.ActionTaskComplete, true},
 		{tenant.RoleManager, authz.ActionTaskDelete, true},
+		{tenant.RoleManager, authz.ActionCustomerRead, true},
+		{tenant.RoleManager, authz.ActionCustomerUpdate, false},
+		{tenant.RoleManager, authz.ActionCustomerDelete, false},
 
 		{tenant.RoleEmployee, authz.ActionMembershipList, false},
 		{tenant.RoleEmployee, authz.ActionMembershipUpdateRole, false},
@@ -83,13 +95,17 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleEmployee, authz.ActionLeadUpdate, true},
 		{tenant.RoleEmployee, authz.ActionLeadDelete, false},
 		{tenant.RoleEmployee, authz.ActionLeadAssign, false},
+		{tenant.RoleEmployee, authz.ActionLeadConvert, false},
 		{tenant.RoleEmployee, authz.ActionActivityCreate, true}, // repository further restricts to own leads
 		{tenant.RoleEmployee, authz.ActionActivityList, true},
 		{tenant.RoleEmployee, authz.ActionTaskCreate, true},
 		{tenant.RoleEmployee, authz.ActionTaskRead, true},
 		{tenant.RoleEmployee, authz.ActionTaskUpdate, true},
 		{tenant.RoleEmployee, authz.ActionTaskComplete, true},
-		{tenant.RoleEmployee, authz.ActionTaskDelete, false}, // the one action Employee never gets
+		{tenant.RoleEmployee, authz.ActionTaskDelete, false},  // the one action Employee never gets
+		{tenant.RoleEmployee, authz.ActionCustomerRead, true}, // repository further restricts to own leads' customers
+		{tenant.RoleEmployee, authz.ActionCustomerUpdate, false},
+		{tenant.RoleEmployee, authz.ActionCustomerDelete, false},
 	}
 
 	for _, c := range cases {

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 24 Agustus 2026 — Issue #22 selesai
-**Phase sekarang:** Phase 2 — CRM Core (4/5 issue selesai)
+**Last updated:** 24 Agustus 2026 — Issue #23 selesai — **Phase 2 tutup**
+**Phase sekarang:** Phase 3 — Owner Dashboard (belum dimulai — PRD/TD belum dibuka)
 
 ---
 
@@ -33,6 +33,7 @@
 | **Issue #20 — Lead CRUD, transisi status, filter, pagination, idempotency, E.164** | — | 2 | `internal/lead` naik jadi domain penuh (`port/usecase/handler_http.go`, `Repository` jadi interface — migrasi yang sama seperti `membership` di #11). `POST/GET/PATCH/DELETE /v1/leads`, `PATCH /v1/leads/{id}/status`. `internal/shared/phone.ToE164` (Indonesia-first). Idempotency-Key dideteksi lewat unique-violation database, **dibuktikan dengan 10 POST bersamaan → tepat 1 lead**. Optimistic locking `409` membawa keadaan terkini di body. Dua `Action` RBAC baru (`lead.create/read/update/delete`). **Bug nyata ditemukan lewat test yang salah pakai** (assignee tak valid → 500 diam-diam) — diperbaiki jadi `400` bersih + test regresi. Satu penyimpangan TD didokumentasikan (keluar dari `lost` belum bisa "satu langkah tepat" tanpa riwayat dari #21). 34 test baru di `internal/lead`, semuanya lolos tanpa perubahan asersi lama. |
 | **Issue #21 — Activity append-only + auto-log, dan Task** | — | 2 | `internal/activity` dan `internal/task` baru — dua domain penuh. `ActivityRecorder` dideklarasikan konsumen (`lead`, `task`), dijembatani `activity.NewRecorder(q)` di composition root — pola `auth.RefreshTokenRevoker` (#11). `lead_created`, `status_changed` (`metadata={from,to}`), `task_created`, `task_completed` ditulis **di dalam `Store.InTx` yang sama** dengan pemicunya — `lead.Usecase.UpdateStatus` kini juga dibungkus `InTx`. `GET/POST /v1/leads/{id}/activities` (append-only — **tidak ada** `PATCH`/`DELETE`, diverifikasi lewat daftar route sungguhan). Tipe sistem dari client → `422`. `internal/task`: visibilitas employee lewat kepemilikan **lead**, bukan assignee task sendiri — dibuktikan test khusus. jsonb pertama yang benar-benar ditulis di codebase ini (`activities.metadata`), diverifikasi round-trip langsung terhadap Postgres asli. Atomisitas dibuktikan dua lapis: fake (unit) dan transaksi Postgres sungguhan (`repository_atomicity_test.go`, membuktikan rollback nyata + `lead_number` tidak "terbakar"). Satu bug desain (visibilitas `task.FindAllByLead`) ketahuan dan diperbaiki sebelum commit. Enam `Action` RBAC baru. Smoke test manual end-to-end lolos seluruh acceptance criteria. |
 | **Issue #22 — Assignment, notification (`0004`), penutupan kewajiban penonaktifan membership** | — | 2 | Migration `0004_notifications`. `internal/notification` baru — satu-satunya resource di codebase ini tanpa akses lebih luas untuk Owner/Admin, selalu di-scope ke `t.MembershipID`. `PATCH /v1/leads/{id}/assignment` — activity `lead_assigned`/`lead_unassigned` **dan** notification (kecuali assign ke diri sendiri) dalam satu `Store.InTx`. **Menutup kewajiban warisan Phase 1**: `DELETE /v1/memberships/{id}` menolak default (`409 membership_has_open_leads`) bila masih ada lead terbuka; `?on_open_leads=unassign\|reassign` sebagai jalan keluar, atomik dengan pencabutan refresh token yang sudah ada sejak #11 — **dibuktikan lewat test Postgres sungguhan**, bukan hanya fake (`internal/membership/handler_test.go`, baru). `internal/lead.OpenLeadRepository` (bridge terpisah, bukan bagian `Repository`) dipakai `internal/membership` lewat interface lokalnya sendiri — `membership` tetap tidak pernah mengimpor `lead`. Satu batu sandungan arsitektural nyata: sentinel error domain (`lead.ErrAssigneeNotFound`) tidak bisa dikenali lintas paket tanpa melanggar ADR-011 — diselesaikan dengan mengembalikan `*httpx.ValidationError` langsung dari bridge method itu sendiri. Satu `Action` RBAC baru (`lead.assign`). Smoke test manual end-to-end lolos, termasuk verifikasi refresh token benar-benar mati via `/v1/auth/refresh`. |
+| **Issue #23 — Customer, konversi dari lead, kasus `lead` pada harness isolasi tenant** | — | 2 | `internal/customer` baru — `POST /v1/leads/{id}/convert` (satu `INSERT ... SELECT ... FROM leads WHERE status='won'`, menyalin field lead ke customer baru dalam satu statement, bukan lewat bridge Go — deviasi sadar dari asumsi awal bahwa konversi akan menambah field ke `lead.Repos`, yang ternyata tidak diperlukan). `uq_customers_org_lead` menegakkan konversi tunggal (`409 lead_already_converted`); lead bukan `won` → `422` (memakai ulang `invalid_status_transition`, tidak ada kode baru). Lead **tidak pernah** berubah oleh konversi atau oleh edit customer setelahnya — dibuktikan langsung, bukan diasumsikan. **Penutup Phase 2**: harness isolasi tenant (`cmd/api/tenant_isolation_test.go`) bertambah entri `lead`/`task`/`customer`/`activity` ke slice `[]isolationCase` yang sama sejak #11 (13 subtest, semua `404`), **terbukti bisa gagal** diulang untuk `lead` (predikat tenant-scoping dihapus sementara → kebocoran data nyata 200, bukan sekadar 500). `docs/architecture/authorization.md` matriks Phase 2 ditulis lengkap (Aturan #1 "belum berlaku" → terwujud); `multi-tenancy.md` lapis 4 kasus #1 & #4 → ✅; `api.md` menambah `lead_already_converted` plus membackfill dua kode yang luput dicatat di #21/#22. Empat `Action` RBAC baru. Smoke test manual end-to-end lolos seluruh acceptance criteria Phase 2. **Phase 2 selesai.** |
 
 ---
 
@@ -44,14 +45,19 @@ _(kosong)_
 
 ## Berikutnya
 
-**Issue #23 — Customer, konversi dari lead, kasus `lead` pada harness isolasi tenant**
+**Buka Phase 3 — Owner Dashboard: PRD + TD, pecah issue**
 
-- Cakupan & acceptance: [issue #23](https://github.com/Pravasta/jualin-crm/issues/23)
-- TD: `docs/phases/02-crm-core/td.md` §1.2, §8, §12, §16, §18
-- **Penutup Phase 2.** `internal/lead/port.go`'s `Repos` kemungkinan menambah field lagi untuk menulis `customers` + activity `lead_converted` dalam satu transaksi (TD §12).
-- `cmd/api/tenant_isolation_test.go`'s `[]isolationCase` bertambah entri `lead`/`task`/`customer`/`activity` — **sengaja ditutup di sini**, bukan sejak #19, supaya mencakup seluruh endpoint Phase 2 sekaligus (lihat `issues.md`).
-- Setelah #23 selesai: `docs/architecture/authorization.md` matriks diperbarui (menjadi nyata, bukan lagi "belum berlaku") mencakup seluruh `Action` yang ditambahkan #20–#23; `multi-tenancy.md` lapis 4 kasus #1 dan #4 jadi ✅; `STATUS.md` mencatat Phase 2 selesai + utang teknis (retensi `idempotency_key`, retensi `notifications`); Phase 3 (Owner Dashboard) dibuka.
-- Berurutan: #19 (selesai) → #20 (selesai) → #21 (selesai) → #22 (selesai) → #23. Rincian di `docs/phases/02-crm-core/issues.md`.
+- Phase 2 tutup dengan seluruh 5 issue (#19–#23) selesai berurutan, tanpa dilewati. Tidak ada pekerjaan
+  Phase 2 yang tersisa.
+- Phase 3 adalah **demo pertama** (freeze bagian 4) — produk bisa dipakai tanpa `curl`. Juga phase
+  pertama di luar `crm_be`, jadi PRD-nya perlu membahas hal yang belum pernah dibahas di repo ini: setup
+  Next.js (`crm_dashboard/`), penyimpanan token di sisi client, bentuk error yang ditampilkan ke
+  pengguna.
+- Awal session berikutnya: baca `CLAUDE.md` → dokumen ini → `docs/workflow.md` → skill →
+  `docs/architecture/*` yang relevan (`multi-tenancy.md` hampir selalu relevan) → mulai PRD Phase 3
+  mengikuti pola `docs/phases/02-crm-core/prd.md`.
+- Belum ada keputusan terbuka yang memblokir Phase 3 — lihat bagian "Keputusan Belum Diambil" di bawah
+  untuk yang masih menunggu (Bahasa UI ditutup **di** Phase 3, bukan sebelumnya).
 
 ---
 
@@ -63,6 +69,8 @@ _(kosong)_
 | Tidak ada auto-migrate saat container `api` start | Issue #2 | `make migrate-up` dijalankan manual. Sengaja dipisah dari entrypoint `api` — migration dan serving punya kelas kegagalan berbeda. |
 | `ratelimit.FixedWindow` tidak pernah membersihkan key lama | Issue #9 | Map tumbuh tanpa batas seiring IP/email baru muncul. Tidak masalah di volume MVP; perlu eviction sebelum traffic produksi nyata. |
 | Angka rate limit (register 5/jam, resend 3/jam+10/jam) belum final | Issue #9 | Cukup untuk membuktikan mekanisme aktif, bukan hasil tuning. Freeze mencatat "strategi rate limit final" sebagai keputusan terbuka hingga Phase 4. |
+| `leads.idempotency_key` tidak punya retensi | Issue #20, TD §7 | Disimpan selamanya — key yang dipakai ulang setahun kemudian mengembalikan lead lama. Tidak berbahaya (tidak pernah membuat duplikat), tetapi salah. Baru relevan saat Phase 4 (API publik) membuat integrator sungguhan mulai mengirim key. |
+| `notifications` tidak punya retensi | Issue #22, TD §2 | Sama seperti `idempotency_key` — tidak ada scheduler di Phase 2 untuk membersihkan notifikasi lama. Tidak mendesak di volume MVP. |
 
 > ~~Test otomatis `db.InTx` dan migration round-trip~~ — selesai di issue #3.
 
@@ -125,7 +133,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 |---|---|---|---|---|---|
 | 0 | Foundation | ✅ | ✅ | ✅ #1–#3 | ✅ |
 | 1 | Auth & Organization | ✅ | ✅ | ✅ #8–#11, #15 | ✅ |
-| 2 | CRM Core | ✅ | ✅ | ✅ #19–#23 | ⬜ |
+| 2 | CRM Core | ✅ | ✅ | ✅ #19–#23 | ✅ |
 | 3 | Owner Dashboard | ⬜ | ⬜ | ⬜ | ⬜ |
 | 4 | Public API | ⬜ | ⬜ | ⬜ | ⬜ |
 | 5 | Employee Mobile | ⬜ | ⬜ | ⬜ | ⬜ |

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -112,6 +112,14 @@ Bertambah seiring fitur. Setiap kode baru dicatat di sini.
 | 403 | `csrf_token_invalid` | Request cookie non-GET tanpa `X-CSRF-Token` yang cocok (issue #10) |
 | 409 | `last_owner_cannot_be_removed` | Owner terakhir organization mencoba menonaktifkan dirinya sendiri (issue #11) |
 | 409 | `invitation_already_accepted` | Undangan yang tokennya valid tapi sudah pernah diterima (issue #11) |
+| 422 | `invalid_activity_type` | Client mengirim tipe activity sistem (`lead_created`, `status_changed`, dst.) ke `POST /v1/leads/{id}/activities` (issue #21) |
+| 409 | `membership_has_open_leads` | Penonaktifan membership ditolak karena masih ada lead terbuka; body memuat `open_lead_count` (issue #22) |
+| 409 | `lead_already_converted` | `POST /v1/leads/{id}/convert` pada lead yang sudah pernah dikonversi — ditegakkan `uq_customers_org_lead` (issue #23) |
+
+> `invalid_activity_type` dan `membership_has_open_leads` seharusnya masuk katalog ini saat issue #21
+> dan #22 selesai ("setiap kode baru dicatat di sini") — luput saat itu, ditambahkan di sini saat
+> mengerjakan #23 sambil menambah `lead_already_converted`. Dicatat sebagai celah yang tertangkap, bukan
+> diperbaiki diam-diam (Aturan #30).
 
 ### Perluasan envelope — `organization_selection_required`
 

--- a/docs/architecture/authorization.md
+++ b/docs/architecture/authorization.md
@@ -29,8 +29,10 @@ func (u *Usecase) Deactivate(ctx context.Context, t tenant.Context, targetID uui
 
 ## Matriks (Phase 1)
 
-Matriks lengkap ada di `architecture_product_review.md` §6.2 dan mencakup resource yang belum ada
-sampai Phase 2+ (Lead, Customer, Deal, dst — kosong sampai tabelnya ada). Baris yang **nyata di Phase 1**:
+Matriks lengkap ada di `architecture_product_review.md` §6.2 dan mencakup resource yang saat itu belum
+ada (Lead, Customer, Deal, dst — kosong sampai tabelnya ada). Lead/Activity/Task/Customer terwujud di
+Phase 2, lihat bagian "Matriks (Phase 2)" di bawah; Deal masih menunggu (pasca-Phase 5). Baris yang
+**nyata di Phase 1**:
 
 | Resource | Owner | Admin | Manager | Employee |
 |---|---|---|---|---|
@@ -55,6 +57,54 @@ bagian berikutnya.
 
 ---
 
+## Matriks (Phase 2) — realisasi Aturan #1
+
+Ditambahkan issue #20–#23. Baris `Lead`/`Activity`/`Task`/`Customer` yang disebut "belum ada" di bagian
+Phase 1 sekarang **nyata**:
+
+| Resource | Owner | Admin | Manager | Employee |
+|---|---|---|---|---|
+| Lead: buat / baca / ubah | CRU | CRU | CRU | RU¹ |
+| Lead: hapus | ✅ | ✅ | — | — |
+| Lead: assign | ✅ | ✅ | ✅ | — |
+| Lead: convert ke Customer | ✅ | ✅ | — | — |
+| Activity: buat (tipe pengguna) / baca | CR | CR | CR | CR¹ |
+| Task: buat / ubah / selesaikan | CRU | CRU | CRU | CRU¹ |
+| Task: hapus | ✅ | ✅ | ✅ | — |
+| Customer: baca | ✅ | ✅ | ✅ | ✅¹ |
+| Customer: ubah / hapus | ✅ | ✅ | — | — |
+
+¹ Dibatasi repository ke lead yang di-assign kepadanya, dan turunannya: activity, task, customer dari
+lead itu (`converted_from_lead_id`-nya). Lihat bagian berikutnya.
+
+Diterjemahkan ke `internal/shared/authz`'s `Action` enum:
+
+| Action | Owner | Admin | Manager | Employee |
+|---|---|---|---|---|
+| `lead.create` | ✅ | ✅ | ✅ | — |
+| `lead.read` | ✅ | ✅ | ✅ | ✅¹ |
+| `lead.update` | ✅ | ✅ | ✅ | ✅¹ |
+| `lead.delete` | ✅ | ✅ | — | — |
+| `lead.assign` | ✅ | ✅ | ✅ | — |
+| `lead.convert` | ✅ | ✅ | — | — |
+| `activity.create` | ✅ | ✅ | ✅ | ✅¹ |
+| `activity.list` | ✅ | ✅ | ✅ | ✅¹ |
+| `task.create` | ✅ | ✅ | ✅ | ✅¹ |
+| `task.read` | ✅ | ✅ | ✅ | ✅¹ |
+| `task.update` | ✅ | ✅ | ✅ | ✅¹ |
+| `task.complete` | ✅ | ✅ | ✅ | ✅¹ |
+| `task.delete` | ✅ | ✅ | ✅ | — |
+| `customer.read` | ✅ | ✅ | ✅ | ✅¹ |
+| `customer.update` | ✅ | ✅ | — | — |
+| `customer.delete` | ✅ | ✅ | — | — |
+
+Dua asimetri yang layak dicatat, bukan kebetulan: `lead.assign` memberi Manager akses yang `lead.delete`
+tidak (Manager bisa memindahkan kepemilikan lead tapi tidak menghapusnya); `customer.update`/`delete`
+lebih ketat daripada `lead.update`/`delete` yang setara — Manager kehilangan akses tulis begitu sebuah
+lead selesai dikonversi.
+
+---
+
 ## Empat aturan yang harus ditulis eksplisit
 
 Sumber: `architecture_product_review.md` §6.2. Tiga dari empat bergantung pada relasi actor-vs-target,
@@ -64,7 +114,7 @@ ditegakkan langsung di `internal/membership.Usecase` (`UpdateRole`/`Deactivate`)
 
 | # | Aturan | Ditegakkan di | Kode error |
 |---|---|---|---|
-| 1 | Employee hanya melihat resource miliknya | Repository (belum berlaku — belum ada resource milik Employee di Phase 1; Lead di Phase 2) | — |
+| 1 | Employee hanya melihat resource miliknya | Repository — `lead.FindByID`/`FindAllByOrg`/`Update`/`UpdateStatus`/`UpdateAssignment`/`Delete`, dan turunannya (`activity`, `task`, `customer`) lewat `EXISTS (SELECT 1 FROM leads ...)` terhadap lead yang sama — **terwujud sejak #20–#23** | 404 `not_found` (Aturan #6 — bukan 403) |
 | 2 | Owner terakhir tidak bisa menghapus atau menurunkan dirinya sendiri | `membership.Usecase.Deactivate` — cek `CountActiveOwners` di dalam `Store.InTx` yang sama dengan write, mencegah race baca-lalu-tulis | 409 `last_owner_cannot_be_removed` |
 | 3 | Tidak ada yang bisa mengubah role dirinya sendiri — **tanpa kecuali**, termasuk Owner | `membership.Usecase.UpdateRole` | 403 `forbidden` |
 | 4 | Admin tidak bisa menyentuh Owner, tidak bisa mengangkat Owner | `membership.Usecase.UpdateRole` & `Deactivate` | 403 `forbidden` |
@@ -73,12 +123,17 @@ ditegakkan langsung di `internal/membership.Usecase` (`UpdateRole`/`Deactivate`)
 matriks hanya membatasi Admin, dan schema tidak punya `UNIQUE` pada jumlah owner. Lihat
 `internal/membership/usecase.go`'s `UpdateRole` untuk logikanya persis.
 
-**Catatan Aturan #1:** belum berlaku secara harfiah di Phase 1 — tidak ada resource yang dimiliki
-Employee sampai `leads` ada (Phase 2). `internal/membership`/`internal/invitation` sendiri memberi
-Employee akses **nol** ke keduanya (bukan "hanya miliknya" — tidak ada sama sekali), jadi aturan ini
-belum punya kasus uji yang berarti; harness isolasi tenant (`cmd/api/tenant_isolation_test.go`) sudah
-dibangun generik atas daftar route sehingga kasus Lead tinggal ditambahkan sebagai entri baru saat
-Phase 2, bukan harness baru.
+**Catatan Aturan #1:** belum berlaku secara harfiah di Phase 1 — `internal/membership`/`internal/invitation`
+memberi Employee akses **nol** ke keduanya (bukan "hanya miliknya" — tidak ada sama sekali). Terwujud di
+Phase 2: setiap query `lead` yang menyentuh satu baris menerapkan `(NOT $isEmployee OR
+assigned_to_membership_id = $membershipID)`; `activity`/`task`/`customer` mewarisi batas yang sama lewat
+`EXISTS` terhadap lead yang sama, bukan kolom kepemilikan masing-masing (`customer` bahkan tidak punya
+kolom assignee — visibilitasnya murni lewat `converted_from_lead_id`). Dibuktikan di dua lapis: test per
+domain (mis. `internal/lead/handler_test.go`'s `TestHandler_Get_Employee_OtherPersonsLead_Returns404`,
+dan padanannya di `task`/`activity`/`customer`) dan harness isolasi tenant generik
+(`cmd/api/tenant_isolation_test.go`) yang sejak #23 mencakup `lead`/`task`/`activity`/`customer` — lihat
+`multi-tenancy.md` lapis 4 untuk kasus #1/#4 dan `docs/phases/02-crm-core/notes.md`'s `## #23` untuk
+prosedur "harness terbukti bisa gagal".
 
 ---
 

--- a/docs/architecture/multi-tenancy.md
+++ b/docs/architecture/multi-tenancy.md
@@ -119,17 +119,17 @@ Untuk setiap endpoint tenant-scoped:
 
 | # | Kasus | Menjaga | Status Phase 1 |
 |---|---|---|---|
-| 1 | Baca resource tenant lain → 404 | Lapis 1 | Tidak ada endpoint GET-by-id lintas tenant di Phase 1 (hanya list yang di-scope query, dan `GET /v1/invitations/token/{token}` yang memang publik by design) — belum ada kasus nyata |
-| 2 | Ubah/hapus resource tenant lain → 404 | Lapis 1 | ✅ `PATCH`/`DELETE /v1/memberships/{id}`, `DELETE /v1/invitations/{id}` — `TestTenantIsolation_CrossOrgMutatingByID_Returns404` |
+| 1 | Baca resource tenant lain → 404 | Lapis 1 | ✅ `GET /v1/leads/{id}`, `GET /v1/leads/{id}/activities`, `GET /v1/customers/{id}` (dan `PATCH`/`DELETE` yang setara) — `TestTenantIsolation_CrossOrgMutatingByID_Returns404`, ditambah issue #23. Tidak ada endpoint GET-by-id lintas tenant di Phase 1 sendiri (hanya list yang di-scope query, dan `GET /v1/invitations/token/{token}` yang memang publik by design) |
+| 2 | Ubah/hapus resource tenant lain → 404 | Lapis 1 | ✅ `PATCH`/`DELETE /v1/memberships/{id}`, `DELETE /v1/invitations/{id}` (Phase 1); `PATCH`/`DELETE /v1/leads/{id}`, `PATCH`/`DELETE /v1/tasks/{id}`, `PATCH`/`DELETE /v1/customers/{id}` (Phase 2, #23) — `TestTenantIsolation_CrossOrgMutatingByID_Returns404` |
 | 3 | Menunjuk membership tenant lain di body → ditolak **database** | Lapis 2 | Ditegakkan lewat composite FK sejak #8; belum ada endpoint Phase 1 yang menerima id membership lewat body request (invitation accept menunjuk lewat token, bukan id) |
-| 4 | Employee membaca lead employee lain di org yang sama → 404 | Otorisasi | Belum berlaku — `leads` adalah Phase 2. `authz` sudah memberi Employee akses nol ke membership/invitation, jadi belum ada resource untuk diuji kasus ini |
+| 4 | Employee membaca lead employee lain di org yang sama → 404 | Otorisasi | ✅ `internal/lead/handler_test.go`'s `TestHandler_Get_Employee_OtherPersonsLead_Returns404`, dan padanannya di `internal/task`, `internal/activity`, `internal/customer` (#20–#23) — `authz` sudah memberi Employee akses nol ke membership/invitation sejak Phase 1, `leads` adalah tempat pertama aturan ini punya kasus nyata |
 | 5 | **User dengan dua membership** tidak bisa melihat data org yang tidak sedang aktif di token | ADR-007 | ✅ `TestTenantIsolation_MultiMembership_OnlySeesActiveOrgInToken` |
 | 6 | Katalog: setiap tabel tenant-scoped punya `organization_id` + `UNIQUE (id, organization_id)` | Aturan #1, #2 | ✅ Sejak #8 |
 
-**Kasus #1 dan #4 belum punya kasus nyata di Phase 1** — dicatat secara jujur di sini, bukan
-dipaksakan dengan resource buatan. Harness (`cmd/api/tenant_isolation_test.go`) sudah generik atas
-sebuah slice `[]isolationCase` — Phase 2 menambah entri untuk `lead` (yang akan mengaktifkan kasus #1
-dan #4 sekaligus) ke slice yang sama, bukan menulis harness baru.
+**Kasus #1 dan #4 sekarang ✅ — ditutup di issue #23**, penutup Phase 2. Harness
+(`cmd/api/tenant_isolation_test.go`) tetap satu slice `[]isolationCase` generik yang sama sejak #11;
+#23 menambah entri untuk `lead`/`task`/`activity`/`customer` ke slice itu, bukan harness baru — persis
+seperti direncanakan.
 
 **Kasus #5 tidak boleh dilewatkan.** Schema mengizinkan multi-membership yang tidak diekspos UI; satu-satunya penjaganya adalah test ini.
 
@@ -146,6 +146,12 @@ dan #4 sekaligus) ke slice yang sama, bukan menulis harness baru.
 `TestTenantIsolation_CrossOrgMutatingByID_Returns404` langsung merah (500, bukan 404). Predikat
 dikembalikan sebelum commit; tidak pernah masuk riwayat git. Detail lengkap di
 `docs/phases/01-auth-organization/notes.md`'s `## #11`.
+
+**Diulang di #23** untuk resource Phase 2: predikat tenant-scoping yang sama dihapus sementara dari
+`lead.postgresRepository.FindByID`, harness dijalankan ulang — `GET /v1/leads/{id} on another org's
+lead` langsung merah, bocor **200 dengan data lengkap** lead org lain (bukan sekadar 500); subtest
+`PATCH` juga merah (409 `version_conflict` alih-alih 404, karena baris jadi terlihat lintas tenant).
+Predikat dikembalikan sebelum commit. Detail lengkap di `docs/phases/02-crm-core/notes.md`'s `## #23`.
 
 ---
 

--- a/docs/phases/02-crm-core/notes.md
+++ b/docs/phases/02-crm-core/notes.md
@@ -206,3 +206,122 @@ Seluruh acceptance criteria issue #22 terpenuhi. Jalur `reassign` diverifikasi o
 - **Pola "sentinel domain diterjemahkan di usecase paket sendiri, tapi bridge lintas paket menerjemahkan langsung ke `httpx`"** sekarang punya satu contoh konkret (`lead.ReassignOpen`). Berlaku untuk bridge serupa yang akan datang — kapan pun sebuah method HANYA melayani sebagai jembatan `OpenLeadRepository`-style, jangan berasumsi errors.Is sentinel domain bisa dikenali pemanggil.
 - **`docs/architecture/authorization.md`'s matrix masih belum diperbarui** — tetap ditunda ke #23 (penutup Phase 2), sekarang bertambah `lead.assign` dan seluruh baris `activity.*`/`task.*` dari #21 yang juga belum masuk.
 - **Retensi `notifications` belum ada** — sama seperti `idempotency_key` (dicatat di `## #20`), TD tidak menyebut kebijakan retensi untuk notifikasi lama, dan Phase 2 tidak punya scheduler untuk membersihkannya. Tidak mendesak di volume MVP; dicatat di sini agar tidak terlupa saat volume bertambah.
+
+---
+
+## #23 — Customer, konversi dari lead, kasus `lead` pada harness isolasi tenant — **penutup Phase 2**
+
+### Keputusan implementasi
+
+- **Konversi ditaruh sepenuhnya di `internal/customer`, bukan `internal/lead`** — deviasi sadar dari
+  kesan literal TD §12 ("berada di bawah `/v1/leads/{id}`", yang hanya bicara soal path URL, bukan
+  paket pemilik). Alasannya struktural: `POST .../convert` harus mengembalikan customer yang baru
+  dibuat (TD §8) — customer punya ~10 field, dan bridge lintas paket (`ActivityRecorder`,
+  `NotificationSender`) selama ini hanya bisa memakai tipe primitif di signature-nya (`uuid.UUID`,
+  `string`, `map[string]any`). Tidak ada cara mengembalikan struct penuh lewat bridge semacam itu tanpa
+  salah satu paket mengimpor tipe domain paket lain. Solusinya: `internal/customer` punya akses `db.Querier`
+  langsung ke database yang sama dengan `leads`, jadi `Convert` cukup satu `INSERT ... SELECT ... FROM
+  leads WHERE status = 'won'` — pola "`WHERE EXISTS` terhadap `leads`, tanpa interface Go" yang sama
+  yang `activity`/`task` sudah pakai untuk cek visibilitas lead, diperluas jadi COPY data, bukan sekadar
+  cek. `internal/lead` sendiri **tidak disentuh** issue ini di luar kebutuhan harness (tidak ada field
+  `Repos` baru, tidak ada method usecase baru) — prediksi di notes.md `## #22` yang bilang `Repos` akan
+  bertambah field lagi ternyata **tidak terjadi**, dan itu dicatat di sini karena penting: desain
+  awal yang masuk akal kadang terbukti salah begitu detail konkretnya (tipe balikan) diperhitungkan.
+- **Baris zero-row `Convert` diurai lewat cek eksistensi susulan** — persis pola disambiguasi
+  optimistic-locking di tempat lain (`lead.Update`, `task.Update`, dst.): `INSERT ... SELECT ... WHERE
+  status = 'won'` yang mengembalikan nol baris **ambigu** antara "lead tidak terlihat" dan "lead
+  terlihat tapi bukan `won`" — keduanya menghasilkan nol baris yang sama. `leadVisible` query terpisah
+  (`SELECT EXISTS(...)` tanpa syarat status) memisahkan keduanya: tidak terlihat → 404, terlihat →
+  `ErrLeadNotWon` → 422. Kode `422`-nya **memakai ulang** `invalid_status_transition` yang sudah ada —
+  TD §14 tidak mencantumkan kode baru untuk kasus ini, jadi tidak diciptakan satu.
+- **`customerColumns` sengaja TANPA alias tabel** — jebakan kecil yang tertangkap sebelum test pertama
+  dijalankan: `Convert`'s `RETURNING` clause pada `INSERT` tidak punya alias `c` dalam scope (statement
+  `INSERT` tidak pernah mengalias tabel targetnya), sementara `FindByID`/`FindAllByOrg`/`Update`/`Delete`
+  mengalias `customers` sebagai `c` untuk klausa `EXISTS` mereka. Kolom tanpa alias bekerja di kedua
+  konteks (Postgres meresolusinya terhadap satu-satunya tabel yang relevan tanpa ambiguitas), jadi satu
+  daftar kolom cukup — tidak perlu dua versi.
+- **Employee visibility untuk `customer` lewat lead ASAL, bukan kolom di `customers`** — tabel
+  `customers` sama sekali tidak punya `assigned_to_membership_id`. `FindByID`/`FindAllByOrg` menerapkan
+  `EXISTS (SELECT 1 FROM leads l WHERE l.id = c.converted_from_lead_id AND
+  l.assigned_to_membership_id = $employee)` — pola identik dengan visibilitas `task` lewat lead
+  pemiliknya (#21), diterapkan instansi ketiga di sini.
+- **`ActionCustomerUpdate`/`ActionCustomerDelete` mengecualikan Manager** — asimetri yang sengaja
+  dicatat eksplisit di kode dan di `authorization.md`: Manager punya `lead.update`/`lead.delete` (untuk
+  lead yang belum dikonversi) tapi tidak `customer.update`/`delete` (setelah dikonversi). TD §9's
+  matriks menggambar batas ini secara sadar, bukan sesuatu yang bisa disimpulkan dari pola lead.
+- **Harness isolasi tenant ditutup — kasus #1 dan #4 lapis 4 sekarang punya kasus nyata.** Entri baru
+  ditambahkan ke `[]isolationCase` yang **sama** sejak #11 (bukan harness baru): `GET`/`PATCH`/`DELETE`
+  untuk `lead` dan `customer`, `PATCH`/`DELETE` untuk `task` (tidak ada `GET /v1/tasks/{id}` — TD tidak
+  pernah mendefinisikan endpoint itu, hanya list dan list-per-lead; percobaan pertama menambahkannya
+  gagal kompilasi dengan jelas lewat 405, bukan lolos diam-diam), dan `GET` untuk
+  `/v1/leads/{id}/activities`. Kasus #4 (Employee vs Employee lead yang sama) sudah punya bukti nyata
+  sejak #20/#21 lewat test per-domain (`TestHandler_Get_..._OtherPersonsLead_Returns404` dan
+  padanannya) — issue ini melengkapi set itu dengan versi `customer`-nya.
+- **Harness terbukti bisa gagal, diulang untuk `lead`** (prosedur yang sama seperti #11): predikat
+  `organization_id = $2 AND (NOT $3 OR assigned_to_membership_id = $4)` dihapus sementara dari
+  `lead.postgresRepository.FindByID`, harness dijalankan ulang. Hasilnya **lebih parah** dari #11's
+  temuan (500 generik) — subtest `GET /v1/leads/{id} on another org's lead` kembali **200 dengan body
+  lead lengkap milik organization lain** (kebocoran data nyata, bukan sekadar error internal), dan
+  subtest `PATCH` kembali `409 version_conflict` (karena baris jadi "terlihat" lintas tenant, `UPDATE`-nya
+  gagal karena `version` bukan alasan tenant tapi tetap bukan 404). Predikat dikembalikan sebelum
+  commit; `git diff` dikonfirmasi kosong pada berkas itu sebelum staging.
+
+### Verifikasi
+
+```
+go build ./...                              → bersih
+go vet ./...                                → bersih
+golangci-lint run                           → 0 issues
+gofmt -l .                                  → bersih
+go test -race -count=1 ./... (2x)           → semua PASS
+
+DOCKER_HOST=unix:///nonexistent/docker.sock \
+  go test ./internal/... -run TestUnit -count=1
+                                             → PASS tanpa Docker (customer + semua paket lama)
+
+go list -deps ./cmd/api | grep docker       → kosong
+```
+
+**Harness isolasi tenant** (`cmd/api/tenant_isolation_test.go`): 13 subtest lintas-tenant, semuanya
+`404`, termasuk seluruh resource baru Phase 2. Prosedur "terbukti bisa gagal" dijalankan ulang untuk
+`lead` (lihat di atas) — merah sebagaimana mestinya, dikembalikan sebelum commit.
+
+**Smoke test manual** (`docker compose up --build`): register+verify+login owner → buat lead → naikkan
+status berurutan `new→contacted→qualified→proposal→won` → `POST .../convert` → `201`, seluruh field
+(nama, email, telepon, `phone_e164`) tersalin persis dari lead → `GET activities` menunjukkan
+`lead_converted` dengan `metadata.customer_id` yang benar, di atas keempat `status_changed` dan
+`lead_created` — riwayat lengkap tidak terganggu → `GET` lead asal → `status` tetap `won`, lead tetap
+ada → konversi kedua pada lead yang sama → `409 lead_already_converted` → `PATCH` nama customer →
+`GET` lead asal lagi → nama **tidak berubah** (data disalin, bukan dirujuk — dibuktikan langsung, bukan
+diasumsikan) → buat lead baru berstatus `new`, coba konversi → `422 invalid_status_transition` →
+`GET /v1/customers` menampilkan customer yang sudah dikonversi dengan `meta.total` benar.
+
+Seluruh acceptance criteria issue #23 terpenuhi — termasuk **seluruh 6 acceptance criteria Phase 2**
+di `prd.md` (dicek ulang satu per satu terhadap test yang ada, bukan diasumsikan lolos karena issue
+individualnya lolos).
+
+### Utang teknis
+
+- Tidak ada item baru dari issue ini sendiri. Retensi `idempotency_key` (#20) dan `notifications` (#22)
+  tetap seperti tercatat sebelumnya — dipindahkan ke `STATUS.md` bagian Utang Teknis sebagai penutup
+  Phase 2, bukan diulang di sini.
+
+### Phase 2 — CRM Core: selesai
+
+Kelima issue (#19–#23) tuntas, berurutan seperti direncanakan `issues.md`, tanpa issue yang dilewati
+atau dikerjakan di luar urutan. Ringkasan yang tidak sudah jelas dari tabel `STATUS.md`:
+
+- **Pola bridge lintas paket** (`ActivityRecorder`/`NotificationSender`/`OpenLeadRepository`, semuanya
+  turunan `auth.RefreshTokenRevoker` dari #11) dipakai **delapan kali** sepanjang phase ini — cukup
+  sering untuk menjadi idiom, tidak cukup sering (atau cukup seragam — lihat catatan
+  `ReassignOpen`/`Convert` di atas) untuk diabstraksi jadi satu tipe generik. Setiap instansi tetap tiga
+  baris yang diketik ulang, bukan diimpor — sesuai ADR-011.
+- **Pola "database-constraint-sebagai-sinyal"** (`user.ErrEmailTaken` dari Phase 1, lalu
+  `ErrIdempotencyKeyExists`/`ErrAssigneeNotFound`/`ErrAlreadyConverted`) muncul di **lima** tempat
+  berbeda di phase ini sendiri — tidak pernah `SELECT`-lalu-tulis di manapun kode tenant-scoped yang
+  ditulis phase ini.
+- **`docker compose up` manual menemukan 1 bug produksi nyata** di seluruh phase ini (assignee tak
+  valid → 500, issue #20) — dibandingkan dengan Phase 1 yang menemukan 1 juga (email tidak
+  terverifikasi, issue #11). Pola yang konsisten dua phase berturut-turut: smoke test manual bukan
+  formalitas, ia benar-benar menangkap sesuatu yang test otomatis (yang ditulis sebelum bug-nya
+  diketahui) tidak mencakup.


### PR DESCRIPTION
## Summary

Fifth and final issue of Phase 2. Closes out the phase:

- **`internal/customer`** (new domain) — explicit lead→customer conversion (B9, never automatic). `POST /v1/leads/{id}/convert` copies a `won` lead's contact fields into a new customer via a single `INSERT ... SELECT FROM leads` statement, rather than a Go-level bridge into `internal/lead` — a full `Customer` record (~10 fields) can't be returned through a bridge interface restricted to primitive types, the same constraint `ActivityRecorder`/`NotificationSender` have held to since #21/#22. `internal/lead` itself needed **no changes** for this issue, which is worth noting: the plan going into this issue expected `lead.Repos` to grow another field, and it didn't.
- **Conversion guarantees**: `uq_customers_org_lead` blocks a second conversion at the database level (`409 lead_already_converted`); converting a non-`won` lead is `422` (reusing the existing `invalid_status_transition` code rather than inventing a new one — TD §14 doesn't list a separate code for this case). The lead is never modified — still `won`, still present — and editing a customer afterward never touches the lead it came from. Both verified directly (a dedicated test reads the lead back after each operation), not assumed.
- **Employee visibility for customers** is scoped through the *originating lead's* assignment — `customers` has no assignee column of its own, so `FindByID`/`FindAllByOrg` join against `leads` via `converted_from_lead_id`, the same pattern `task` already uses for lead-based scoping.
- **Closes the tenant isolation harness** (`cmd/api/tenant_isolation_test.go`): `[]isolationCase` — unchanged in shape since #11 — gains entries for `lead`/`task`/`activity`/`customer`, activating `multi-tenancy.md`'s lapis 4 cases #1 (cross-org GET-by-id) and #4 (Employee reading another employee's lead), both empty since Phase 1. **Proven able to fail again** before committing: temporarily stripping `lead`'s tenant-scoping predicate leaked a full cross-org lead body (`200`, not just a `500` like #11's version) — reverted before commit, confirmed via `git diff`.
- **Documentation closes the phase**: `authorization.md`'s matrix is written out in full for Phase 2 (rule #1 goes from "not yet applicable" to realized); `multi-tenancy.md` marks lapis 4 cases #1/#4 ✅; `api.md` adds `lead_already_converted` and backfills two error codes (`invalid_activity_type`, `membership_has_open_leads`) that were missed in #21's and #22's own catalog entries; `STATUS.md` marks **Phase 2 — CRM Core complete**.

## Test plan

- [x] `go build/vet ./...`, `gofmt -l .` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./... -race -count=1` — green, run twice for flakiness
- [x] `DOCKER_HOST=<bogus> go test ./internal/... -run TestUnit` — business logic confirmed Docker-free
- [x] `go list -deps ./cmd/api | grep docker` — production binary confirmed testcontainers-free
- [x] Tenant isolation harness: 13 cross-org subtests, all `404`; harness-can-fail procedure rerun for `lead` and confirmed red before reverting
- [x] Manual `docker compose up` smoke test: create a lead → walk it through every status to `won` → convert → `201`, every field copied correctly → activity log shows `lead_converted` with `metadata.customer_id` above the full status-change history → lead confirmed still `won` and unchanged → convert again → `409` → edit the customer's name → re-read the lead → name unchanged → convert a `new`-status lead → `422` → `GET /v1/customers` lists the converted customer with correct `meta.total`

Phase 2 — CRM Core is complete (issues #19–#23).

Refs #23