### PR TITLE
docs(phase-3): open Owner Dashboard with PRD, TD, and issue breakdown

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 24 Agustus 2026 — Issue #23 selesai — **Phase 2 tutup**
-**Phase sekarang:** Phase 3 — Owner Dashboard (belum dimulai — PRD/TD belum dibuka)
+**Last updated:** 24 Agustus 2026 — Phase 3 dibuka (PRD + TD + issue #30–#35)
+**Phase sekarang:** Phase 3 — Owner Dashboard (0/6 issue selesai)
 
 ---
 
@@ -45,19 +45,16 @@ _(kosong)_
 
 ## Berikutnya
 
-**Buka Phase 3 — Owner Dashboard: PRD + TD, pecah issue**
+**Issue #30 — CORS + endpoint metrik** (backend, pembuka Phase 3)
 
-- Phase 2 tutup dengan seluruh 5 issue (#19–#23) selesai berurutan, tanpa dilewati. Tidak ada pekerjaan
-  Phase 2 yang tersisa.
-- Phase 3 adalah **demo pertama** (freeze bagian 4) — produk bisa dipakai tanpa `curl`. Juga phase
-  pertama di luar `crm_be`, jadi PRD-nya perlu membahas hal yang belum pernah dibahas di repo ini: setup
-  Next.js (`crm_dashboard/`), penyimpanan token di sisi client, bentuk error yang ditampilkan ke
-  pengguna.
-- Awal session berikutnya: baca `CLAUDE.md` → dokumen ini → `docs/workflow.md` → skill →
-  `docs/architecture/*` yang relevan (`multi-tenancy.md` hampir selalu relevan) → mulai PRD Phase 3
-  mengikuti pola `docs/phases/02-crm-core/prd.md`.
-- Belum ada keputusan terbuka yang memblokir Phase 3 — lihat bagian "Keputusan Belum Diambil" di bawah
-  untuk yang masih menunggu (Bahasa UI ditutup **di** Phase 3, bukan sebelumnya).
+- Cakupan & acceptance: [issue #30](https://github.com/Pravasta/jualin-crm/issues/30)
+- TD: `docs/phases/03-owner-dashboard/td.md` §1, §2
+- **Phase 3 bukan phase frontend murni.** Dua pekerjaan Go mendahului layar manapun: middleware CORS
+  (belum ada sama sekali — tanpanya tidak ada request browser yang sampai ke handler) dan endpoint
+  metrik agregat (`02-crm-core/td.md` §5 sudah mencatatnya sebagai milik Phase 3).
+- `internal/metrics` adalah paket **read-only** — tidak punya `Store`/`InTx`, karena tidak pernah
+  menulis. Penyimpangan sadar dari bentuk lima berkas, dicatat di TD §2.
+- Berurutan: #30 → #31 → #32 → #33 → #34 → #35. Rincian di `docs/phases/03-owner-dashboard/issues.md`.
 
 ---
 
@@ -87,7 +84,6 @@ Tidak ada yang memblokir. Semuanya diputuskan saat fitur terkait dikerjakan.
 | — | Email provider (Resend / Postmark / SES) | Phase 1 — ⏳ *lead time, lihat bawah* |
 | — | Domain final & branding | Phase 1 — ⏳ *lead time, lihat bawah* |
 | — | Hosting & managed PostgreSQL | Phase 0 akhir |
-| — | Bahasa UI (ID / EN / dwibahasa) | Phase 3 |
 | — | Retensi data free tier | Phase 8 |
 | — | Push provider detail | Phase 5 — ⏳ *lead time, lihat bawah* |
 | — | Pricing final & limit free tier | Phase 8 |
@@ -96,6 +92,8 @@ Tidak ada yang memblokir. Semuanya diputuskan saat fitur terkait dikerjakan.
 Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 dan `docs/brainstorming/architecture_product_review.md` bagian 12.
 
 > **B6–B9 ditutup** saat PRD Phase 2 dibuka (21 Agustus 2026), seluruhnya mengikuti rekomendasi freeze: `lost_reason` 6 nilai · mundur satu langkah · `tasks.lead_id NOT NULL` · konversi ke Customer adalah aksi eksplisit. Alasan tiap keputusan ada di `docs/phases/02-crm-core/prd.md` bagian *Keputusan yang ditutup di phase ini*.
+
+> **C1–C3 ditutup** saat PRD Phase 3 dibuka (24 Agustus 2026): **Bahasa UI Indonesia saja, tanpa i18n** (C1 — satu-satunya dari ketiganya yang memang tercatat di tabel ini) · **browser → Go langsung dengan CORS**, bukan BFF (C2) · **shadcn/ui + Tailwind** (C3). C2 dan C3 ternyata belum pernah diputuskan di dokumen manapun; keduanya ditutup di muka, bukan di tengah implementasi. Alasan tiap keputusan ada di `docs/phases/03-owner-dashboard/prd.md`.
 
 ---
 
@@ -134,7 +132,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 0 | Foundation | ✅ | ✅ | ✅ #1–#3 | ✅ |
 | 1 | Auth & Organization | ✅ | ✅ | ✅ #8–#11, #15 | ✅ |
 | 2 | CRM Core | ✅ | ✅ | ✅ #19–#23 | ✅ |
-| 3 | Owner Dashboard | ⬜ | ⬜ | ⬜ | ⬜ |
+| 3 | Owner Dashboard | ✅ | ✅ | ✅ #30–#35 | ⬜ |
 | 4 | Public API | ⬜ | ⬜ | ⬜ | ⬜ |
 | 5 | Employee Mobile | ⬜ | ⬜ | ⬜ | ⬜ |
 

--- a/docs/phases/03-owner-dashboard/issues.md
+++ b/docs/phases/03-owner-dashboard/issues.md
@@ -1,0 +1,97 @@
+# Phase 3 — Owner Dashboard · Issues
+
+> Indeks pekerjaan. **Tanpa kolom status** — status hidup di GitHub ([ADR-008](../../decisions/ADR-008-delivery-workflow.md)).
+>
+> Status terkini: `gh issue list --milestone "Phase 3 — Owner Dashboard"`
+
+**Milestone:** [Phase 3 — Owner Dashboard](https://github.com/Pravasta/jualin-crm/milestone/4)
+
+---
+
+## Daftar
+
+| # | Judul | Aplikasi | Cakupan | TD |
+|---|---|---|---|---|
+| [30](https://github.com/Pravasta/jualin-crm/issues/30) | CORS + endpoint metrik | `crm_be` | Middleware CORS + config fail-fast, `internal/metrics` (2 endpoint agregat), `metrics.read` | §1, §2 |
+| [31](https://github.com/Pravasta/jualin-crm/issues/31) | Setup Next.js, klien API, sesi, auth UI | `crm_dashboard` | Proyek + Tailwind + shadcn/ui + CI, klien API (CSRF + refresh single-flight), proteksi route, 5 layar auth + pilih organization | §3, §4, §5 |
+| [32](https://github.com/Pravasta/jualin-crm/issues/32) | Daftar lead: filter, pencarian, pagination | `crm_dashboard` | Layar traffic tertinggi. Filter status/pemilik/sumber/periode/kata kunci + **"lead tanpa pemilik aktif"** | §7.1, §8 |
+| [33](https://github.com/Pravasta/jualin-crm/issues/33) | Detail lead: timeline, activity, task, status, assignment, konversi | `crm_dashboard` | Layar traffic tertinggi kedua; hampir seluruh aksi tulis | §5, §6, §8 |
+| [34](https://github.com/Pravasta/jualin-crm/issues/34) | Tim: anggota, undangan, penonaktifan, notifikasi | `crm_dashboard` | Area admin. Penonaktifan dengan alur `on_open_leads` tiga cabang | §5, §8 |
+| [35](https://github.com/Pravasta/jualin-crm/issues/35) | Home metrik, customer, daftar task, settings | `crm_dashboard` | Layar top-level tersisa; mengonsumsi endpoint dari #30. **Penutup phase** | §2.1, §8 |
+
+---
+
+## Urutan
+
+```
+#30 backend ──► #31 fondasi + auth ──► #32 daftar lead ──► #33 detail lead ──► #34 tim ──► #35 penutup
+```
+
+| Dependensi | Sifat |
+|---|---|
+| #31 → #30 | **Keras.** Tanpa CORS, tidak ada satu pun request browser yang sampai ke handler. |
+| #32 → #31 | **Keras.** Butuh sesi, klien API, dan proteksi route. |
+| #33 → #32 | **Praktis.** Detail dibuka dari daftar; komponen tampilan lead (badge status, nama pemilik) lahir di #32 dan dipakai ulang. |
+| #34 → #31 | **Keras** ke #31 saja. Tidak bergantung pada #32/#33 — bisa ditukar dengan keduanya bila perlu. |
+| #35 → #30 | **Keras** untuk bagian metrik (endpointnya dibuat di sana). |
+
+**#34 dan #35 boleh ditukar.** Sisanya berurutan.
+
+---
+
+## Batas per issue
+
+| Issue | Berhenti di |
+|---|---|
+| #30 | **Tidak ada satu baris UI.** Hanya Go: CORS, metrik, authz. Diverifikasi lewat test dan `curl` dengan header `Origin`. |
+| #31 | Bisa mendaftar, verifikasi, masuk, keluar — **tidak ada layar lead sama sekali**. Setelah masuk, halaman utama boleh kosong. |
+| #32 | Daftar lead bisa dilihat dan disaring. **Mengklik satu lead belum membuka apa pun** — itu #33. |
+| #33 | Satu lead bisa dikelola sepenuhnya. **Belum ada layar tim, metrik, atau customer.** |
+| #34 | Tim bisa dikelola dan notifikasi terbaca. **Belum ada angka.** |
+| #35 | Phase 3 tutup. Mobile (Phase 5) dan API publik (Phase 4) **tidak** disentuh. |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Tiga issue yang perlu perhatian ekstra saat review
+
+**#30 — tidak menghasilkan layar apa pun.** Nilainya seluruhnya ada di dua hal yang gagal secara senyap:
+konfigurasi CORS yang salah membuat dashboard mati total **tanpa satu error pun di sisi server**, dan
+metrik yang salah menghitung akan menampilkan angka yang terlihat masuk akal tetapi bohong. Yang layak
+direview di PR itu adalah **definisi `conversion_rate` dan waktu respons** (TD §2.2, §2.3) — apakah
+`spam`/`unqualified` benar-benar keluar dari **penyebut**, dan apakah lead yang belum tersentuh
+benar-benar dikecualikan dari rata-rata alih-alih dihitung nol.
+
+**#31 — refresh single-flight adalah bagian yang sebenarnya sulit.** Layar auth-nya sendiri lurus. Yang
+tidak lurus: enam request yang menerima `401` bersamaan harus menghasilkan **tepat satu** panggilan
+refresh. Bila tidak, rotasi refresh token (#10) membaca token yang sudah dirotasi sebagai reuse attack
+dan mencabut seluruh `family_id` — pengguna terlempar keluar, dan gejalanya terlihat seperti "aplikasi
+mengeluarkan saya sendiri", bukan seperti bug klien. Ini kegagalan yang **hanya muncul di bawah
+konkurensi**, persis seperti alokasi `lead_number` di #19: test berurutan akan hijau meski logikanya
+salah total. **Yang direview adalah apakah test-nya benar-benar paralel.**
+
+**#34 — penonaktifan anggota membawa keputusan, bukan konfirmasi.** `DELETE /v1/memberships/{id}` menolak
+default bila anggota masih memegang lead terbuka, dan mengembalikan `409` beserta jumlahnya (#22). Layar
+**tidak boleh** mengubahnya menjadi dialog "Yakin? [Ya]/[Batal]" — pengguna harus memilih secara sadar
+antara melepas assignment dan memindahkannya ke orang lain. Menyembunyikan pilihan itu di balik satu
+tombol berarti membuang seluruh alasan aturan tersebut ada (freeze 2.3): lead yang tetap ter-assign ke
+orang yang tidak bisa login lagi tidak muncul di "My Leads" siapa pun dan tidak tertangkap filter "belum
+ter-assign".
+
+---
+
+## Setelah keenamnya selesai
+
+Phase 3 tutup bila **13 acceptance criteria** di [`prd.md`](./prd.md) terpenuhi — terutama #1: *Owner
+menyelesaikan seluruh core loop tanpa menyentuh terminal*. Lalu:
+
+1. `api.md`, `authentication.md`, `authorization.md`, `multi-tenancy.md` diperbarui (TD §11)
+2. `docs/STATUS.md` — Phase 3 ✅
+3. **Demo ke calon pengguna** — ini tujuan phase-nya (freeze bagian 4), bukan langkah opsional setelahnya
+4. Buka **Phase 4 — Public API** atau **Phase 5 — Employee Mobile**
+
+> Freeze menempatkan Phase 4 dan Phase 5 sebagai **tidak saling bergantung**; Phase 5 hanya bergantung
+> praktis pada Phase 3 (Owner butuh jalan untuk membuat dan meng-assign lead agar ada yang muncul di
+> aplikasi employee). Urutan berikutnya ditentukan setelah demo — apa yang calon pengguna minta lebih
+> berhak menentukannya daripada tebakan hari ini.

--- a/docs/phases/03-owner-dashboard/prd.md
+++ b/docs/phases/03-owner-dashboard/prd.md
@@ -1,0 +1,176 @@
+# Phase 3 — Owner Dashboard · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md).
+> Sumber: [`architecture/freeze.md`](../../architecture/freeze.md) bagian 4 (Phase 3), 3.2 (cakupan dashboard & metrik dasar), 2.3 ketentuan #3 (filter jaring pengaman), Aturan #25 (token di cookie) · [ADR-009](../../decisions/ADR-009-monorepo-structure.md) (letak `crm_dashboard/`)
+
+---
+
+## Tujuan
+
+**Demo pertama.** Produk bisa dipakai tanpa `curl`.
+
+Phase 0 menyiapkan lantai, Phase 1 dinding tenancy, Phase 2 seluruh siklus hidup lead. Ketiganya nyata,
+tetapi **tidak seorang pun di luar terminal ini pernah melihatnya**. Phase 3 adalah yang pertama
+menghasilkan sesuatu yang bisa ditunjukkan ke calon pelanggan.
+
+> Ini juga phase pertama di luar `crm_be`. Sampai sekarang `crm_dashboard/` hanya berisi `README.md`
+> yang menyatakan "belum dibuat" (ADR-009) — Phase 3 mengisinya.
+
+**Lead list & detail adalah produknya** (freeze 3.2). Layar itu dibuka ratusan kali sehari; sisanya
+sesekali. Alokasi usaha dan pembagian issue di bawah mengikuti perbandingan itu, bukan membagi rata.
+
+---
+
+## Kebutuhan
+
+| # | Sebagai… | Saya butuh… | Supaya… |
+|---|---|---|---|
+| 1 | Owner baru | Mendaftar, memverifikasi email, dan masuk lewat layar | Tidak perlu tahu apa itu `curl` untuk mulai memakai produk yang saya bayar |
+| 2 | Owner | Melihat daftar lead dengan filter dan pencarian | Bisa menjawab "mana yang belum ditangani" dalam hitungan detik, bukan dengan membaca seluruh daftar |
+| 3 | Owner | Melihat satu lead beserta seluruh riwayatnya dalam satu layar | Bisa melanjutkan pekerjaan orang lain tanpa bertanya |
+| 4 | Owner | Menugaskan lead ke sales lewat beberapa klik | Distribusi kerja tidak lagi bergantung pada saya mengingat siapa memegang apa |
+| 5 | Owner | Melihat lead yang **tidak punya pemilik aktif** | Lead tidak menghilang diam-diam saat seseorang resign — jaring pengaman yang freeze 2.3 wajibkan |
+| 6 | Owner | Mengundang, mengubah role, dan menonaktifkan anggota tim | Tidak perlu meminta developer setiap ada karyawan masuk atau keluar |
+| 7 | Owner | Melihat angka dasar: lead masuk, per status, belum ter-assign, conversion rate, performa per employee | Bisa tahu keadaan bisnis tanpa menghitung manual |
+| 8 | Owner | Mengubah lead yang berhasil menjadi customer lewat satu aksi | Relasi jangka panjang tercatat, dan saya tahu kapan itu terjadi |
+| 9 | Siapa pun yang login | Melihat notifikasi saat ada lead ditugaskan ke saya | Bisa merespons tanpa memantau layar terus-menerus |
+| 10 | Siapa pun yang login | Melihat pesan kesalahan yang bisa dimengerti, dalam Bahasa Indonesia | Tahu apa yang salah dan apa yang harus dilakukan, bukan melihat kode HTTP |
+
+---
+
+## Acceptance Criteria
+
+Phase 3 selesai bila **semuanya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | Owner menyelesaikan **seluruh core loop tanpa menyentuh terminal**: daftar → verifikasi → masuk → buat lead → assign → catat activity → buat task → ubah status → konversi ke customer |
+| 2 | Browser di origin dashboard bisa memanggil API — CORS dikonfigurasi eksplisit per origin, **tidak pernah** `*`, dan **gagal saat boot** bila kosong di production |
+| 3 | Cookie sesi tetap `HttpOnly` — JavaScript dashboard **tidak pernah** menyentuh access/refresh token (Aturan #25), dan setiap request non-GET membawa `X-CSRF-Token` |
+| 4 | Beberapa request yang bersamaan menerima `401` menghasilkan **tepat satu** panggilan refresh, bukan satu per request |
+| 5 | Daftar lead bisa disaring per status, pemilik, sumber, periode, dan kata kunci, dengan pagination yang menampilkan jumlah total |
+| 6 | Filter **"lead tanpa pemilik aktif"** tersedia permanen di daftar lead — kewajiban yang diteruskan Phase 2 |
+| 7 | Layar detail lead menampilkan timeline activity terbaru-dulu, task pada lead itu, dan seluruh aksi tulis (status, assignment, catatan, konversi) |
+| 8 | Menyimpan perubahan pada data yang sudah berubah di tempat lain → layar menampilkan **konflik**, memuat ulang keadaan terkini, dan **tidak pernah menimpa otomatis** |
+| 9 | Menonaktifkan anggota yang masih memegang lead terbuka → layar menampilkan jumlahnya dan **memaksa memilih** lepas assignment / pindahkan / batal |
+| 10 | Metrik dasar freeze 3.2 tampil dari endpoint agregat backend — **bukan** dihitung di browser dari halaman yang sedang terlihat |
+| 11 | Conversion rate **mengecualikan** `spam` dan `unqualified` dari penyebut |
+| 12 | Seluruh teks antarmuka dan pesan kesalahan dalam **Bahasa Indonesia** |
+| 13 | CI punya workflow tersendiri untuk `crm_dashboard/` dengan `paths:` filter — backend tidak ikut jalan saat hanya UI berubah, dan sebaliknya |
+
+---
+
+## Keputusan yang ditutup di phase ini
+
+`STATUS.md` menandai **Bahasa UI** sebagai keputusan yang jatuh tempo di Phase 3. Dua lagi ternyata
+belum pernah diputuskan di dokumen manapun dan ditutup di sini juga, sebelum implementasi — bukan di
+tengah jalan:
+
+| # | Pertanyaan | Keputusan | Alasan |
+|---|---|---|---|
+| **C1** | Bahasa UI: Indonesia / Inggris / dwibahasa | **Indonesia saja, tanpa i18n** | Backend sudah mengunci `error.message` dalam Bahasa Indonesia sejak #9 (*"Role Anda tidak mengizinkan aksi ini"*). Memasang i18n berarti antarmuka dwibahasa di atas lapisan error yang tetap satu bahasa — campur aduk di layar yang sama, dengan biaya setiap string lewat kunci terjemahan. Retrofit i18n memang menyakitkan; tetapi memasangnya sekarang untuk bahasa kedua yang belum ada pelanggannya adalah persis yang Aturan #28 larang. |
+| **C2** | Bagaimana browser bicara ke Go API | **Browser → Go langsung, dengan CORS.** Bukan BFF. | Cookie `HttpOnly SameSite=Lax` tetap terkirim antar-subdomain (`app.` → `api.` adalah same-site), dan CSRF double-submit `httpx.VerifyCSRF` sudah dibangun dan diuji sejak #10 **persis untuk kasus ini**. BFF lewat Next.js route handler menghilangkan CORS, tetapi menambah satu hop di setiap request dan mewajibkan runtime Node permanen — menaikkan biaya infrastruktur per tenant untuk memecahkan masalah yang sudah dipecahkan. |
+| **C3** | Komponen UI | **shadcn/ui + Tailwind** | Komponen di-*copy* ke repo, bukan dependensi runtime — tidak ada versi library yang mengunci, dan setiap komponen bisa diubah tanpa melawan library. Bundle kecil, relevan untuk sales yang membuka dashboard dari koneksi lambat. Alternatif (Mantine/MUI) memberi lebih banyak komponen jadi, dengan harga gaya visual yang sulit dilepas. |
+
+C1 dicoret dari `STATUS.md` bagian *Keputusan Belum Diambil* dan diperbarui di
+[`product/glossary.md`](../../product/glossary.md) — dua tempat yang sebelumnya menyatakan "belum
+diputuskan".
+
+---
+
+## Phase 3 bukan phase frontend murni
+
+Dua pekerjaan Go wajib mendahului layar manapun. Keduanya bukan temuan kejutan — keduanya tercatat
+sebagai utang Phase 2 — tetapi keduanya mudah terlewat kalau phase ini dibaca sebagai "phase UI":
+
+**1. CORS belum ada sama sekali.** Tidak ada middleware CORS di `crm_be`, dan tidak ada satu pun
+keputusan tentang origin di `docs/architecture/`. Tanpa itu, keputusan C2 tidak bisa berjalan: browser
+di origin dashboard akan ditolak sebelum request pertama sampai ke handler.
+
+**2. Endpoint metrik belum ada.** [`02-crm-core/td.md`](../02-crm-core/td.md) §5 menyatakannya
+eksplisit: *"Di Phase 2 belum ada endpoint metrik (itu Phase 3)"*. Freeze 3.2 mewajibkan lima metrik.
+Menghitungnya di browser dari endpoint list yang berpaginasi **salah** — angkanya akan mengikuti halaman
+yang sedang terlihat, bukan keseluruhan data, dan salahnya tidak akan terlihat sampai ada organization
+dengan lebih dari satu halaman lead.
+
+Keduanya digabung menjadi satu issue Go yang mendahului seluruh pekerjaan UI (issue #30).
+
+---
+
+## Di luar cakupan
+
+| Tidak dikerjakan | Ke |
+|---|---|
+| Landing page (`crm_landing_page/`) | Belum dijadwalkan — bukan bagian Phase 3 |
+| Mobile app, push notification, `device_tokens` | Phase 5 |
+| API Key, `POST /v1/leads` publik, halaman dokumentasi integrator | Phase 4 |
+| Angka revenue / nilai deal di metrik | Menunggu Deal, pasca-Phase 5 — freeze 3.2 mencatatnya sebagai ekspektasi yang disepakati, bukan kekurangan |
+| Grafik tren & laporan lanjutan | Phase 9 — Phase 3 menampilkan angka, bukan visualisasi deret waktu |
+| Export CSV dari daftar lead | Belum dijadwalkan — sama seperti import, naikkan prioritas bila calon pelanggan memintanya |
+| Realtime / websocket (notifikasi muncul tanpa refresh) | Belum dijadwalkan — freeze melarang message broker; polling sederhana cukup untuk MVP |
+| Dark mode, tema, kustomisasi tampilan | Saat diminta |
+| Layar untuk Employee | Employee memakai mobile (Phase 5). Dashboard adalah alat Owner/Admin/Manager. |
+
+### Dua hal yang sengaja tertahan
+
+**Realtime notification.** Freeze melarang message broker, dan websocket untuk memunculkan lonceng
+notifikasi bukan alasan yang cukup untuk melanggarnya. Dashboard mengambil notifikasi saat halaman
+dimuat dan saat pengguna membukanya. Bila nanti terasa kurang, jawabannya polling interval — bukan
+infrastruktur baru.
+
+**Layar Employee.** Dashboard ini untuk Owner/Admin/Manager. Employee **bisa** login (backend tidak
+melarangnya) dan akan melihat data yang di-scope repository ke lead miliknya sendiri — tetapi tidak ada
+layar yang dirancang untuk alur kerja mereka. Itu Phase 5, dan mencampurnya ke sini berarti membangun
+dua produk dalam satu phase.
+
+---
+
+## Dependensi
+
+Phase 2 selesai — seluruh siklus lead, activity, task, assignment, notification, dan customer sudah ada
+di API internal, tertutup harness isolasi tenant yang terbukti bisa gagal.
+
+**Satu kewajiban diwarisi Phase 2** ([`02-crm-core/td.md`](../02-crm-core/td.md) §19): dashboard wajib
+menyediakan filter permanen **"lead tanpa pemilik aktif"** sebagai jaring pengaman terhadap membership
+yang dinonaktifkan (freeze 2.3 ketentuan #3). Query-nya sudah didukung `assigned_to=none` sejak #20 —
+yang belum ada hanya layarnya. Ia masuk sebagai acceptance criterion #6, bukan sebagai catatan.
+
+**Keputusan yang masih menunggu tetapi tidak memblokir:** domain final & hosting. Keduanya menentukan
+nilai konkret `CORS_ALLOWED_ORIGINS` dan `COOKIE_DOMAIN` saat deploy, bukan bentuk kodenya —
+pengembangan lokal berjalan dengan `localhost`.
+
+---
+
+## Pembagian issue
+
+Freeze memetakan Phase 3 sebagai session 9–12 (**empat**). Setelah menghitung isinya — ±15 layar, dua
+endpoint Go baru, middleware CORS, plus setup aplikasi yang belum pernah ada sama sekali — saya pecah
+menjadi **enam**:
+
+| Urut | Issue | Kenapa dipisah |
+|---|---|---|
+| 1 | Backend: CORS + endpoint metrik | Murni Go, bisa diuji penuh tanpa satu baris UI, dan **memblokir semua issue lain** — tanpa CORS tidak ada request browser yang berhasil. Mereviewnya bersama layar berarti mereview dua hal yang gagal dengan cara sangat berbeda. |
+| 2 | Setup Next.js + auth UI + sesi | Fondasi: proyek, Tailwind/shadcn, klien API + CSRF + refresh single-flight, proteksi route, lima layar auth. Semua issue berikutnya butuh "bisa login". |
+| 3 | Lead list + filter + pagination | Layar dengan traffic tertinggi (freeze 3.2). Termasuk filter "lead tanpa pemilik aktif". |
+| 4 | Lead detail + timeline + activity + task + status + assignment + konversi | Traffic tertinggi kedua, dan tempat hampir seluruh aksi tulis berada. Digabung dengan #3 akan menghasilkan satu PR yang tidak bisa direview dengan jujur. |
+| 5 | Tim: employee, undangan, penonaktifan, notification | Area admin. Penonaktifan membawa alur `on_open_leads` tiga cabang dari #22 — satu-satunya layar dengan percabangan keputusan sungguhan. |
+| 6 | Home metrik + customer + daftar task + settings | Layar top-level yang tersisa, mengonsumsi endpoint dari issue #1. Penutup phase. |
+
+Ini **penyimpangan dari peta session di freeze**, dicatat agar terlihat — pola yang sama dipakai Phase 1
+(3 → 4) dan Phase 2 (4 → 5). Bila Anda lebih memilih lebih sedikit PR, katakan saat review: #5 dan #6
+paling mudah digabung.
+
+Rincian: [`issues.md`](./issues.md)
+
+---
+
+## Bukan tujuan phase ini
+
+- **Bukan** membangun landing page atau apa pun yang menghadap publik selain dashboard itu sendiri
+- **Bukan** mengubah kontrak API yang sudah ada — bila sebuah layar terasa butuh endpoint baru, itu
+  sinyal untuk memeriksa apakah endpoint yang ada sudah cukup sebelum menambah (dua endpoint metrik
+  adalah satu-satunya penambahan yang sudah disetujui di muka)
+- **Bukan** mengejar kelengkapan visual — layar yang benar dan bisa dipakai lebih penting daripada layar
+  yang cantik, dan seluruh Phase 3 ada untuk dibuktikan di depan calon pengguna
+- **Bukan** menyiapkan struktur untuk Deal, grafik, atau realtime yang "sudah pasti datang"
+  (Aturan #27, #28)

--- a/docs/phases/03-owner-dashboard/td.md
+++ b/docs/phases/03-owner-dashboard/td.md
@@ -1,0 +1,363 @@
+# Phase 3 — Owner Dashboard · Technical Design
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+>
+> Memuat **delta** untuk Phase 3. Yang sudah ada di [`freeze.md`](../../architecture/freeze.md), [`api.md`](../../architecture/api.md), [`authentication.md`](../../architecture/authentication.md), [`authorization.md`](../../architecture/authorization.md), [`multi-tenancy.md`](../../architecture/multi-tenancy.md), dan `.claude/skills/jualin-backend/` **tidak diulang** — hanya dirujuk.
+
+---
+
+## 0. Dua sisi, satu produk
+
+Phase 3 menyentuh dua aplikasi:
+
+| Aplikasi | Pekerjaan | Issue |
+|---|---|---|
+| `crm_be` (Go) | Middleware CORS · paket `internal/metrics` · satu `Action` authz baru | #30 |
+| `crm_dashboard` (Next.js) | Seluruh antarmuka | #31–#35 |
+
+Bagian §1–§2 adalah backend, §3 seterusnya frontend. Keduanya di satu TD karena satu phase, satu produk
+(ADR-009) — bukan karena keduanya saling bergantung secara teknis di luar kontrak HTTP.
+
+---
+
+## 1. CORS
+
+**Belum ada sama sekali.** Tidak ada middleware CORS di `crm_be` dan tidak ada keputusan origin di
+`docs/architecture/`. Tanpa ini, keputusan C2 (browser → Go langsung) tidak bisa berjalan.
+
+### 1.1 Konfigurasi
+
+```go
+// internal/shared/config/config.go
+CORSAllowedOrigins []string `env:"CORS_ALLOWED_ORIGINS" envSeparator:","`
+```
+
+| Keputusan | Alasan |
+|---|---|
+| Daftar eksplisit, **tidak pernah `*`** | `Access-Control-Allow-Credentials: true` dan `Access-Control-Allow-Origin: *` **saling meniadakan** — browser menolak kombinasinya. Karena dashboard mengirim cookie, wildcard bukan pilihan yang tersedia, bukan sekadar tidak disarankan. |
+| **Wajib non-kosong saat `AppEnv == "production"`** — divalidasi di `config.validate()` | Aturan #36 (fail-fast). Konfigurasi CORS yang kosong di production berarti dashboard mati total; lebih baik proses berhenti saat boot dengan pesan yang menyebut variabelnya daripada menyajikan traffic yang seluruhnya gagal di browser. |
+| Default kosong di development | Pengembangan lokal memakai `http://localhost:3000` yang ditulis eksplisit di `.env`/`docker-compose.yml` — bukan disembunyikan sebagai default kode. |
+
+`AppBaseURL` yang sudah ada **bukan** penggantinya: ia satu nilai untuk membangun tautan email, sementara
+origin yang diizinkan bisa lebih dari satu (production + staging + preview).
+
+### 1.2 Middleware
+
+`internal/shared/httpx/cors.go` (baru), dipasang di `newRouter` **sebelum** route manapun dan sebelum
+`authn.Middleware` — request preflight tidak membawa kredensial dan tidak boleh menyentuh lapisan auth.
+
+```
+Origin request tidak ada di daftar  → lanjut tanpa header CORS (browser yang menolak, bukan server
+                                      yang membocorkan bahwa origin itu "salah")
+Origin cocok                        → echo origin persis + Access-Control-Allow-Credentials: true
+Method OPTIONS                      → 204, tanpa memanggil handler
+```
+
+Header yang diizinkan minimal: `Content-Type`, `Authorization`, `X-CSRF-Token`, `Idempotency-Key`.
+Method: `GET`, `POST`, `PATCH`, `DELETE`, `OPTIONS`.
+
+`Access-Control-Max-Age` disetel supaya preflight tidak berulang di setiap request — tanpa itu, setiap
+`PATCH` menjadi dua round trip.
+
+### 1.3 Test
+
+| Test | Membuktikan |
+|---|---|
+| Origin diizinkan → header echo + `Allow-Credentials: true` | Jalur normal |
+| Origin tidak diizinkan → **tidak ada** header CORS, request tetap diproses | Server tidak membocorkan daftar origin |
+| `OPTIONS` → `204` tanpa menyentuh handler | Preflight tidak memicu logika bisnis |
+| **Tidak pernah** mengirim `Allow-Origin: *` saat `Allow-Credentials: true` | Kombinasi yang mustahil, dikunci test |
+| `config.validate()` menolak `CORS_ALLOWED_ORIGINS` kosong saat `APP_ENV=production` | Aturan #36 |
+
+---
+
+## 2. Metrik — `internal/metrics` (paket baru)
+
+[`02-crm-core/td.md`](../02-crm-core/td.md) §5: *"Di Phase 2 belum ada endpoint metrik (itu Phase 3)"*.
+
+**Paket sendiri, bukan tempelan di `internal/lead`.** Ia membaca lintas `leads`/`customers`/`activities`
+dan tidak dimiliki satu pun dari ketiganya; package-by-feature (ADR-011) menempatkan fitur di foldernya
+sendiri. Membaca tabel lintas domain lewat **SQL langsung**, bukan interface Go — pola yang sama
+`customer.Convert` pakai terhadap `leads` di #23, dengan alasan yang sama: satu database, agregat lintas
+tabel, tidak ada yang bisa diambil dari interface sempit tanpa N+1.
+
+Paket ini **read-only** — tidak ada `Store.InTx`, tidak ada `Repos`, karena tidak ada satu pun tulis.
+Ini penyimpangan sadar dari bentuk lima berkas: `entity.go` · `port.go` · `usecase.go` ·
+`repository_postgres.go` · `handler_http.go` tetap ada, tetapi `port.go` hanya berisi `Repository`
+(tanpa `Store`), dan `NewUsecase` menerima `Repository` langsung. Menambahkan `Store`/`InTx` untuk paket
+yang tidak pernah menulis adalah mesin yang tidak dipakai (Aturan #27).
+
+### 2.1 Dua endpoint, bukan lima
+
+Satu layar home tidak boleh butuh lima round trip.
+
+| Method | Path | Isi |
+|---|---|---|
+| `GET` | `/v1/metrics/summary?from=&to=` | `total_new` · `by_status{}` · `unassigned` · `conversion_rate` |
+| `GET` | `/v1/metrics/employees?from=&to=` | array per employee: `membership_id`, `full_name`, `lead_count`, `avg_response_seconds`, `converted_count` |
+
+`from`/`to` ISO 8601 UTC (Aturan #33), opsional — kosong berarti seluruh riwayat. Rentang membatasi
+`leads.created_at`, bukan waktu peristiwa lain: "lead masuk periode ini, apa yang terjadi padanya".
+
+### 2.2 Conversion rate — definisi, bukan tebakan
+
+```
+conversion_rate = jumlah lead won / (total lead - lead spam - lead unqualified)
+```
+
+**`spam` dan `unqualified` dikeluarkan dari penyebut.** Ini akhirnya menegakkan acceptance criterion #5
+Phase 2, yang sampai sekarang hanya berupa "kedua status itu ada dan terpisah" (`02-crm-core/td.md` §5).
+Lead sampah bukan kegagalan penjualan; memasukkannya ke penyebut membuat angka konversi turun karena
+alasan yang tidak ada hubungannya dengan performa.
+
+Penyebut nol → `conversion_rate` dikirim `null`, **bukan** `0`. Nol berarti "sudah dicoba, tidak ada yang
+berhasil"; `null` berarti "belum ada yang bisa dihitung". Keduanya tampil berbeda di layar.
+
+### 2.3 Waktu respons — definisi, bukan tebakan
+
+```
+waktu respons satu lead = MIN(activities.created_at WHERE type <> 'lead_created') - leads.created_at
+```
+
+Artinya: **berapa lama sampai ada yang benar-benar menyentuh lead ini.** Setiap peristiwa nyata sejak #21
+menghasilkan activity, jadi tabel itu adalah jejak yang paling jujur — lebih baik daripada memakai
+`status_changed` saja (mencatat pindah status tapi melewatkan catatan dan telepon) atau `updated_at`
+(berubah karena hal yang bukan respons manusia).
+
+**Lead yang belum pernah tersentuh dikecualikan dari rata-rata, bukan dihitung nol.** Memasukkannya
+sebagai nol membuat rata-rata terlihat membaik justru saat lead diabaikan.
+
+### 2.4 RBAC
+
+`ActionMetricsRead` baru di `internal/shared/authz`:
+
+| Action | Owner | Admin | Manager | Employee |
+|---|---|---|---|---|
+| `metrics.read` | ✅ | ✅ | ✅ | — |
+
+Employee tidak dapat: dashboard memang bukan alatnya (PRD *Di luar cakupan*), dan angka lintas
+organization adalah informasi manajemen. Employee mendapat mobile di Phase 5.
+
+> Konsekuensinya `internal/metrics` **tidak** punya cabang `isEmployee` di query-nya sama sekali —
+> tidak seperti `lead`/`task`/`customer`. Employee tidak pernah sampai ke repository ini.
+
+### 2.5 Test
+
+- Unit tanpa Docker (`TestUnit_*`, fake `Repository`): gerbang `authz` per role; `conversion_rate`
+  `null` saat penyebut nol; rentang `from`/`to` diteruskan apa adanya.
+- Postgres asli: `spam`/`unqualified` benar-benar keluar dari penyebut (bukan sekadar dari pembilang);
+  lead tak tersentuh tidak menarik rata-rata waktu respons ke bawah; agregat di-scope ke satu
+  organization saja — **wajib**, karena kebocoran di endpoint agregat berarti membocorkan bentuk bisnis
+  tenant lain, bukan satu baris.
+- Harness isolasi tenant (`cmd/api/tenant_isolation_test.go`): entri baru untuk kedua endpoint metrik.
+  Slice `[]isolationCase` yang sama, sesuai desainnya sejak #11.
+
+---
+
+## 3. Fondasi `crm_dashboard`
+
+| Keputusan | Nilai |
+|---|---|
+| Framework | Next.js, **App Router**, TypeScript |
+| Styling | Tailwind |
+| Komponen | shadcn/ui (di-copy ke repo, bukan dependensi runtime — C3) |
+| Bahasa | Indonesia, **tanpa library i18n** (C1) |
+| Konfigurasi | `NEXT_PUBLIC_API_BASE_URL` — satu-satunya yang dibutuhkan untuk bicara ke API |
+
+### 3.1 CI
+
+`.github/workflows/ci-dashboard.yml` (baru), dengan `paths:` filter `crm_dashboard/**` — satu workflow
+per aplikasi, persis bentuk `ci-backend.yml` yang sudah ada (CLAUDE.md, ADR-009). Isinya: install,
+typecheck, lint, build. Backend tidak ikut jalan saat hanya UI berubah, dan sebaliknya.
+
+---
+
+## 4. Klien API & sesi
+
+Bagian tersulit di seluruh phase ini, dan satu-satunya yang bisa rusak dengan cara yang tidak terlihat
+di layar.
+
+### 4.1 Cookie yang tidak bisa dibaca
+
+Aturan #25: token dashboard di cookie `HttpOnly` — **tidak pernah** `localStorage`. Konsekuensi yang
+harus diterima klien:
+
+- `access_token` dan `refresh_token` **tidak bisa disentuh JavaScript sama sekali.** Klien tidak pernah
+  tahu apakah ia punya sesi; ia hanya tahu setelah bertanya.
+- `csrf_token` **sengaja bukan** `HttpOnly` (sudah begitu sejak #10) — klien membacanya dan
+  mengirimkannya kembali sebagai header `X-CSRF-Token` di setiap request non-GET. Itulah keseluruhan
+  mekanisme double-submit: penyerang lintas situs bisa memicu request dengan cookie ikut terkirim, tetapi
+  tidak bisa **membaca** cookie untuk menyusun headernya.
+- Setiap `fetch` memakai `credentials: 'include'`.
+
+Sesi ditegakkan dengan memanggil `GET /v1/me` di layout terproteksi — bukan dengan memeriksa token
+(tidak bisa). `401` berarti belum masuk; arahkan ke login.
+
+### 4.2 Refresh single-flight — wajib, bukan optimasi
+
+> Satu layar dengan enam widget yang semuanya menerima `401` bersamaan akan memanggil
+> `/v1/auth/refresh` enam kali. Rotasi refresh token (#10) menganggap pemakaian token yang sudah
+> dirotasi sebagai **reuse attack** dan mencabut seluruh `family_id` — pengguna terlempar keluar.
+> Tanpa single-flight, sesi mati sendiri di layar yang paling sibuk.
+
+Kontraknya:
+
+```
+401 diterima
+  → apakah sudah ada refresh berjalan?
+      ya    → tunggu hasil yang sama
+      tidak → mulai satu refresh
+  → refresh berhasil → ulangi request asli SEKALI
+  → refresh gagal    → bersihkan state, arahkan ke login
+```
+
+Request yang diulang **tidak pernah** memicu refresh kedua — satu percobaan, lalu menyerah. Loop
+refresh→401→refresh adalah cara paling mudah membuat backend melihat pola serangan dari client sendiri.
+
+`/v1/auth/refresh` sendiri dikecualikan dari mekanisme ini; `401` darinya berarti sesi memang habis.
+
+### 4.3 Bentuk respons
+
+Envelope `{data, meta}` dan `{error}` (Aturan #33) sudah tetap. Klien mengetiknya sekali sebagai tipe
+generik dan memakainya di semua tempat — bukan mengurai bentuk yang sama berulang kali di tiap layar.
+
+---
+
+## 5. Error di layar
+
+Backend mengirim `error.message` **dalam Bahasa Indonesia** — ditampilkan **apa adanya**. Tidak
+diterjemahkan ulang di klien: dua sumber kebenaran untuk satu kalimat berarti keduanya akan berbeda
+suatu saat, dan yang di layar belum tentu yang benar.
+
+`error.code` yang menggerakkan **perilaku** (kontrak `api.md`: `code` stabil, `message` boleh berubah).
+Empat kode butuh perlakuan khusus, bukan toast biasa:
+
+| `code` | HTTP | Perilaku UI |
+|---|---|---|
+| `version_conflict` | 409 | Body memuat `error.current`. Tampilkan "data sudah diubah orang lain", muat ulang form dari `current`, dan **jangan pernah menimpa otomatis** (Aturan #35). Ini satu-satunya tempat pengguna harus memilih secara sadar. |
+| `organization_selection_required` | 409 | Body memuat `organizations`. Layar pemilihan organization saat login (ADR-007) — pengguna dengan lebih dari satu membership aktif. |
+| `membership_has_open_leads` | 409 | Body memuat `open_lead_count`. Dialog yang **memaksa memilih** `unassign` / `reassign` / batal sebelum penonaktifan berjalan (#22). |
+| `validation_failed` | 400 | `details[]` berisi `{field, code}` — tampilkan di bawah field yang bersangkutan, bukan sebagai pesan global. |
+
+Sisanya (`forbidden`, `not_found`, `rate_limited`, `internal_error`, …) ditampilkan sebagai pesan biasa.
+
+---
+
+## 6. `version` wajib bolak-balik lewat form
+
+`leads` dan `tasks` memakai optimistic locking (Aturan #35). Setiap form edit **menyimpan `version` yang
+diterima saat membaca** dan mengirimkannya kembali saat menyimpan.
+
+Form yang lupa membawanya akan bekerja tepat sekali lalu gagal `409` di setiap penyimpanan berikutnya —
+gejala yang mudah salah dibaca sebagai "backend rusak". Dicatat di sini supaya tidak didiagnosis dari
+nol saat terjadi.
+
+---
+
+## 7. Endpoint yang dikonsumsi
+
+Seluruhnya **sudah ada** kecuali dua endpoint metrik (§2), yang dibuat issue #30.
+
+| Area | Endpoint | Sejak |
+|---|---|---|
+| Auth | `POST /v1/auth/{register,verify-email,verify-email/resend,login,refresh,logout,password/forgot,password/reset}` · `GET /v1/me` | #9, #10 |
+| Lead | `POST/GET /v1/leads` · `GET/PATCH/DELETE /v1/leads/{id}` · `PATCH /v1/leads/{id}/{status,assignment}` | #20, #22 |
+| Activity | `GET/POST /v1/leads/{id}/activities` | #21 |
+| Task | `POST/GET /v1/leads/{id}/tasks` · `GET /v1/tasks` · `PATCH/DELETE /v1/tasks/{id}` · `POST /v1/tasks/{id}/complete` | #21 |
+| Customer | `POST /v1/leads/{id}/convert` · `GET /v1/customers` · `GET/PATCH/DELETE /v1/customers/{id}` | #23 |
+| Notification | `GET /v1/notifications` · `POST /v1/notifications/{id}/read` · `POST /v1/notifications/read-all` | #22 |
+| Membership | `GET /v1/memberships` · `PATCH/DELETE /v1/memberships/{id}` | #11, #22 |
+| Invitation | `POST/GET /v1/invitations` · `DELETE /v1/invitations/{id}` · `GET /v1/invitations/token/{token}` · `POST /v1/invitations/accept` | #11 |
+| **Metrik** | `GET /v1/metrics/{summary,employees}` | **#30 — belum ada** |
+
+> Bila sebuah layar terasa membutuhkan endpoint yang tidak ada di tabel ini, periksa dulu apakah yang
+> ada sudah cukup. Menambah endpoint di tengah phase UI berarti dua aplikasi berubah dalam satu PR
+> tanpa direncanakan.
+
+### 7.1 Filter yang sudah didukung
+
+`GET /v1/leads` menerima `status` · `source` (keduanya dipisah koma) · `assigned_to` (id **atau**
+`none`) · `q` · `created_from` · `created_to` · `page` · `per_page` — sejak #20.
+
+**`assigned_to=none` adalah "lead tanpa pemilik aktif"** — kewajiban warisan Phase 2
+(`02-crm-core/td.md` §19, freeze 2.3 ketentuan #3). Query-nya sudah ada; Phase 3 membangun layarnya dan
+menjadikannya filter **permanen** yang terlihat, bukan opsi tersembunyi di menu lanjutan.
+
+---
+
+## 8. Peta layar
+
+| Layar | Endpoint utama | Issue |
+|---|---|---|
+| Login · Register · Verifikasi email · Lupa/reset password · Pilih organization | `/v1/auth/*`, `GET /v1/me` | #31 |
+| Daftar lead + filter + pagination | `GET /v1/leads` | #32 |
+| Detail lead: timeline, activity, task, status, assignment, konversi | `GET /v1/leads/{id}` + activities/tasks/status/assignment/convert | #33 |
+| Daftar & undangan anggota · ubah role · nonaktifkan | `/v1/memberships`, `/v1/invitations` | #34 |
+| Notifikasi | `/v1/notifications` | #34 |
+| Home metrik | `GET /v1/metrics/*` | #35 |
+| Daftar customer + detail | `/v1/customers` | #35 |
+| Daftar task lintas lead | `GET /v1/tasks` | #35 |
+| Settings organization | `GET /v1/me` | #35 |
+
+---
+
+## 9. Rencana test
+
+Dashboard **tidak** memakai testcontainers — ia tidak menyentuh database. Yang diuji adalah lapisan yang
+bisa salah tanpa terlihat:
+
+| Yang diuji | Kenapa wajib |
+|---|---|
+| **Refresh single-flight** — N request paralel yang `401` menghasilkan **tepat satu** panggilan refresh | §4.2: tanpa ini rotasi token mencabut sesi. Ini bug yang hanya muncul di bawah konkurensi, persis seperti alokasi `lead_number` di #19 — dan sama seperti di sana, test berurutan akan hijau meski logikanya salah total. |
+| Header `X-CSRF-Token` terpasang di setiap request non-GET, dan **tidak** di `GET` | Satu request tulis yang lupa header → `403` yang membingungkan |
+| Pemetaan `error.code` → perilaku (empat kode di §5) | Perilaku, bukan tampilan — dan `version_conflict` yang salah tangani berarti data pengguna tertimpa |
+| `version` ikut terkirim di setiap form edit | §6 |
+| Backend: seluruh test §1.3 dan §2.5 | Sisi Go |
+
+Test UI visual (snapshot, e2e penuh) **di luar cakupan** Phase 3 — nilai terbesarnya ada setelah bentuk
+layar stabil, dan bentuk itu justru yang paling mungkin berubah setelah demo pertama ke calon pengguna.
+
+---
+
+## 10. Risiko teknis
+
+| Risiko | Mitigasi |
+|---|---|
+| **Refresh storm mencabut sesi pengguna** — kegagalannya terlihat seperti "aplikasi mengeluarkan saya sendiri", bukan seperti bug klien | Single-flight (§4.2) + test konkurensi wajib (§9) |
+| **CORS salah konfigurasi di production** — dashboard mati total, tanpa error di sisi server | Validasi fail-fast saat boot (§1.1, Aturan #36) |
+| **Metrik dihitung di browser** dari halaman yang terlihat | Endpoint agregat (§2); tidak ada jalur lain yang tersedia karena list berpaginasi |
+| **`version` lupa dibawa form** → `409` di setiap penyimpanan kedua | §6 + test (§9) |
+| **Endpoint baru diminta di tengah phase UI** | Tabel §7 mengunci permukaan di muka; permintaan baru = periksa dulu, bukan langsung tambah |
+| **Cakupan layar membengkak** (grafik, realtime, dark mode) | PRD *Di luar cakupan* menyebut ketiganya eksplisit |
+
+---
+
+## 11. Yang berubah pada dokumentasi
+
+| Berkas | Perubahan |
+|---|---|
+| [`api.md`](../../architecture/api.md) | Dua endpoint metrik; catatan CORS pada bagian konvensi |
+| [`authentication.md`](../../architecture/authentication.md) | Bagian klien dashboard: cookie tak terbaca, CSRF double-submit dari sisi klien, refresh single-flight |
+| [`authorization.md`](../../architecture/authorization.md) | Baris `metrics.read` pada matriks |
+| [`multi-tenancy.md`](../../architecture/multi-tenancy.md) | Entri harness isolasi untuk endpoint metrik |
+| `STATUS.md` | C1 dicoret dari *Keputusan Belum Diambil*; Phase 3 berjalan |
+| [`product/glossary.md`](../../product/glossary.md) | Bahasa UI: "belum diputuskan" → Indonesia |
+| `phases/03-owner-dashboard/notes.md` | Satu bagian per issue (dibuat saat issue pertama dikerjakan) |
+
+---
+
+## 12. Kewajiban yang diteruskan ke phase berikutnya
+
+Ditulis di sini agar tidak bergantung pada ingatan:
+
+> **Phase 4 (API Publik)** menambah layar manajemen API key ke dashboard ini. Bentuk daftar + aksi
+> revoke sudah punya preseden di layar undangan (#34) — ikuti itu, jangan rancang ulang.
+>
+> **Phase 5 (Mobile)** memakai jalur autentikasi yang sama dengan dashboard (Aturan #24), tetapi
+> menyimpan token di secure storage, bukan cookie. Yang **tidak** boleh ikut disalin: mekanisme CSRF
+> double-submit (§4.1) tidak relevan di mobile — ia ada khusus karena cookie terkirim otomatis oleh
+> browser.
+>
+> **Angka revenue** tetap absen dari metrik sampai Deal ada (pasca-Phase 5). Freeze 3.2 mencatatnya
+> sebagai ekspektasi yang disepakati; jangan menambahkan kolom uang ke `internal/metrics` lebih awal
+> (Aturan #14, #28).

--- a/docs/product/glossary.md
+++ b/docs/product/glossary.md
@@ -86,4 +86,4 @@
 
 - **Dokumentasi & komunikasi:** Bahasa Indonesia
 - **Kode, nama kolom, nama endpoint, pesan error `code`:** Bahasa Inggris
-- **Bahasa UI produk:** belum diputuskan (lihat `docs/STATUS.md`)
+- **Bahasa UI produk:** **Bahasa Indonesia**, tanpa i18n — ditutup sebagai keputusan C1 saat PRD Phase 3 dibuka (`docs/phases/03-owner-dashboard/prd.md`). Konsisten dengan `error.message` backend yang sudah Bahasa Indonesia sejak issue #9.


### PR DESCRIPTION
## Summary

Opens **Phase 3 — Owner Dashboard**: the first demo (produk bisa dipakai tanpa `curl`), and the first work outside `crm_be`. Documents only — no code. `crm_dashboard/` stays a lone `README.md` until #31.

Same shape as the Phase 2 opening (PR #24): PRD + TD + `issues.md`, `STATUS.md` updated, milestone and issues created.

## Three product decisions closed up front

Only one of the three was actually tracked as an open decision; the other two had never been decided anywhere, and finding that out mid-implementation would have been worse.

| # | Decision | Why |
|---|---|---|
| **C1** | UI language: **Indonesian only, no i18n** | The backend has emitted Indonesian `error.message` since #9. Adding i18n means a bilingual interface sitting on top of a single-language error layer — mixed output on the same screen, at the cost of every string going through a translation key. |
| **C2** | **Browser → Go directly over CORS**, not a Next.js BFF | `HttpOnly SameSite=Lax` cookies already cross subdomains, and the CSRF double-submit in `httpx.VerifyCSRF` was built in #10 for exactly this. A BFF removes CORS but adds a hop to every request and requires a permanent Node runtime — raising per-tenant infra cost to solve an already-solved problem. |
| **C3** | **shadcn/ui + Tailwind** | Components are copied into the repo rather than pulled as a runtime dependency, so no library version pins the design and any component can be changed without fighting it. |

## Phase 3 is not a pure frontend phase

Two Go pieces must land before any screen. Both are recorded Phase 2 debts, and both are easy to miss when this is read as "the UI phase":

1. **CORS middleware does not exist at all** — nothing in `crm_be`, and no origin decision anywhere in `docs/architecture/`. Without it, C2 cannot work: the browser is rejected before the first request reaches a handler.
2. **The metrics endpoints do not exist** — `02-crm-core/td.md` §5 already says so explicitly: *"Di Phase 2 belum ada endpoint metrik (itu Phase 3)"*. Computing them in the browser from paginated list endpoints would report whatever is on the current page as the total, and that would not be visible as wrong until an organization has more than one page of leads.

Both go into issue #30, which blocks everything else.

Two definitions are pinned in the TD rather than left to implementation, because both are easy to get quietly wrong: `conversion_rate` excludes `spam`/`unqualified` from the **denominator** (finally enforcing Phase 2's acceptance criterion #5, which until now only required the two statuses to exist), and response time excludes never-touched leads from the average rather than counting them as zero — otherwise the average *improves* as leads get ignored.

## Six issues, not freeze's four sessions

~15 screens, two new Go endpoints, CORS middleware, and an application that does not exist yet. The same documented deviation Phase 1 (3→4) and Phase 2 (4→5) made.

| # | Issue | Note |
|---|---|---|
| #30 | CORS + metrics | Pure Go, blocks everything |
| #31 | Next.js setup + API client + auth | Refresh single-flight is the genuinely hard part — see below |
| #32 | Lead list | Highest-traffic screen; carries the inherited "lead tanpa pemilik aktif" filter |
| #33 | Lead detail | Second-highest traffic, and nearly every write action |
| #34 | Team: members, invitations, deactivation, notifications | The `on_open_leads` three-way branch |
| #35 | Metrics home, customers, tasks, settings | Phase closer |

**Three issues flagged for extra review attention** in `issues.md` — #30 (both failure modes are silent: misconfigured CORS kills the dashboard with no server-side error, and wrong metrics look plausible), #31 (six parallel `401`s without single-flight trigger six refreshes; token rotation from #10 reads the rotated token as a reuse attack and revokes the whole `family_id`, so the session kills itself — a concurrency-only failure, exactly like `lead_number` in #19), and #34 (collapsing deactivation into a Yes/Cancel dialog throws away the entire reason freeze 2.3's rule exists).

## Verification

- [x] All 13 PRD acceptance criteria mapped to one of the six issues — checked individually
- [x] Every endpoint claimed in TD §7 verified against the handlers as they exist today; the two metrics endpoints are the only ones marked as not-yet-built
- [x] `STATUS.md` drops "Bahasa UI" from *Keputusan Belum Diambil*; `product/glossary.md` updated to match — otherwise the two documents would contradict each other (Rule #30)
- [x] Milestone "Phase 3 — Owner Dashboard" (already existed from repo setup, `milestone/4`) now holds issues #30–#35, matching `issues.md` exactly

Refs #30, #31, #32, #33, #34, #35