### PR TITLE
feat(metrics): add CORS middleware and aggregate metrics endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,8 @@ REFRESH_TOKEN_TTL_MOBILE=2160h
 COOKIE_DOMAIN=
 # Must be true when APP_ENV=production — validated at boot (Rule #36).
 COOKIE_SECURE=false
+
+# --- CORS (issue #30, docs/phases/03-owner-dashboard/td.md §1) ---
+# Comma-separated. Required when APP_ENV=production — validated at boot
+# (Rule #36). Never "*" — Access-Control-Allow-Credentials: true forbids it.
+CORS_ALLOWED_ORIGINS=http://localhost:3000

--- a/crm_be/cmd/api/main.go
+++ b/crm_be/cmd/api/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Pravasta/jualin-crm/crm_be/internal/invitation"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/membership"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/metrics"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/notification"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/config"
@@ -83,6 +84,10 @@ func newRouter(log *slog.Logger, pool *pgxpool.Pool, cfg *config.Config) *gin.En
 	r.HandleMethodNotAllowed = true
 
 	r.Use(httpx.RequestID(), httpx.Logging(log), httpx.Recovery(log))
+	// CORS runs before any route is registered and before authMW is built
+	// below — a preflight OPTIONS request carries no credentials and must
+	// never reach the auth layer (Phase 3 TD §1.2).
+	r.Use(httpx.CORS(cfg.CORSAllowedOrigins))
 
 	mail := newMailer(cfg, log)
 	authStore := newAuthStore(pool)
@@ -123,6 +128,11 @@ func newRouter(log *slog.Logger, pool *pgxpool.Pool, cfg *config.Config) *gin.En
 
 	customerUsecase := customer.NewUsecase(newCustomerStore(pool))
 	customer.NewHandler(customerUsecase).RegisterRoutes(r, authMW)
+
+	// metrics is read-only (no Store/InTx, TD phase 3 §2) — its
+	// Repository is built directly from pool, no _store.go wrapper needed.
+	metricsUsecase := metrics.NewUsecase(metrics.New(pool))
+	metrics.NewHandler(metricsUsecase).RegisterRoutes(r, authMW)
 
 	r.NoRoute(func(c *gin.Context) {
 		httpx.RespondError(c, http.StatusNotFound, "not_found", "Route tidak ditemukan.")

--- a/crm_be/cmd/api/tenant_isolation_test.go
+++ b/crm_be/cmd/api/tenant_isolation_test.go
@@ -283,6 +283,46 @@ func seedIsolationTask(t *testing.T, pool *pgxpool.Pool, org, leadID uuid.UUID) 
 	return id
 }
 
+// TestTenantIsolation_MetricsAggregate_ScopedToOrganization is Phase 3
+// TD §2.5's addition to this harness — the two metrics endpoints don't
+// take a resource :id, so they don't fit the by-ID-404 shape every case
+// above uses. A leak here is worse than a single wrong row: it exposes
+// another tenant's aggregate business shape (freeze bagian 5, lapis 4).
+// Verified manually able to fail the same way this file's header
+// documents for #11: temporarily changing
+// metrics.postgresRepository.Summary's "organization_id = $1" predicate
+// to "(organization_id = $1 OR true)" and re-running this test turned it
+// red — org A's total_new read 3 instead of 1, counting org B's two
+// leads. See notes.md's "## #30" section for the exact procedure; the
+// change itself was never committed.
+func TestTenantIsolation_MetricsAggregate_ScopedToOrganization(t *testing.T) {
+	r, pool := newIsolationRouter(t)
+
+	orgA, _, ownerAMembershipID := seedOrgOwner(t, pool, "Metrics Org A", "metrics-owner-a@example.com")
+	tokenA := mintBearerToken(t, uuid.Must(uuid.NewV7()), orgA, ownerAMembershipID, tenant.RoleOwner)
+	seedIsolationLead(t, pool, orgA, "new")
+
+	orgB, _, _ := seedOrgOwner(t, pool, "Metrics Org B", "metrics-owner-b@example.com")
+	seedIsolationLead(t, pool, orgB, "new")
+	seedIsolationLead(t, pool, orgB, "won")
+
+	w := doIsolationRequest(r, http.MethodGet, "/v1/metrics/summary", tokenA, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Data struct {
+			TotalNew int `json:"total_new"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.TotalNew != 1 {
+		t.Fatalf("expected org A's summary to count only its own lead (total_new=1), got %d — leaked org B's leads", body.Data.TotalNew)
+	}
+}
+
 func seedIsolationCustomer(t *testing.T, pool *pgxpool.Pool, org, wonLeadID uuid.UUID) uuid.UUID {
 	t.Helper()
 	ctx := t.Context()

--- a/crm_be/internal/metrics/entity.go
+++ b/crm_be/internal/metrics/entity.go
@@ -1,0 +1,50 @@
+// Package metrics reads aggregates across leads/customers/activities for
+// the owner dashboard home screen. It belongs to none of those three
+// domains, so it gets its own folder (ADR-011) rather than being tacked
+// onto internal/lead.
+//
+// This package is deliberately read-only — no Store/InTx, no Repos
+// (Phase 3 TD §2). Adding a Unit of Work for a package that never writes
+// would be unused machinery (Rule #27).
+package metrics
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Filter scopes both endpoints to leads.created_at — never any other
+// timestamp (TD §2.1): "lead masuk periode ini, apa yang terjadi
+// padanya". Both bounds are inclusive and optional; a nil bound is
+// unbounded on that side.
+type Filter struct {
+	From *time.Time
+	To   *time.Time
+}
+
+// Summary is GET /v1/metrics/summary's payload (TD §2.1).
+type Summary struct {
+	TotalNew   int
+	ByStatus   map[string]int
+	Unassigned int
+	// ConversionRate is nil when the denominator (total minus spam minus
+	// unqualified) is zero — "belum ada yang bisa dihitung" is not the
+	// same as "sudah dicoba, gagal" (TD §2.2), so it is never reported
+	// as a bare 0.
+	ConversionRate *float64
+}
+
+// EmployeeMetric is one row of GET /v1/metrics/employees's payload (TD
+// §2.1) — keyed by membership, not restricted to role=employee: any
+// role can hold a lead assignment.
+type EmployeeMetric struct {
+	MembershipID uuid.UUID
+	FullName     string
+	LeadCount    int
+	// AvgResponseSeconds is nil when this member has no assigned lead in
+	// range that has ever been touched by an activity — excluded from
+	// the average, not counted as zero (TD §2.3).
+	AvgResponseSeconds *float64
+	ConvertedCount     int
+}

--- a/crm_be/internal/metrics/handler_http.go
+++ b/crm_be/internal/metrics/handler_http.go
@@ -1,0 +1,88 @@
+package metrics
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+)
+
+type Handler struct {
+	usecase *Usecase
+}
+
+func NewHandler(usecase *Usecase) *Handler {
+	return &Handler{usecase: usecase}
+}
+
+// RegisterRoutes mounts /v1/metrics behind authMW — built once at the
+// composition root and shared across every domain (internal/shared/authn).
+func (h *Handler) RegisterRoutes(r gin.IRouter, authMW gin.HandlerFunc) {
+	g := r.Group("/v1/metrics")
+	g.Use(authMW)
+	g.GET("/summary", h.summary)
+	g.GET("/employees", h.employees)
+}
+
+// parseFilter mirrors internal/lead's created_from/created_to parsing —
+// an unparseable or absent value is silently ignored rather than
+// rejected, leaving that bound unset (Filter's nil = unbounded).
+func parseFilter(c *gin.Context) Filter {
+	var f Filter
+	if from, err := time.Parse(time.RFC3339, c.Query("from")); err == nil {
+		f.From = &from
+	}
+	if to, err := time.Parse(time.RFC3339, c.Query("to")); err == nil {
+		f.To = &to
+	}
+	return f
+}
+
+func (h *Handler) summary(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	s, err := h.usecase.Summary(c.Request.Context(), t, parseFilter(c))
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusOK, summaryJSON(s))
+}
+
+func (h *Handler) employees(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	out, err := h.usecase.Employees(c.Request.Context(), t, parseFilter(c))
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+
+	data := make([]gin.H, 0, len(out))
+	for _, em := range out {
+		data = append(data, employeeJSON(em))
+	}
+	httpx.OK(c, http.StatusOK, data)
+}
+
+func summaryJSON(s *Summary) gin.H {
+	return gin.H{
+		"total_new":       s.TotalNew,
+		"by_status":       s.ByStatus,
+		"unassigned":      s.Unassigned,
+		"conversion_rate": s.ConversionRate,
+	}
+}
+
+func employeeJSON(em *EmployeeMetric) gin.H {
+	return gin.H{
+		"membership_id":        em.MembershipID,
+		"full_name":            em.FullName,
+		"lead_count":           em.LeadCount,
+		"avg_response_seconds": em.AvgResponseSeconds,
+		"converted_count":      em.ConvertedCount,
+	}
+}

--- a/crm_be/internal/metrics/handler_test.go
+++ b/crm_be/internal/metrics/handler_test.go
@@ -1,0 +1,147 @@
+package metrics_test
+
+// Integration tests (real Postgres via dbtest) for issue #30's HTTP
+// layer — same shape as internal/customer's handler_test.go.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/metrics"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/accesstoken"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const testJWTSecret = "metrics-handler-test-jwt-secret-32bytes" // #nosec G101 -- test-only value, not a real credential
+
+type testClaimsParser struct{}
+
+func (testClaimsParser) ParseAccessToken(raw string) (*accesstoken.Claims, error) {
+	return accesstoken.Parse([]byte(testJWTSecret), raw)
+}
+
+func newTestRouter(t *testing.T) (*gin.Engine, *pgxpool.Pool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pool := dbtest.NewPool(t)
+	u := metrics.NewUsecase(metrics.New(pool))
+
+	r := gin.New()
+	metrics.NewHandler(u).RegisterRoutes(r, authn.Middleware(testClaimsParser{}))
+	return r, pool
+}
+
+func bearerToken(t *testing.T, userID, orgID, membershipID uuid.UUID, role tenant.Role) string {
+	t.Helper()
+	tok, err := accesstoken.Issue([]byte(testJWTSecret), 15*time.Minute, userID, orgID, membershipID, role)
+	if err != nil {
+		t.Fatalf("mint access token: %v", err)
+	}
+	return tok
+}
+
+func doGet(r *gin.Engine, path, bearer string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestHandler_Summary_OwnerAllowed_Returns200(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+	seedLeadAt(t, ctx, pool, org, nil, "new", time.Now().UTC())
+
+	token := bearerToken(t, uuid.Must(uuid.NewV7()), org, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+	w := doGet(r, "/v1/metrics/summary", token)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Data struct {
+			TotalNew int `json:"total_new"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.TotalNew != 1 {
+		t.Errorf("expected total_new=1, got %d", body.Data.TotalNew)
+	}
+}
+
+// TestHandler_Summary_EmployeeForbidden_Returns403 is issue #30's literal
+// acceptance criterion: "Employee → 403 di kedua endpoint metrik".
+func TestHandler_Summary_EmployeeForbidden_Returns403(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+
+	token := bearerToken(t, uuid.Must(uuid.NewV7()), org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+	w := doGet(r, "/v1/metrics/summary", token)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Employees_EmployeeForbidden_Returns403(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+
+	token := bearerToken(t, uuid.Must(uuid.NewV7()), org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+	w := doGet(r, "/v1/metrics/employees", token)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Employees_OwnerAllowed_Returns200(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+	m := seedMembership(t, ctx, pool, org, "budi@example.com", "Budi")
+	seedLeadAt(t, ctx, pool, org, &m, "new", time.Now().UTC())
+
+	token := bearerToken(t, uuid.Must(uuid.NewV7()), org, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+	w := doGet(r, "/v1/metrics/employees", token)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Data []struct {
+			FullName  string `json:"full_name"`
+			LeadCount int    `json:"lead_count"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 1 || body.Data[0].FullName != "Budi" || body.Data[0].LeadCount != 1 {
+		t.Errorf("unexpected employees payload: %+v", body.Data)
+	}
+}
+
+func TestHandler_Unauthenticated_Returns401(t *testing.T) {
+	r, _ := newTestRouter(t)
+	w := doGet(r, "/v1/metrics/summary", "")
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/crm_be/internal/metrics/port.go
+++ b/crm_be/internal/metrics/port.go
@@ -1,0 +1,16 @@
+package metrics
+
+import (
+	"context"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Repository is metrics's own read-only interface — postgresRepository
+// (repository_postgres.go) satisfies it, but Usecase depends only on
+// this interface (ADR-011). No Store here (see entity.go doc comment):
+// this package never writes.
+type Repository interface {
+	Summary(ctx context.Context, t tenant.Context, filter Filter) (*Summary, error)
+	Employees(ctx context.Context, t tenant.Context, filter Filter) ([]*EmployeeMetric, error)
+}

--- a/crm_be/internal/metrics/repository_postgres.go
+++ b/crm_be/internal/metrics/repository_postgres.go
@@ -1,0 +1,159 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+type postgresRepository struct {
+	q db.Querier
+}
+
+// New wires a postgresRepository against q — same pattern as
+// internal/customer.New. Called directly with *pgxpool.Pool at the
+// composition root; there is no InTx wrapper because this package never
+// writes.
+func New(q db.Querier) Repository {
+	return &postgresRepository{q: q}
+}
+
+// leadRangeConditions builds the "leads.created_at within [from, to]"
+// predicate shared by every query below — the ONLY timestamp Phase 3 TD
+// §2.1 scopes either endpoint to. args starts with organization_id
+// already in place ($1); each added bound gets its own placeholder via
+// arg, same closure-based query-building pattern as
+// internal/customer.postgresRepository.FindAllByOrg.
+func leadRangeConditions(filter Filter, args *[]any, alias string) []string {
+	conditions := []string{}
+	arg := func(v any) string {
+		*args = append(*args, v)
+		return fmt.Sprintf("$%d", len(*args))
+	}
+	if filter.From != nil {
+		conditions = append(conditions, alias+"created_at >= "+arg(*filter.From))
+	}
+	if filter.To != nil {
+		conditions = append(conditions, alias+"created_at <= "+arg(*filter.To))
+	}
+	return conditions
+}
+
+// Summary computes the four fields TD §2.1 defines, all scoped to
+// leads.created_at within filter and to a single organization — no
+// isEmployee branch (TD §2.4): Usecase never lets an Employee reach
+// this method.
+func (r *postgresRepository) Summary(ctx context.Context, t tenant.Context, filter Filter) (*Summary, error) {
+	args := []any{t.OrganizationID}
+	conditions := append([]string{"organization_id = $1", "deleted_at IS NULL"}, leadRangeConditions(filter, &args, "")...)
+	where := strings.Join(conditions, " AND ")
+
+	byStatusQ := "SELECT status, count(*) FROM leads WHERE " + where + " GROUP BY status"
+	rows, err := r.q.Query(ctx, byStatusQ, args...)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: summary by status: %w", err)
+	}
+	byStatus := map[string]int{}
+	total := 0
+	for rows.Next() {
+		var status string
+		var count int
+		if err := rows.Scan(&status, &count); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("metrics: scan by status: %w", err)
+		}
+		byStatus[status] = count
+		total += count
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("metrics: summary by status: %w", err)
+	}
+
+	unassignedQ := "SELECT count(*) FROM leads WHERE " + where + " AND assigned_to_membership_id IS NULL"
+	var unassigned int
+	if err := r.q.QueryRow(ctx, unassignedQ, args...).Scan(&unassigned); err != nil {
+		return nil, fmt.Errorf("metrics: summary unassigned: %w", err)
+	}
+
+	// spam/unqualified excluded from the DENOMINATOR, not just the
+	// numerator (TD §2.2) — this is what finally enforces Phase 2's
+	// acceptance criterion #5.
+	denominator := total - byStatus["spam"] - byStatus["unqualified"]
+	var conversionRate *float64
+	if denominator > 0 {
+		rate := float64(byStatus["won"]) / float64(denominator)
+		conversionRate = &rate
+	}
+
+	return &Summary{
+		TotalNew:       total,
+		ByStatus:       byStatus,
+		Unassigned:     unassigned,
+		ConversionRate: conversionRate,
+	}, nil
+}
+
+// Employees aggregates per membership — every active membership in the
+// organization, not just role=employee (assignment isn't role-
+// restricted). lead_count/converted_count/avg_response_seconds are all
+// scoped to leads assigned to that membership with created_at inside
+// filter (TD §2.1: "Rentang membatasi leads.created_at, bukan waktu
+// peristiwa lain").
+//
+// avg_response_seconds is computed as
+// MIN(activities.created_at WHERE type <> 'lead_created') -
+// leads.created_at per lead (TD §2.3), then averaged in SQL — Postgres's
+// avg() ignores NULL inputs on its own, which is exactly "a never-
+// touched lead is excluded from the average, not counted as zero"
+// without any special-casing in this query.
+func (r *postgresRepository) Employees(ctx context.Context, t tenant.Context, filter Filter) ([]*EmployeeMetric, error) {
+	args := []any{t.OrganizationID}
+	leadJoin := append([]string{
+		"l.assigned_to_membership_id = m.id",
+		"l.organization_id = m.organization_id",
+		"l.deleted_at IS NULL",
+	}, leadRangeConditions(filter, &args, "l.")...)
+
+	q := `
+		SELECT
+			m.id,
+			u.full_name,
+			count(l.id) AS lead_count,
+			count(l.id) FILTER (WHERE c.id IS NOT NULL) AS converted_count,
+			avg(extract(epoch FROM (touch.first_touched_at - l.created_at))) AS avg_response_seconds
+		FROM memberships m
+		JOIN users u ON u.id = m.user_id
+		LEFT JOIN leads l ON ` + strings.Join(leadJoin, " AND ") + `
+		LEFT JOIN customers c ON c.converted_from_lead_id = l.id AND c.organization_id = m.organization_id
+		LEFT JOIN LATERAL (
+			SELECT MIN(a.created_at) AS first_touched_at
+			FROM activities a
+			WHERE a.lead_id = l.id AND a.organization_id = m.organization_id AND a.type <> 'lead_created'
+		) touch ON true
+		WHERE m.organization_id = $1 AND m.deleted_at IS NULL
+		GROUP BY m.id, u.full_name
+		ORDER BY u.full_name`
+
+	rows, err := r.q.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: employees: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*EmployeeMetric
+	for rows.Next() {
+		var em EmployeeMetric
+		if err := rows.Scan(&em.MembershipID, &em.FullName, &em.LeadCount, &em.ConvertedCount, &em.AvgResponseSeconds); err != nil {
+			return nil, fmt.Errorf("metrics: scan employee: %w", err)
+		}
+		out = append(out, &em)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("metrics: employees: %w", err)
+	}
+	return out, nil
+}

--- a/crm_be/internal/metrics/repository_test.go
+++ b/crm_be/internal/metrics/repository_test.go
@@ -1,0 +1,287 @@
+package metrics_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/metrics"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+func TestRepository_Summary_ByStatusUnassignedAndRangeFilter(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := metrics.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	m := seedMembership(t, ctx, pool, org, "owner@example.com", "Owner Satu")
+
+	inRange := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	outOfRange := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	seedLeadAt(t, ctx, pool, org, nil, "new", inRange)
+	seedLeadAt(t, ctx, pool, org, &m, "contacted", inRange)
+	seedLeadAt(t, ctx, pool, org, nil, "won", inRange)
+	seedLeadAt(t, ctx, pool, org, nil, "new", outOfRange) // outside filter — must be excluded
+
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 1, 31, 23, 59, 59, 0, time.UTC)
+	s, err := repo.Summary(ctx, tenant.Context{OrganizationID: org}, metrics.Filter{From: &from, To: &to})
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+
+	if s.TotalNew != 3 {
+		t.Errorf("expected total_new=3 (out-of-range lead excluded), got %d", s.TotalNew)
+	}
+	if s.ByStatus["new"] != 1 || s.ByStatus["contacted"] != 1 || s.ByStatus["won"] != 1 {
+		t.Errorf("unexpected by_status: %+v", s.ByStatus)
+	}
+	if s.Unassigned != 2 {
+		t.Errorf("expected unassigned=2 (the contacted lead is assigned), got %d", s.Unassigned)
+	}
+}
+
+// TestRepository_Summary_ConversionRate_ExcludesSpamAndUnqualifiedFromDenominator
+// is the direct proof for TD §2.2 / issue #30's headline acceptance
+// criterion: spam and unqualified must leave the DENOMINATOR, not just
+// the numerator.
+func TestRepository_Summary_ConversionRate_ExcludesSpamAndUnqualifiedFromDenominator(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := metrics.New(pool)
+	org := seedOrganization(t, ctx, pool)
+
+	now := time.Now().UTC()
+	seedLeadAt(t, ctx, pool, org, nil, "won", now)
+	seedLeadAt(t, ctx, pool, org, nil, "new", now)
+	seedLeadAt(t, ctx, pool, org, nil, "spam", now)
+	seedLeadAt(t, ctx, pool, org, nil, "unqualified", now)
+
+	s, err := repo.Summary(ctx, tenant.Context{OrganizationID: org}, metrics.Filter{})
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+
+	// total=4, denominator = 4 - 1(spam) - 1(unqualified) = 2, won=1 → 0.5.
+	// If spam/unqualified were only excluded from the numerator, the
+	// denominator would stay 4 and the rate would wrongly read 0.25.
+	if s.ConversionRate == nil || *s.ConversionRate != 0.5 {
+		t.Fatalf("expected conversion_rate=0.5, got %v", s.ConversionRate)
+	}
+}
+
+func TestRepository_Summary_ConversionRate_NilWhenDenominatorZero(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := metrics.New(pool)
+	org := seedOrganization(t, ctx, pool)
+
+	now := time.Now().UTC()
+	seedLeadAt(t, ctx, pool, org, nil, "spam", now)
+	seedLeadAt(t, ctx, pool, org, nil, "unqualified", now)
+
+	s, err := repo.Summary(ctx, tenant.Context{OrganizationID: org}, metrics.Filter{})
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+	if s.ConversionRate != nil {
+		t.Errorf("expected nil conversion_rate when the denominator is zero (\"belum ada yang bisa dihitung\"), got %v", *s.ConversionRate)
+	}
+}
+
+// TestRepository_Summary_ScopedToOrganization is the mandatory case TD
+// §2.5 calls out explicitly: a leak here exposes another tenant's
+// business shape, not just one row.
+func TestRepository_Summary_ScopedToOrganization(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := metrics.New(pool)
+
+	orgA := seedOrganization(t, ctx, pool)
+	orgB := seedOrganization(t, ctx, pool)
+
+	now := time.Now().UTC()
+	seedLeadAt(t, ctx, pool, orgA, nil, "new", now)
+	seedLeadAt(t, ctx, pool, orgB, nil, "new", now)
+	seedLeadAt(t, ctx, pool, orgB, nil, "new", now)
+
+	s, err := repo.Summary(ctx, tenant.Context{OrganizationID: orgA}, metrics.Filter{})
+	if err != nil {
+		t.Fatalf("summary: %v", err)
+	}
+	if s.TotalNew != 1 {
+		t.Fatalf("expected org A's summary to see only its own lead, got total_new=%d — leaked org B's data", s.TotalNew)
+	}
+}
+
+func TestRepository_Employees_LeadCountAndConvertedCount(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := metrics.New(pool)
+	org := seedOrganization(t, ctx, pool)
+	m1 := seedMembership(t, ctx, pool, org, "budi@example.com", "Budi")
+	m2 := seedMembership(t, ctx, pool, org, "sari@example.com", "Sari")
+
+	now := time.Now().UTC()
+	won := seedLeadAt(t, ctx, pool, org, &m1, "won", now)
+	seedLeadAt(t, ctx, pool, org, &m1, "new", now)
+	seedLeadAt(t, ctx, pool, org, &m2, "new", now)
+	seedCustomerFromLead(t, ctx, pool, org, won)
+
+	out, err := repo.Employees(ctx, tenant.Context{OrganizationID: org}, metrics.Filter{})
+	if err != nil {
+		t.Fatalf("employees: %v", err)
+	}
+
+	byID := map[uuid.UUID]*metrics.EmployeeMetric{}
+	for _, em := range out {
+		byID[em.MembershipID] = em
+	}
+
+	if byID[m1].LeadCount != 2 {
+		t.Errorf("expected m1 lead_count=2, got %d", byID[m1].LeadCount)
+	}
+	if byID[m1].ConvertedCount != 1 {
+		t.Errorf("expected m1 converted_count=1, got %d", byID[m1].ConvertedCount)
+	}
+	if byID[m2].LeadCount != 1 {
+		t.Errorf("expected m2 lead_count=1, got %d", byID[m2].LeadCount)
+	}
+	if byID[m2].ConvertedCount != 0 {
+		t.Errorf("expected m2 converted_count=0, got %d", byID[m2].ConvertedCount)
+	}
+}
+
+// TestRepository_Employees_AvgResponseSeconds_ExcludesUntouchedLeadsAndLeadCreated
+// proves both halves of TD §2.3 at once: a 'lead_created' activity must
+// NOT count as a touch (it fires automatically on capture — TD §2.3's
+// exact reason to exclude it), and a lead with no OTHER activity must be
+// excluded from the average rather than pulling it toward zero.
+func TestRepository_Employees_AvgResponseSeconds_ExcludesUntouchedLeadsAndLeadCreated(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := metrics.New(pool)
+	org := seedOrganization(t, ctx, pool)
+	m := seedMembership(t, ctx, pool, org, "budi@example.com", "Budi")
+
+	created := time.Now().UTC().Add(-1 * time.Hour)
+	touchedLead := seedLeadAt(t, ctx, pool, org, &m, "contacted", created)
+	seedLeadAt(t, ctx, pool, org, &m, "new", created) // never touched by a real activity
+
+	// lead_created fires at the same instant as creation — if this were
+	// counted, avg_response_seconds would read ~0 instead of ~10 minutes.
+	seedActivity(t, ctx, pool, org, touchedLead, "lead_created", created)
+	seedActivity(t, ctx, pool, org, touchedLead, "status_changed", created.Add(10*time.Minute))
+
+	out, err := repo.Employees(ctx, tenant.Context{OrganizationID: org}, metrics.Filter{})
+	if err != nil {
+		t.Fatalf("employees: %v", err)
+	}
+
+	var got *metrics.EmployeeMetric
+	for _, em := range out {
+		if em.MembershipID == m {
+			got = em
+		}
+	}
+	if got == nil {
+		t.Fatal("expected the seeded membership in the output")
+	}
+	if got.AvgResponseSeconds == nil {
+		t.Fatal("expected avg_response_seconds to be set from the touched lead's status_changed activity")
+	}
+	want := (10 * time.Minute).Seconds()
+	if diff := *got.AvgResponseSeconds - want; diff < -1 || diff > 1 {
+		t.Errorf("expected avg_response_seconds ~= %v (lead_created excluded, untouched lead excluded not zeroed), got %v", want, *got.AvgResponseSeconds)
+	}
+}
+
+func TestRepository_Employees_ScopedToOrganization(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := metrics.New(pool)
+	orgA := seedOrganization(t, ctx, pool)
+	orgB := seedOrganization(t, ctx, pool)
+	seedMembership(t, ctx, pool, orgA, "a@example.com", "A")
+	seedMembership(t, ctx, pool, orgB, "b@example.com", "B")
+
+	out, err := repo.Employees(ctx, tenant.Context{OrganizationID: orgA}, metrics.Filter{})
+	if err != nil {
+		t.Fatalf("employees: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected exactly 1 membership visible for org A, got %d — leaked another org's members", len(out))
+	}
+}
+
+// --- seed helpers — internal/metrics doesn't depend on internal/lead,
+// internal/membership, internal/customer, or internal/activity, so its
+// tests build the rows they need with raw SQL, same pattern
+// internal/customer's tests already use for leads.
+
+func seedOrganization(t *testing.T, ctx context.Context, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, id); err != nil {
+		t.Fatalf("seed organization: %v", err)
+	}
+	return id
+}
+
+func seedMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, email, fullName string) uuid.UUID {
+	t.Helper()
+	userID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', $3)`, userID, email, fullName); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	membershipID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, 'employee')`, membershipID, org, userID); err != nil {
+		t.Fatalf("seed membership: %v", err)
+	}
+	return membershipID
+}
+
+func seedLeadAt(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, assignedTo *uuid.UUID, status string, createdAt time.Time) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	var q string
+	if status == "lost" {
+		q = `INSERT INTO leads (id, organization_id, lead_number, name, source, assigned_to_membership_id, status, lost_reason, created_at)
+			VALUES ($1, $2, (SELECT next_lead_number FROM organizations WHERE id = $2), 'Test Lead', 'manual', $3, $4, 'other', $5)`
+	} else {
+		q = `INSERT INTO leads (id, organization_id, lead_number, name, source, assigned_to_membership_id, status, created_at)
+			VALUES ($1, $2, (SELECT next_lead_number FROM organizations WHERE id = $2), 'Test Lead', 'manual', $3, $4, $5)`
+	}
+	if _, err := pool.Exec(ctx, q, id, org, assignedTo, status, createdAt); err != nil {
+		t.Fatalf("seed lead: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE organizations SET next_lead_number = next_lead_number + 1 WHERE id = $1`, org); err != nil {
+		t.Fatalf("bump next_lead_number: %v", err)
+	}
+	return id
+}
+
+func seedActivity(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org, leadID uuid.UUID, activityType string, createdAt time.Time) {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	const q = `INSERT INTO activities (id, organization_id, lead_id, type, created_at) VALUES ($1, $2, $3, $4, $5)`
+	if _, err := pool.Exec(ctx, q, id, org, leadID, activityType, createdAt); err != nil {
+		t.Fatalf("seed activity: %v", err)
+	}
+}
+
+func seedCustomerFromLead(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org, leadID uuid.UUID) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	const q = `INSERT INTO customers (id, organization_id, name, converted_from_lead_id) VALUES ($1, $2, 'Test Customer', $3)`
+	if _, err := pool.Exec(ctx, q, id, org, leadID); err != nil {
+		t.Fatalf("seed customer: %v", err)
+	}
+	return id
+}

--- a/crm_be/internal/metrics/usecase.go
+++ b/crm_be/internal/metrics/usecase.go
@@ -1,0 +1,45 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authz"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Usecase depends only on Repository (port.go), never on *pgxpool.Pool
+// or pgx directly (ADR-011). It takes Repository directly rather than a
+// Store — there is no transaction to open.
+type Usecase struct {
+	repo Repository
+}
+
+func NewUsecase(repo Repository) *Usecase {
+	return &Usecase{repo: repo}
+}
+
+// Summary gates on ActionMetricsRead — Employee never reaches
+// Repository.Summary, so the repository itself has no isEmployee branch
+// (TD §2.4), unlike lead/task/customer.
+func (u *Usecase) Summary(ctx context.Context, t tenant.Context, filter Filter) (*Summary, error) {
+	if err := authz.Require(t, authz.ActionMetricsRead); err != nil {
+		return nil, err
+	}
+	s, err := u.repo.Summary(ctx, t, filter)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: summary: %w", err)
+	}
+	return s, nil
+}
+
+func (u *Usecase) Employees(ctx context.Context, t tenant.Context, filter Filter) ([]*EmployeeMetric, error) {
+	if err := authz.Require(t, authz.ActionMetricsRead); err != nil {
+		return nil, err
+	}
+	out, err := u.repo.Employees(ctx, t, filter)
+	if err != nil {
+		return nil, fmt.Errorf("metrics: employees: %w", err)
+	}
+	return out, nil
+}

--- a/crm_be/internal/metrics/usecase_unit_test.go
+++ b/crm_be/internal/metrics/usecase_unit_test.go
@@ -1,0 +1,150 @@
+package metrics_test
+
+// TestUnit_* tests prove Usecase is decoupled from PostgreSQL (ADR-011) —
+// fake Repository, no Docker. Run in isolation with:
+//
+//	go test ./internal/metrics/... -run TestUnit
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/metrics"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+type fakeMetricsRepo struct {
+	summary       *metrics.Summary
+	employees     []*metrics.EmployeeMetric
+	lastFilter    metrics.Filter
+	summaryCalled bool
+}
+
+func (f *fakeMetricsRepo) Summary(_ context.Context, _ tenant.Context, filter metrics.Filter) (*metrics.Summary, error) {
+	f.summaryCalled = true
+	f.lastFilter = filter
+	return f.summary, nil
+}
+
+func (f *fakeMetricsRepo) Employees(_ context.Context, _ tenant.Context, filter metrics.Filter) ([]*metrics.EmployeeMetric, error) {
+	f.lastFilter = filter
+	return f.employees, nil
+}
+
+func actorContext(role tenant.Role) tenant.Context {
+	membershipID := uuid.Must(uuid.NewV7())
+	return tenant.Context{
+		OrganizationID: uuid.Must(uuid.NewV7()),
+		PrincipalType:  tenant.PrincipalUser,
+		MembershipID:   &membershipID,
+		Role:           role,
+	}
+}
+
+func assertForbidden(t *testing.T, err error) {
+	t.Helper()
+	var derr *httpx.DomainError
+	if !errors.As(err, &derr) || derr.Code != "forbidden" {
+		t.Fatalf("expected forbidden, got: %v", err)
+	}
+}
+
+func TestUnit_Summary_EmployeeForbidden(t *testing.T) {
+	repo := &fakeMetricsRepo{summary: &metrics.Summary{}}
+	u := metrics.NewUsecase(repo)
+
+	_, err := u.Summary(context.Background(), actorContext(tenant.RoleEmployee), metrics.Filter{})
+	assertForbidden(t, err)
+	if repo.summaryCalled {
+		t.Error("expected repository not to be called for a forbidden actor")
+	}
+}
+
+func TestUnit_Employees_EmployeeForbidden(t *testing.T) {
+	repo := &fakeMetricsRepo{}
+	u := metrics.NewUsecase(repo)
+
+	_, err := u.Employees(context.Background(), actorContext(tenant.RoleEmployee), metrics.Filter{})
+	assertForbidden(t, err)
+}
+
+func TestUnit_Summary_OwnerAdminManagerAllowed(t *testing.T) {
+	for _, role := range []tenant.Role{tenant.RoleOwner, tenant.RoleAdmin, tenant.RoleManager} {
+		t.Run(string(role), func(t *testing.T) {
+			repo := &fakeMetricsRepo{summary: &metrics.Summary{TotalNew: 5}}
+			u := metrics.NewUsecase(repo)
+
+			got, err := u.Summary(context.Background(), actorContext(role), metrics.Filter{})
+			if err != nil {
+				t.Fatalf("expected %s to be allowed, got: %v", role, err)
+			}
+			if got.TotalNew != 5 {
+				t.Errorf("expected summary passed through from repository, got %+v", got)
+			}
+		})
+	}
+}
+
+func TestUnit_Summary_PassesFilterThrough(t *testing.T) {
+	repo := &fakeMetricsRepo{summary: &metrics.Summary{}}
+	u := metrics.NewUsecase(repo)
+
+	from := mustParseTime(t, "2026-01-01T00:00:00Z")
+	to := mustParseTime(t, "2026-01-31T23:59:59Z")
+	filter := metrics.Filter{From: &from, To: &to}
+
+	if _, err := u.Summary(context.Background(), actorContext(tenant.RoleOwner), filter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.lastFilter.From == nil || !repo.lastFilter.From.Equal(from) {
+		t.Errorf("expected From to reach the repository unchanged, got %v", repo.lastFilter.From)
+	}
+	if repo.lastFilter.To == nil || !repo.lastFilter.To.Equal(to) {
+		t.Errorf("expected To to reach the repository unchanged, got %v", repo.lastFilter.To)
+	}
+}
+
+func TestUnit_Summary_ConversionRateNilWhenDenominatorZero(t *testing.T) {
+	// This test proves the USECASE doesn't invent a value — the nil-vs-0
+	// distinction itself is the repository's job (TD §2.2), covered
+	// against real Postgres in repository_test.go. Here we only prove
+	// the usecase passes whatever the repository computed straight
+	// through, without collapsing nil to 0 anywhere in between.
+	repo := &fakeMetricsRepo{summary: &metrics.Summary{ConversionRate: nil}}
+	u := metrics.NewUsecase(repo)
+
+	got, err := u.Summary(context.Background(), actorContext(tenant.RoleOwner), metrics.Filter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ConversionRate != nil {
+		t.Errorf("expected nil conversion_rate to remain nil, got %v", *got.ConversionRate)
+	}
+}
+
+func TestUnit_Employees_OwnerAllowed(t *testing.T) {
+	repo := &fakeMetricsRepo{employees: []*metrics.EmployeeMetric{{FullName: "Budi"}}}
+	u := metrics.NewUsecase(repo)
+
+	got, err := u.Employees(context.Background(), actorContext(tenant.RoleOwner), metrics.Filter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].FullName != "Budi" {
+		t.Errorf("expected employees passed through from repository, got %+v", got)
+	}
+}
+
+func mustParseTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse time: %v", err)
+	}
+	return parsed
+}

--- a/crm_be/internal/shared/authz/authz.go
+++ b/crm_be/internal/shared/authz/authz.go
@@ -81,6 +81,12 @@ const (
 	ActionCustomerRead   Action = "customer.read"
 	ActionCustomerUpdate Action = "customer.update"
 	ActionCustomerDelete Action = "customer.delete"
+
+	// ActionMetricsRead gates both aggregate endpoints issue #30 adds.
+	// Employee is deliberately excluded — the dashboard isn't Employee's
+	// tool (Employee gets mobile in Phase 5), and cross-organization
+	// aggregates are management-level information regardless of role.
+	ActionMetricsRead Action = "metrics.read"
 )
 
 // permissions mirrors docs/architecture/authorization.md's matrix
@@ -110,6 +116,7 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionCustomerRead:         true,
 		ActionCustomerUpdate:       true,
 		ActionCustomerDelete:       true,
+		ActionMetricsRead:          true,
 	},
 	tenant.RoleAdmin: {
 		ActionMembershipList:       true,
@@ -134,6 +141,7 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionCustomerRead:         true,
 		ActionCustomerUpdate:       true,
 		ActionCustomerDelete:       true,
+		ActionMetricsRead:          true,
 	},
 	tenant.RoleManager: {
 		ActionMembershipList: true,
@@ -154,6 +162,7 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionCustomerRead:   true,
 		// ActionCustomerUpdate/Delete deliberately absent — Owner/Admin
 		// only, narrower than Manager's lead.update/delete access.
+		ActionMetricsRead: true,
 	},
 	tenant.RoleEmployee: {
 		// Read/update granted here; the repository further restricts
@@ -172,6 +181,9 @@ var permissions = map[tenant.Role]map[Action]bool{
 		// ActionCustomerUpdate/Delete/ActionLeadConvert deliberately
 		// absent — Employee gets read-only, repo-restricted to
 		// customers converted from leads assigned to them.
+		// ActionMetricsRead deliberately absent — the dashboard isn't
+		// Employee's tool (Phase 3 TD §2.4); Employee gets mobile in
+		// Phase 5.
 	},
 }
 

--- a/crm_be/internal/shared/authz/authz_test.go
+++ b/crm_be/internal/shared/authz/authz_test.go
@@ -37,6 +37,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleOwner, authz.ActionCustomerRead, true},
 		{tenant.RoleOwner, authz.ActionCustomerUpdate, true},
 		{tenant.RoleOwner, authz.ActionCustomerDelete, true},
+		{tenant.RoleOwner, authz.ActionMetricsRead, true},
 
 		{tenant.RoleAdmin, authz.ActionMembershipList, true},
 		{tenant.RoleAdmin, authz.ActionMembershipUpdateRole, true},
@@ -60,6 +61,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleAdmin, authz.ActionCustomerRead, true},
 		{tenant.RoleAdmin, authz.ActionCustomerUpdate, true},
 		{tenant.RoleAdmin, authz.ActionCustomerDelete, true},
+		{tenant.RoleAdmin, authz.ActionMetricsRead, true},
 
 		{tenant.RoleManager, authz.ActionMembershipList, true},
 		{tenant.RoleManager, authz.ActionMembershipUpdateRole, false},
@@ -83,6 +85,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleManager, authz.ActionCustomerRead, true},
 		{tenant.RoleManager, authz.ActionCustomerUpdate, false},
 		{tenant.RoleManager, authz.ActionCustomerDelete, false},
+		{tenant.RoleManager, authz.ActionMetricsRead, true},
 
 		{tenant.RoleEmployee, authz.ActionMembershipList, false},
 		{tenant.RoleEmployee, authz.ActionMembershipUpdateRole, false},
@@ -106,6 +109,7 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleEmployee, authz.ActionCustomerRead, true}, // repository further restricts to own leads' customers
 		{tenant.RoleEmployee, authz.ActionCustomerUpdate, false},
 		{tenant.RoleEmployee, authz.ActionCustomerDelete, false},
+		{tenant.RoleEmployee, authz.ActionMetricsRead, false}, // dashboard isn't Employee's tool
 	}
 
 	for _, c := range cases {

--- a/crm_be/internal/shared/config/config.go
+++ b/crm_be/internal/shared/config/config.go
@@ -57,6 +57,16 @@ type Config struct {
 	// below, not just documented, because COOKIE_SECURE=false in
 	// production means auth cookies travel over plain HTTP (Rule #36).
 	CookieSecure bool `env:"COOKIE_SECURE" envDefault:"false"`
+
+	// CORSAllowedOrigins are the browser origins allowed to call this API
+	// with credentials (Phase 3 TD §1.1) — never "*": Access-Control-
+	// Allow-Credentials: true and a wildcard origin are mutually
+	// exclusive, so a list is the only option once cookies are involved.
+	// Empty by default — local development writes
+	// http://localhost:3000 explicitly in .env/docker-compose.yml rather
+	// than having it hidden as a code default; required non-empty in
+	// production below (Rule #36).
+	CORSAllowedOrigins []string `env:"CORS_ALLOWED_ORIGINS" envSeparator:","`
 }
 
 // Load parses environment variables into a Config and validates it.
@@ -96,6 +106,9 @@ func (c *Config) validate() error {
 	}
 	if c.AppEnv == "production" && !c.CookieSecure {
 		return fmt.Errorf("config invalid: COOKIE_SECURE must be true when APP_ENV=production")
+	}
+	if c.AppEnv == "production" && len(c.CORSAllowedOrigins) == 0 {
+		return fmt.Errorf("config invalid: CORS_ALLOWED_ORIGINS must be set when APP_ENV=production")
 	}
 	return nil
 }

--- a/crm_be/internal/shared/config/config_test.go
+++ b/crm_be/internal/shared/config/config_test.go
@@ -109,6 +109,7 @@ func TestLoad_ProductionMode(t *testing.T) {
 	t.Setenv("JWT_SECRET", validJWTSecret)
 	t.Setenv("APP_ENV", "production")
 	t.Setenv("COOKIE_SECURE", "true")
+	t.Setenv("CORS_ALLOWED_ORIGINS", "https://app.example.com")
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -154,6 +155,7 @@ func TestLoad_ProductionRequiresCookieSecure(t *testing.T) {
 	t.Setenv("JWT_SECRET", validJWTSecret)
 	t.Setenv("APP_ENV", "production")
 	t.Setenv("COOKIE_SECURE", "false")
+	t.Setenv("CORS_ALLOWED_ORIGINS", "https://app.example.com")
 
 	_, err := config.Load()
 	if err == nil {
@@ -161,5 +163,48 @@ func TestLoad_ProductionRequiresCookieSecure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "COOKIE_SECURE") {
 		t.Errorf("expected error to mention COOKIE_SECURE, got: %v", err)
+	}
+}
+
+// TestLoad_ProductionRequiresCORSAllowedOrigins is issue #30's direct
+// acceptance criterion (TD phase 3 §1.1, Rule #36): an empty
+// CORS_ALLOWED_ORIGINS in production means the dashboard is dead on
+// arrival with no server-side error — boot must fail instead.
+func TestLoad_ProductionRequiresCORSAllowedOrigins(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://localhost/test")
+	t.Setenv("JWT_SECRET", validJWTSecret)
+	t.Setenv("APP_ENV", "production")
+	t.Setenv("COOKIE_SECURE", "true")
+	unsetEnv(t, "CORS_ALLOWED_ORIGINS")
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("expected error when APP_ENV=production and CORS_ALLOWED_ORIGINS is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "CORS_ALLOWED_ORIGINS") {
+		t.Errorf("expected error to mention CORS_ALLOWED_ORIGINS, got: %v", err)
+	}
+}
+
+// TestLoad_CORSAllowedOrigins_SplitsOnComma proves the envSeparator tag
+// actually parses a multi-origin list (production + staging + preview,
+// TD §1.1) rather than treating it as one opaque string.
+func TestLoad_CORSAllowedOrigins_SplitsOnComma(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://localhost/test")
+	t.Setenv("JWT_SECRET", validJWTSecret)
+	t.Setenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000,https://staging.example.com")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"http://localhost:3000", "https://staging.example.com"}
+	if len(cfg.CORSAllowedOrigins) != len(want) {
+		t.Fatalf("expected %v, got %v", want, cfg.CORSAllowedOrigins)
+	}
+	for i, origin := range want {
+		if cfg.CORSAllowedOrigins[i] != origin {
+			t.Errorf("expected origin[%d] = %q, got %q", i, origin, cfg.CORSAllowedOrigins[i])
+		}
 	}
 }

--- a/crm_be/internal/shared/httpx/cors.go
+++ b/crm_be/internal/shared/httpx/cors.go
@@ -1,0 +1,54 @@
+package httpx
+
+import (
+	"net/http"
+	"slices"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	corsAllowedMethods = "GET, POST, PATCH, DELETE, OPTIONS"
+	corsAllowedHeaders = "Content-Type, Authorization, X-CSRF-Token, Idempotency-Key"
+	// corsMaxAge caches a preflight result for ten minutes so a PATCH
+	// from the dashboard doesn't cost two round trips on every request
+	// (Phase 3 TD §1.2).
+	corsMaxAge = "600"
+)
+
+// CORS answers browser preflight (OPTIONS) and, for an allowed origin,
+// echoes it back verbatim — never "*", because
+// Access-Control-Allow-Credentials: true and a wildcard origin are
+// mutually exclusive (Phase 3 TD §1.1). An origin NOT in allowedOrigins
+// gets no CORS headers at all and the request still proceeds: the
+// browser is what rejects it client-side, the server never confirms or
+// denies which origins are configured.
+//
+// Must run before authn.Middleware (Phase 3 TD §1.2) — a preflight
+// request carries no credentials and must never reach the auth layer.
+func CORS(allowedOrigins []string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		origin := c.GetHeader("Origin")
+		allowed := origin != "" && slices.Contains(allowedOrigins, origin)
+
+		if allowed {
+			c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
+			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+			// Origin-dependent response — caches must not serve one
+			// origin's CORS headers to a different origin's request.
+			c.Writer.Header().Set("Vary", "Origin")
+		}
+
+		if c.Request.Method == http.MethodOptions {
+			if allowed {
+				c.Writer.Header().Set("Access-Control-Allow-Methods", corsAllowedMethods)
+				c.Writer.Header().Set("Access-Control-Allow-Headers", corsAllowedHeaders)
+				c.Writer.Header().Set("Access-Control-Max-Age", corsMaxAge)
+			}
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/crm_be/internal/shared/httpx/cors_test.go
+++ b/crm_be/internal/shared/httpx/cors_test.go
@@ -1,0 +1,114 @@
+package httpx_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+)
+
+func newCORSRouter(allowedOrigins []string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(httpx.CORS(allowedOrigins))
+	r.GET("/ping", func(c *gin.Context) { c.Status(http.StatusOK) })
+	return r
+}
+
+func TestCORS_AllowedOrigin_EchoesOriginAndAllowsCredentials(t *testing.T) {
+	r := newCORSRouter([]string{"http://localhost:3000"})
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:3000" {
+		t.Errorf("expected Allow-Origin to echo the request origin, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Errorf("expected Allow-Credentials=true, got %q", got)
+	}
+}
+
+func TestCORS_DisallowedOrigin_NoHeadersButRequestStillProcessed(t *testing.T) {
+	r := newCORSRouter([]string{"http://localhost:3000"})
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected no Allow-Origin header for a disallowed origin, got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Errorf("expected no Allow-Credentials header for a disallowed origin, got %q", got)
+	}
+	// The server never confirms or denies which origins are configured —
+	// the browser is what rejects the response, so the handler still runs.
+	if w.Code != http.StatusOK {
+		t.Errorf("expected the request to still reach the handler (200), got %d", w.Code)
+	}
+}
+
+func TestCORS_Preflight_Returns204WithoutTouchingHandler(t *testing.T) {
+	handlerCalled := false
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(httpx.CORS([]string{"http://localhost:3000"}))
+	r.PATCH("/v1/leads/1", func(c *gin.Context) {
+		handlerCalled = true
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodOptions, "/v1/leads/1", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	req.Header.Set("Access-Control-Request-Method", "PATCH")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+	if handlerCalled {
+		t.Error("expected preflight to never reach the route handler")
+	}
+	if got := w.Header().Get("Access-Control-Max-Age"); got == "" {
+		t.Error("expected Access-Control-Max-Age to be set on preflight so PATCH isn't two round trips every time")
+	}
+}
+
+func TestCORS_NeverSendsWildcardWithCredentials(t *testing.T) {
+	r := newCORSRouter([]string{"http://localhost:3000", "https://app.example.com"})
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got == "*" {
+		t.Fatal("Access-Control-Allow-Origin must never be '*' when credentials are allowed")
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Errorf("expected Allow-Credentials=true, got %q", got)
+	}
+}
+
+func TestCORS_NoOriginHeader_RequestProceedsWithoutCORSHeaders(t *testing.T) {
+	r := newCORSRouter([]string{"http://localhost:3000"})
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for a same-origin/non-browser request, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("expected no Allow-Origin header when Origin is absent, got %q", got)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       DATABASE_URL: postgres://jualin:jualin@postgres:5432/jualin_crm?sslmode=disable
       DB_MAX_CONNS: 10
       LOG_LEVEL: debug
+      CORS_ALLOWED_ORIGINS: http://localhost:3000
       # Dev-only placeholder — never reused in a real environment. Required
       # (no default) so a missing secret fails boot loudly instead of
       # silently invalidating tokens on restart (Rule #36).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 24 Agustus 2026 — Phase 3 dibuka (PRD + TD + issue #30–#35)
-**Phase sekarang:** Phase 3 — Owner Dashboard (0/6 issue selesai)
+**Last updated:** 25 Agustus 2026 — Issue #30 selesai (CORS + endpoint metrik)
+**Phase sekarang:** Phase 3 — Owner Dashboard (1/6 issue selesai)
 
 ---
 
@@ -34,6 +34,7 @@
 | **Issue #21 — Activity append-only + auto-log, dan Task** | — | 2 | `internal/activity` dan `internal/task` baru — dua domain penuh. `ActivityRecorder` dideklarasikan konsumen (`lead`, `task`), dijembatani `activity.NewRecorder(q)` di composition root — pola `auth.RefreshTokenRevoker` (#11). `lead_created`, `status_changed` (`metadata={from,to}`), `task_created`, `task_completed` ditulis **di dalam `Store.InTx` yang sama** dengan pemicunya — `lead.Usecase.UpdateStatus` kini juga dibungkus `InTx`. `GET/POST /v1/leads/{id}/activities` (append-only — **tidak ada** `PATCH`/`DELETE`, diverifikasi lewat daftar route sungguhan). Tipe sistem dari client → `422`. `internal/task`: visibilitas employee lewat kepemilikan **lead**, bukan assignee task sendiri — dibuktikan test khusus. jsonb pertama yang benar-benar ditulis di codebase ini (`activities.metadata`), diverifikasi round-trip langsung terhadap Postgres asli. Atomisitas dibuktikan dua lapis: fake (unit) dan transaksi Postgres sungguhan (`repository_atomicity_test.go`, membuktikan rollback nyata + `lead_number` tidak "terbakar"). Satu bug desain (visibilitas `task.FindAllByLead`) ketahuan dan diperbaiki sebelum commit. Enam `Action` RBAC baru. Smoke test manual end-to-end lolos seluruh acceptance criteria. |
 | **Issue #22 — Assignment, notification (`0004`), penutupan kewajiban penonaktifan membership** | — | 2 | Migration `0004_notifications`. `internal/notification` baru — satu-satunya resource di codebase ini tanpa akses lebih luas untuk Owner/Admin, selalu di-scope ke `t.MembershipID`. `PATCH /v1/leads/{id}/assignment` — activity `lead_assigned`/`lead_unassigned` **dan** notification (kecuali assign ke diri sendiri) dalam satu `Store.InTx`. **Menutup kewajiban warisan Phase 1**: `DELETE /v1/memberships/{id}` menolak default (`409 membership_has_open_leads`) bila masih ada lead terbuka; `?on_open_leads=unassign\|reassign` sebagai jalan keluar, atomik dengan pencabutan refresh token yang sudah ada sejak #11 — **dibuktikan lewat test Postgres sungguhan**, bukan hanya fake (`internal/membership/handler_test.go`, baru). `internal/lead.OpenLeadRepository` (bridge terpisah, bukan bagian `Repository`) dipakai `internal/membership` lewat interface lokalnya sendiri — `membership` tetap tidak pernah mengimpor `lead`. Satu batu sandungan arsitektural nyata: sentinel error domain (`lead.ErrAssigneeNotFound`) tidak bisa dikenali lintas paket tanpa melanggar ADR-011 — diselesaikan dengan mengembalikan `*httpx.ValidationError` langsung dari bridge method itu sendiri. Satu `Action` RBAC baru (`lead.assign`). Smoke test manual end-to-end lolos, termasuk verifikasi refresh token benar-benar mati via `/v1/auth/refresh`. |
 | **Issue #23 — Customer, konversi dari lead, kasus `lead` pada harness isolasi tenant** | — | 2 | `internal/customer` baru — `POST /v1/leads/{id}/convert` (satu `INSERT ... SELECT ... FROM leads WHERE status='won'`, menyalin field lead ke customer baru dalam satu statement, bukan lewat bridge Go — deviasi sadar dari asumsi awal bahwa konversi akan menambah field ke `lead.Repos`, yang ternyata tidak diperlukan). `uq_customers_org_lead` menegakkan konversi tunggal (`409 lead_already_converted`); lead bukan `won` → `422` (memakai ulang `invalid_status_transition`, tidak ada kode baru). Lead **tidak pernah** berubah oleh konversi atau oleh edit customer setelahnya — dibuktikan langsung, bukan diasumsikan. **Penutup Phase 2**: harness isolasi tenant (`cmd/api/tenant_isolation_test.go`) bertambah entri `lead`/`task`/`customer`/`activity` ke slice `[]isolationCase` yang sama sejak #11 (13 subtest, semua `404`), **terbukti bisa gagal** diulang untuk `lead` (predikat tenant-scoping dihapus sementara → kebocoran data nyata 200, bukan sekadar 500). `docs/architecture/authorization.md` matriks Phase 2 ditulis lengkap (Aturan #1 "belum berlaku" → terwujud); `multi-tenancy.md` lapis 4 kasus #1 & #4 → ✅; `api.md` menambah `lead_already_converted` plus membackfill dua kode yang luput dicatat di #21/#22. Empat `Action` RBAC baru. Smoke test manual end-to-end lolos seluruh acceptance criteria Phase 2. **Phase 2 selesai.** |
+| **Issue #30 — CORS + endpoint metrik** | — | 3 | Pembuka Phase 3, murni Go, **tidak ada UI**. `internal/shared/httpx/cors.go` baru — origin di-echo eksplisit (tidak pernah `*`), `OPTIONS` → `204` tanpa menyentuh handler, dipasang sebelum route manapun dan sebelum `authn.Middleware`. `CORS_ALLOWED_ORIGINS` di `internal/shared/config`, wajib non-kosong saat `APP_ENV=production` (Aturan #36). `internal/metrics` baru — **read-only, sengaja tanpa `Store`/`InTx`** (TD §2, penyimpangan sadar dari bentuk lima berkas). `GET /v1/metrics/summary` (`total_new`, `by_status`, `unassigned`, `conversion_rate`) dan `GET /v1/metrics/employees` (per membership: `lead_count`, `avg_response_seconds`, `converted_count`). `conversion_rate` mengecualikan `spam`/`unqualified` dari **penyebut** (menegakkan acceptance criterion #5 Phase 2 yang sampai sekarang hanya "kedua status ada") dan mengirim `null` (bukan `0`) saat penyebut nol. `avg_response_seconds` mengecualikan lead yang belum tersentuh dari rata-rata lewat perilaku native `avg()` mengabaikan `NULL` — tidak ada cabang logic tambahan, dibuktikan lewat test yang menaruh activity `lead_created` di lead yang sama untuk memastikan tipe itu benar-benar tidak ikut terhitung. `ActionMetricsRead` baru (Owner/Admin/Manager, bukan Employee). Harness isolasi tenant bertambah `TestTenantIsolation_MetricsAggregate_ScopedToOrganization` (bentuk terpisah dari slice `isolationCase` karena endpoint agregat tidak punya `:id`) — **terbukti bisa gagal** (predikat tenant di-tautologi-kan → kebocoran nyata 3 vs 1). 18 test baru di `internal/metrics` (unit + Postgres asli + HTTP), semuanya lolos tanpa perubahan asersi lama. |
 
 ---
 
@@ -45,16 +46,18 @@ _(kosong)_
 
 ## Berikutnya
 
-**Issue #30 — CORS + endpoint metrik** (backend, pembuka Phase 3)
+**Issue #31 — Setup Next.js, klien API, sesi, auth UI** (`crm_dashboard`)
 
-- Cakupan & acceptance: [issue #30](https://github.com/Pravasta/jualin-crm/issues/30)
-- TD: `docs/phases/03-owner-dashboard/td.md` §1, §2
-- **Phase 3 bukan phase frontend murni.** Dua pekerjaan Go mendahului layar manapun: middleware CORS
-  (belum ada sama sekali — tanpanya tidak ada request browser yang sampai ke handler) dan endpoint
-  metrik agregat (`02-crm-core/td.md` §5 sudah mencatatnya sebagai milik Phase 3).
-- `internal/metrics` adalah paket **read-only** — tidak punya `Store`/`InTx`, karena tidak pernah
-  menulis. Penyimpangan sadar dari bentuk lima berkas, dicatat di TD §2.
-- Berurutan: #30 → #31 → #32 → #33 → #34 → #35. Rincian di `docs/phases/03-owner-dashboard/issues.md`.
+- Cakupan & acceptance: [issue #31](https://github.com/Pravasta/jualin-crm/issues/31)
+- TD: `docs/phases/03-owner-dashboard/td.md` §3, §4, §5
+- CORS dan kedua endpoint metrik yang memblokirnya (#30) sudah selesai — `crm_dashboard/` sekarang bisa
+  mulai dibangun. `CORS_ALLOWED_ORIGINS=http://localhost:3000` sudah ada di `.env.example` dan
+  `docker-compose.yml`.
+- **Refresh single-flight adalah bagian yang sebenarnya sulit** (TD §4.2) — enam request yang menerima
+  `401` bersamaan harus menghasilkan tepat satu panggilan refresh, atau rotasi refresh token (#10)
+  mencabut seluruh `family_id` dan pengguna terlempar keluar. Kegagalan yang hanya muncul di bawah
+  konkurensi, persis seperti alokasi `lead_number` di #19.
+- Berurutan: #30 ✅ → #31 → #32 → #33 → #34 → #35. Rincian di `docs/phases/03-owner-dashboard/issues.md`.
 
 ---
 

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -15,6 +15,8 @@ Prefix path `/v1/` pada **seluruh** endpoint, termasuk yang hanya dipakai intern
 /v1/auth/login
 /v1/leads
 /v1/leads/{id}
+/v1/metrics/summary
+/v1/metrics/employees
 ```
 
 Murah sekarang, mustahil ditambahkan setelah ada integrator.
@@ -150,6 +152,20 @@ Ini **satu-satunya** tempat di API ini sebuah error membawa field domain di luar
 Offset: `?page=1&per_page=25`. Default `per_page = 25`, maksimum `100`.
 
 **Kenapa offset, bukan cursor:** offset punya masalah "halaman bergeser" saat data baru masuk di atas. Tapi endpoint list bersifat **internal** (dashboard & mobile) dan bukan bagian API publik Phase 4 — yang hanya `POST /v1/leads`. Jadi ia bisa diganti ke cursor kapan saja tanpa memutus integrator siapapun.
+
+---
+
+## CORS (issue #30)
+
+Browser (dashboard) memanggil API ini langsung, lintas subdomain — keputusan C2, `docs/phases/03-owner-dashboard/prd.md`. `CORS_ALLOWED_ORIGINS` (daftar dipisah koma di `internal/shared/config`) menentukan origin yang diizinkan; **wajib non-kosong saat `APP_ENV=production`** (Aturan #36).
+
+| Ketentuan | Alasan |
+|---|---|
+| Origin di-echo eksplisit, **tidak pernah `*`** | `Access-Control-Allow-Credentials: true` (dibutuhkan cookie sesi) tidak bisa digabung dengan wildcard origin |
+| Origin tak dikenal → lanjut **tanpa** header CORS | Server tidak membocorkan daftar origin lewat penolakan eksplisit; browser yang menolak |
+| `OPTIONS` → `204` tanpa menyentuh handler | Preflight tidak membawa kredensial dan tidak boleh menyentuh lapis auth |
+
+Implementasi: `internal/shared/httpx/cors.go`, dipasang di `newRouter` sebelum route manapun dan sebelum `authn.Middleware`. Detail: `docs/phases/03-owner-dashboard/td.md` §1.
 
 ---
 

--- a/docs/architecture/authorization.md
+++ b/docs/architecture/authorization.md
@@ -105,6 +105,19 @@ lead selesai dikonversi.
 
 ---
 
+## Matriks (Phase 3) — issue #30
+
+| Action | Owner | Admin | Manager | Employee |
+|---|---|---|---|---|
+| `metrics.read` | ✅ | ✅ | ✅ | — |
+
+Employee tidak dapat: dashboard bukan alatnya (Employee dapat mobile di Phase 5), dan agregat lintas
+organization adalah informasi manajemen. Konsekuensinya `internal/metrics` **tidak** punya cabang
+`isEmployee` di query-nya sama sekali — tidak seperti `lead`/`task`/`customer`, Employee tidak pernah
+sampai ke repository ini (`docs/phases/03-owner-dashboard/td.md` §2.4).
+
+---
+
 ## Empat aturan yang harus ditulis eksplisit
 
 Sumber: `architecture_product_review.md` §6.2. Tiga dari empat bergantung pada relasi actor-vs-target,

--- a/docs/architecture/multi-tenancy.md
+++ b/docs/architecture/multi-tenancy.md
@@ -125,6 +125,7 @@ Untuk setiap endpoint tenant-scoped:
 | 4 | Employee membaca lead employee lain di org yang sama → 404 | Otorisasi | ✅ `internal/lead/handler_test.go`'s `TestHandler_Get_Employee_OtherPersonsLead_Returns404`, dan padanannya di `internal/task`, `internal/activity`, `internal/customer` (#20–#23) — `authz` sudah memberi Employee akses nol ke membership/invitation sejak Phase 1, `leads` adalah tempat pertama aturan ini punya kasus nyata |
 | 5 | **User dengan dua membership** tidak bisa melihat data org yang tidak sedang aktif di token | ADR-007 | ✅ `TestTenantIsolation_MultiMembership_OnlySeesActiveOrgInToken` |
 | 6 | Katalog: setiap tabel tenant-scoped punya `organization_id` + `UNIQUE (id, organization_id)` | Aturan #1, #2 | ✅ Sejak #8 |
+| 7 | Endpoint agregat (tanpa `:id`) tidak membocorkan bentuk bisnis tenant lain | Lapis 1 | ✅ `GET /v1/metrics/{summary,employees}` — `TestTenantIsolation_MetricsAggregate_ScopedToOrganization` (Phase 3, #30) |
 
 **Kasus #1 dan #4 sekarang ✅ — ditutup di issue #23**, penutup Phase 2. Harness
 (`cmd/api/tenant_isolation_test.go`) tetap satu slice `[]isolationCase` generik yang sama sejak #11;
@@ -134,6 +135,14 @@ seperti direncanakan.
 **Kasus #5 tidak boleh dilewatkan.** Schema mengizinkan multi-membership yang tidak diekspos UI; satu-satunya penjaganya adalah test ini.
 
 **Kasus #6 adalah penegak otomatis.** Sekali ditulis, ia menangkap setiap tabel baru yang lupa mengikuti konvensi — untuk selamanya, tanpa ada yang perlu mengingatnya saat review.
+
+### Kasus #7 — endpoint agregat (Phase 3, issue #30)
+
+`GET /v1/metrics/summary` dan `GET /v1/metrics/employees` tidak punya `:id` — mereka tidak masuk bentuk
+"kasus #1/#2" (mutating/reading resource by id). Kebocoran di sini bukan satu baris salah tenant, tapi
+**bentuk bisnis** tenant lain (jumlah lead, conversion rate) yang bocor lewat agregat. Diuji terpisah:
+`TestTenantIsolation_MetricsAggregate_ScopedToOrganization` di file yang sama, dibuktikan bisa gagal
+dengan cara yang sama seperti kasus lain — lihat komentar di test itu.
 
 ### Kriteria kualitas harness
 

--- a/docs/phases/03-owner-dashboard/notes.md
+++ b/docs/phases/03-owner-dashboard/notes.md
@@ -1,0 +1,89 @@
+# Phase 3 — Owner Dashboard · Notes
+
+One section per issue, appended as each is implemented.
+
+---
+
+## #30 — CORS + endpoint metrik
+
+### Keputusan implementasi
+
+- **`internal/metrics` benar-benar tidak punya `Store`/`InTx`**, sesuai TD §2 — hanya `entity.go` +
+  `port.go` (interface `Repository`, tanpa `Store`) + `usecase.go` (menerima `Repository` langsung,
+  bukan `Store`) + `repository_postgres.go` + `handler_http.go`. Tidak ada `cmd/api/metrics_store.go`:
+  composition root memanggil `metrics.New(pool)` langsung karena `*pgxpool.Pool` sudah memenuhi
+  `db.Querier`, sama seperti `customer.New(pool)` dipakai di test — tidak ada wrapper yang perlu ditulis
+  untuk paket yang tidak pernah membuka transaksi.
+
+- **Query dibangun dengan closure `arg()` yang sama seperti `internal/lead`/`internal/customer`**
+  (`WHERE ... created_at >= $2`), bukan pola `$2::timestamptz IS NULL OR ...` yang sempat ada di draf
+  TD §1.1's contoh kode — mengikuti konvensi yang sudah dipakai `lead.FindAllByOrg` untuk
+  `created_from`/`created_to`, bukan menciptakan pola baru untuk hal yang sama.
+
+- **`avg_response_seconds` memakai `avg()` Postgres apa adanya**, tanpa `FILTER` atau `COALESCE` untuk
+  menangani lead yang belum tersentuh — `avg()` sudah mengabaikan `NULL` secara native, dan
+  `MIN(activities.created_at WHERE type <> 'lead_created') - leads.created_at` menghasilkan `NULL`
+  persis saat lead itu belum pernah disentuh activity non-`lead_created`. Ini yang membuat "dikecualikan
+  dari rata-rata, bukan dihitung nol" (TD §2.3) benar tanpa cabang logic tambahan di Go maupun SQL.
+  Dibuktikan lewat `TestRepository_Employees_AvgResponseSeconds_ExcludesUntouchedLeadsAndLeadCreated`,
+  yang menguji **dua** klaim sekaligus: `lead_created` tidak ikut terhitung (lead yang sama juga punya
+  activity `lead_created` di waktu pembuatan — kalau ini ikut terhitung, hasilnya akan ~0 detik, bukan
+  ~10 menit), dan lead kedua yang sama sekali tidak tersentuh tidak menarik rata-rata turun ke arah nol.
+
+- **`Employees` mengagregasi seluruh membership aktif di organization, bukan hanya `role = 'employee'`.**
+  Assignment lead (`leads.assigned_to_membership_id`) tidak dibatasi role — Owner/Admin/Manager juga bisa
+  jadi assignee. Field responsnya tetap `membership_id`/`full_name` (generik), bukan menyaring ke satu
+  role tertentu sebelum agregasi.
+
+- **Harness isolasi tenant (`cmd/api/tenant_isolation_test.go`) mendapat test terpisah, bukan entri di
+  slice `isolationCase` yang ada.** Kasus itu berbentuk "resource by-id milik org lain → 404"; endpoint
+  metrik tidak punya `:id` sama sekali — kebocorannya berbentuk agregat (angka yang salah), bukan baris
+  yang salah. `TestTenantIsolation_MetricsAggregate_ScopedToOrganization` ditulis sebagai test terpisah
+  di file yang sama, dan **benar-benar dibuktikan bisa gagal**: mengubah predikat
+  `organization_id = $1` di `metrics.postgresRepository.Summary` sementara jadi
+  `(organization_id = $1 OR true)` membuat test merah — `total_new` organisasi A terbaca 3, bukan 1,
+  ikut menghitung dua lead milik organisasi B. Perubahan itu tidak pernah di-commit; lihat komentar di
+  test itu sendiri untuk detail.
+
+### Menyimpang dari rencana issue
+
+Tidak ada penyimpangan dari checklist issue #30 atau TD §1–§2 — implementasi mengikuti keduanya persis.
+
+### Verifikasi
+
+```
+go build ./...                    → bersih
+go vet ./...                      → bersih
+gofmt -l .                        → bersih
+go test ./... (real Postgres via testcontainers, semua paket)  → semua PASS, termasuk 33 test lama
+                                     tanpa perubahan asersi
+
+go test ./internal/shared/config/...    → 11/11 PASS (termasuk 3 test CORS_ALLOWED_ORIGINS baru)
+go test ./internal/shared/httpx/... -run TestCORS  → 5/5 PASS
+go test ./internal/shared/authz/...     → PASS (matrix bertambah metrics.read × 4 role)
+go test ./internal/metrics/...          → 18/18 PASS
+  TestUnit_*        (6)  — fake Repository, tanpa Docker
+  TestRepository_*  (7)  — Postgres asli: by_status/unassigned/range filter, conversion_rate
+                            (denominator excludes spam/unqualified, nil saat 0), avg_response_seconds
+                            (excludes lead_created & untouched lead), scoping per organization (×2)
+  TestHandler_*     (5)  — HTTP end-to-end: 200 Owner, 403 Employee (×2 endpoint), 401 tanpa kredensial
+
+go test ./cmd/api/... -run TestTenantIsolation  → PASS, termasuk
+  TestTenantIsolation_MetricsAggregate_ScopedToOrganization (dibuktikan bisa gagal, lihat di atas)
+```
+
+Seluruh acceptance criteria issue #30 terpenuhi.
+
+### Utang teknis
+
+- Tidak ada item baru dari issue ini.
+
+### Catatan untuk session berikutnya
+
+- **#31 dan seterusnya (`crm_dashboard`) sekarang bisa mulai** — CORS dan kedua endpoint metrik yang
+  memblokirnya sudah ada. `CORS_ALLOWED_ORIGINS=http://localhost:3000` sudah ditambahkan ke
+  `.env.example` dan `docker-compose.yml`; dashboard lokal di port 3000 akan langsung bisa memanggil API
+  ini tanpa konfigurasi tambahan.
+- `GET /v1/metrics/employees` **tidak dipaginasi** — TD §2.1 tidak menyebutnya, dan jumlah membership per
+  organization di volume MVP kecil. Bila ini berubah, itu percakapan produk baru, bukan diam-diam
+  ditambah paginasi.


### PR DESCRIPTION
## Summary

Opens Phase 3's UI work. Two Go pieces had to land before any dashboard screen could be built (both flagged for extra review attention in `issues.md`):

- **CORS middleware did not exist at all.** No browser request could reach a handler without it — blocks C2 (browser → Go directly).
- **The two metrics endpoints Phase 2 deferred** (`02-crm-core/td.md` §5: *"Di Phase 2 belum ada endpoint metrik (itu Phase 3)"*) — computing them client-side from paginated lists would report whatever's on the current page as the total.

## CORS (`internal/shared/httpx/cors.go`)

- Origin echoed verbatim when allowed — **never `*`**, which is incompatible with `Access-Control-Allow-Credentials: true`.
- Unknown origin → request proceeds with **no** CORS headers (the browser rejects it client-side; the server never confirms/denies which origins are configured).
- `OPTIONS` → `204` without touching the handler.
- `CORS_ALLOWED_ORIGINS` (comma-separated) in `internal/shared/config`, **required non-empty when `APP_ENV=production`** (Rule #36, fail-fast) — a misconfigured origin list kills the dashboard with zero server-side error.
- Installed before any route and before `authn.Middleware` — preflight carries no credentials.

## Metrics (`internal/metrics`, new — deliberately read-only)

No `Store`/`InTx`: this package never writes, so a Unit of Work would be unused machinery (Rule #27). `entity.go` / `port.go` (interface only, no `Store`) / `usecase.go` / `repository_postgres.go` / `handler_http.go`.

| Endpoint | Payload |
|---|---|
| `GET /v1/metrics/summary?from=&to=` | `total_new`, `by_status{}`, `unassigned`, `conversion_rate` |
| `GET /v1/metrics/employees?from=&to=` | per membership: `lead_count`, `avg_response_seconds`, `converted_count` |

Two definitions worth calling out because they're easy to get quietly wrong:

- **`conversion_rate` excludes `spam`/`unqualified` from the denominator**, not just the numerator — this finally enforces Phase 2's acceptance criterion #5. Denominator zero → `null`, never `0` ("nothing computable yet" ≠ "tried and failed").
- **`avg_response_seconds`** = `MIN(activities.created_at WHERE type <> 'lead_created') - leads.created_at`, averaged with Postgres's native `avg()` — which ignores `NULL` inputs on its own, so a never-touched lead is excluded from the average rather than pulling it toward zero, with no special-case branch anywhere.

`ActionMetricsRead`: Owner/Admin/Manager, not Employee — the repository has no `isEmployee` branch at all, unlike lead/task/customer, because Employee never reaches it.

## Tenant isolation

The existing harness (`cmd/api/tenant_isolation_test.go`) is shaped for "resource-by-id belonging to another org → 404" — metrics endpoints have no `:id`, so a leak here is a wrong aggregate number, not a wrong row. Added a dedicated test instead of forcing it into the existing table shape, and **actually verified it can fail** (not just asserted it can): temporarily changed the `organization_id = $1` predicate to `(organization_id = $1 OR true)`, reran, watched `total_new` read 3 instead of 1 (leaking another org's 2 leads), then reverted. Documented in the test's comment and in `notes.md`.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- [x] `go test ./...` — full suite green, including all pre-existing tests with zero assertion changes
- [x] `internal/metrics`: 18 new tests (6 fake-repo unit tests, 7 real-Postgres repository tests, 5 HTTP end-to-end tests covering 200/403/401)
- [x] `internal/shared/httpx`: 5 new CORS tests (allowed origin, disallowed origin, preflight, never-wildcard, no-Origin-header)
- [x] `internal/shared/config`: 3 new tests (production requires `CORS_ALLOWED_ORIGINS`, comma-split parsing)
- [x] `internal/shared/authz`: matrix extended with `metrics.read` × 4 roles
- [x] Tenant isolation: new aggregate-scoping test, verified red/green as described above

Refs #30