### PR TITLE
docs(phase-3): add design brief for external design work and dashboard skill

### DIFF
--- a/.claude/skills/jualin-dashboard/SKILL.md
+++ b/.claude/skills/jualin-dashboard/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: jualin-dashboard
+description: Konvensi menulis kode frontend Next.js untuk Jualin CRM dashboard — struktur route, klien API, sesi, penanganan error, optimistic locking di form, shadcn/ui, dan pola testing. Gunakan setiap kali menulis, mengubah, atau mereview kode di crm_dashboard/.
+---
+
+# Jualin Dashboard — Konvensi Menulis Kode
+
+> **Skill ini menjawab "bagaimana menulis kode di `crm_dashboard/`".**
+> Untuk "apa yang harus dibangun dan kenapa", baca `docs/phases/03-owner-dashboard/{prd,td}.md`.
+> Untuk sisi Go, pakai skill `jualin-backend`.
+>
+> Fondasi (proyek, klien API, sesi, lima layar auth) dibangun di **issue #31**. Catatan
+> implementasinya — termasuk keputusan yang mudah salah dibaca dari kode saja — ada di
+> `docs/phases/03-owner-dashboard/notes.md` bagian `## #31`.
+
+---
+
+## Stack
+
+Next.js **App Router** · TypeScript · Tailwind **v4** · shadcn/ui (style `base-nova`, primitive `@base-ui/react`, ikon `lucide-react`) · **Vitest**
+
+**Tanpa** state manager eksternal (Redux/Zustand/Jotai), **tanpa** data-fetching library (React Query/SWR), **tanpa** library i18n, **tanpa** library form (react-hook-form/zod). Bila salah satunya terasa dibutuhkan, itu sinyal untuk berhenti dan mendiskusikan — bukan menambahkannya.
+
+> Alasan tidak ada library form: form di produk ini 2–4 field per layar. Alasan tidak ada i18n: keputusan **C1** — Bahasa Indonesia saja (`docs/phases/03-owner-dashboard/prd.md`).
+
+---
+
+## Struktur
+
+```
+crm_dashboard/                ← npm workspace sendiri, BUKAN bagian module Go
+  src/
+    app/
+      (auth)/                 route group publik — TIDAK pernah memanggil GET /v1/me
+        layout.tsx            kartu sempit di tengah
+        login/ register/ verify-email/ forgot-password/ reset-password/
+      (protected)/            route group terproteksi — SELALU di balik SessionGate
+        layout.tsx            <SessionGate>{children}</SessionGate>
+        page.tsx              home
+      layout.tsx              root: lang="id", font, globals.css
+      globals.css             token Tailwind v4 + shadcn (oklch)
+
+    components/
+      ui/                     shadcn/ui — DI-COPY ke repo (keputusan C3), boleh diubah
+      field-error.tsx         pesan di bawah satu field
+      form-error-banner.tsx   pesan global non-field
+
+    lib/
+      api-client.ts           apiFetch — credentials, CSRF, refresh single-flight
+      api-types.ts            Envelope<T>, ApiError, ErrorDetail
+      auth.ts                 pembungkus /v1/auth/* dan /v1/me
+      auth-errors.ts          error.code → perilaku
+      csrf.ts                 baca cookie csrf_token
+      session-context.tsx     SessionGate + useSession()
+      utils.ts                cn() dari shadcn
+
+  vitest.config.mts           .mts, bukan .ts — lihat "Jebakan yang sudah pernah kena"
+  components.json             config shadcn, registries kosong
+```
+
+Perintah dijalankan dari **`crm_dashboard/`**, bukan akar repository:
+
+```
+npm run dev · npm run typecheck · npm run lint · npm run test · npm run build
+```
+
+**Buat folder hanya saat layarnya dikerjakan.** Route kosong adalah utang yang terlihat seperti kemajuan.
+
+---
+
+## Klien API — satu-satunya jalan ke backend
+
+`apiFetch` sudah menangani **empat** hal. Jangan menulis ulang salah satunya di call site:
+
+```ts
+import { apiFetch } from "@/lib/api-client";
+
+const lead = await apiFetch<Lead>(`/v1/leads/${id}`);
+await apiFetch(`/v1/leads/${id}/status`, {
+  method: "PATCH",
+  body: { status: "contacted", version },   // objek biasa — JSON.stringify otomatis
+});
+```
+
+| Ditangani otomatis | Artinya |
+|---|---|
+| `credentials: 'include'` | Cookie sesi ikut terkirim di setiap request |
+| Header `X-CSRF-Token` | Dipasang di **setiap non-GET**, dibaca dari cookie `csrf_token` |
+| `Content-Type: application/json` | Saat ada `body` |
+| **Refresh single-flight** | `401` → satu panggilan refresh dipakai bersama, request diulang **sekali** |
+
+Gagal → melempar **`ApiError`** (`status`, `code`, `details`, `body`). Sukses → mengembalikan isi `data` saja.
+
+### Yang dilarang
+
+```ts
+// ⛔ Menyentuh token — access_token & refresh_token HttpOnly, JavaScript TIDAK BISA membacanya
+document.cookie.match(/access_token=/)
+localStorage.setItem("token", …)          // Aturan #25, tidak pernah
+
+// ⛔ fetch mentah ke API — kehilangan CSRF, credentials, DAN refresh single-flight
+fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/v1/leads`)
+
+// ⛔ Memasang CSRF manual — apiFetch sudah melakukannya; di GET justru salah
+headers: { "X-CSRF-Token": … }
+
+// ⛔ Memanggil /v1/auth/refresh sendiri — merusak single-flight,
+//    backend membacanya sebagai reuse attack lalu mencabut seluruh sesi
+```
+
+> **Kenapa single-flight bukan optimasi:** satu layar dengan enam widget yang semuanya menerima `401`
+> tanpa single-flight memanggil refresh enam kali. Rotasi refresh token (issue #10) menganggap token
+> yang sudah dirotasi sebagai **reuse attack** dan mencabut seluruh `family_id` — pengguna terlempar
+> keluar, dan gejalanya terlihat seperti *"aplikasi mengeluarkan saya sendiri"*, bukan seperti bug
+> klien. Kegagalan ini **hanya muncul di bawah konkurensi**.
+
+### Endpoint list (`meta`)
+
+`apiFetch` mengembalikan `data` saja dan **membuang `meta`**. Endpoint berpaginasi butuh `meta.total`.
+
+**Tambahkan fungsi baru** (mis. `apiFetchList`) yang mengembalikan `{ data, meta }` — **jangan** ubah signature `apiFetch`, karena akan memaksa setiap pemanggil non-list menangani `meta` yang tidak mereka butuhkan.
+
+> Jumlah total **selalu** dari `meta.total`, tidak pernah dari `data.length` — panjang array hanya
+> mewakili halaman yang sedang terlihat.
+
+---
+
+## Sesi & proteksi route
+
+Ditegakkan dengan **memanggil `GET /v1/me`**, bukan dengan memeriksa token — tidak bisa, token `HttpOnly`.
+
+```tsx
+// (protected)/layout.tsx — satu-satunya penjaga
+export default function ProtectedLayout({ children }: { children: React.ReactNode }) {
+  return <SessionGate>{children}</SessionGate>;
+}
+
+// Layar mana pun di bawahnya:
+const session = useSession();   // dijamin sudah ada; melempar bila dipakai di luar (protected)
+session.role                    // "owner" | "admin" | "manager" | "employee"
+session.organization_name
+```
+
+**Tidak ada `middleware.ts`** yang membaca token. Layar baru cukup diletakkan di dalam `(protected)/` — tidak ada pengecekan tambahan yang perlu ditulis.
+
+---
+
+## Error — `code` menggerakkan perilaku, `message` ditampilkan apa adanya
+
+Backend sudah mengirim `error.message` dalam **Bahasa Indonesia** sejak issue #9. **Jangan menerjemahkan ulang di klien** — dua sumber kebenaran untuk satu kalimat akan berbeda suatu saat, dan yang di layar belum tentu yang benar.
+
+```ts
+import { fieldErrorsFrom, globalMessage, organizationsFrom } from "@/lib/auth-errors";
+
+try { … } catch (err) {
+  const fields = fieldErrorsFrom(err);           // validation_failed → { email: "Wajib diisi." }
+  if (Object.keys(fields).length) setFieldErrors(fields);
+  else setError(globalMessage(err));             // sisanya → banner, message apa adanya
+}
+```
+
+Empat kode butuh perlakuan khusus — **bukan** toast biasa:
+
+| `code` | HTTP | Perilaku wajib |
+|---|---|---|
+| `validation_failed` | 400 | `details[]` tampil **di bawah field masing-masing** (`<FieldError>`), bukan sebagai pesan global |
+| `version_conflict` | 409 | Tampilkan konflik, muat ulang dari `error.current`, **JANGAN PERNAH menimpa otomatis** |
+| `organization_selection_required` | 409 | Tampilkan pemilih organization dari `error.organizations`, panggil ulang login |
+| `membership_has_open_leads` | 409 | Dialog **memaksa memilih**: lepas assignment / pindahkan / batal — dengan `error.open_lead_count` |
+
+> `membership_has_open_leads` **tidak boleh** disederhanakan jadi *"Yakin? [Ya]/[Batal]"*. Lead yang
+> tetap ter-assign ke orang yang tidak bisa login lagi tidak muncul di daftar siapa pun **dan tidak
+> tertangkap filter "belum ter-assign"** — karena secara teknis ia masih punya pemilik. Itu persis
+> kegagalan senyap yang aturan itu dibangun untuk mencegah (freeze 2.3).
+
+Aksi yang role-nya tidak izinkan **tidak ditawarkan di UI** — bukan ditawarkan lalu ditolak backend. Otorisasi sungguhan tetap di backend; UI hanya tidak berbohong tentang apa yang bisa dilakukan.
+
+---
+
+## `version` wajib bolak-balik lewat form
+
+`leads` dan `tasks` memakai optimistic locking (Aturan #35).
+
+```tsx
+const [lead, setLead] = useState<Lead>();     // simpan versi yang DITERIMA saat membaca
+await apiFetch(`/v1/leads/${id}`, {
+  method: "PATCH",
+  body: { name, version: lead.version },      // kirim kembali apa adanya
+});
+```
+
+Form yang lupa membawanya bekerja **tepat sekali**, lalu gagal `409` di setiap penyimpanan berikutnya — gejala yang mudah salah dibaca sebagai "backend rusak". Bila `409` muncul saat pengembangan, **periksa form-nya lebih dulu**.
+
+Setelah `version_conflict`, pakai `version` dari `error.current` — jangan menaikkan sendiri.
+
+---
+
+## shadcn/ui
+
+```bash
+npx shadcn@latest add table select dialog badge
+```
+
+Komponen **di-copy ke `src/components/ui/`** (keputusan C3) — bukan dependensi runtime. Boleh diubah langsung; itu memang tujuannya.
+
+| Aturan | |
+|---|---|
+| Ambil komponen **saat dibutuhkan**, bukan borongan di muka | Aturan #27 |
+| `components.json` → `registries: {}` **tetap kosong** | Tidak ada registry privat; menambahkannya = konfigurasi untuk kebutuhan yang belum ada |
+| Tailwind **v4** — konfigurasi di `globals.css` (`@theme inline`), **tidak ada** `tailwind.config.js` | Jangan buat file itu |
+| Warna lewat token (`bg-card`, `text-muted-foreground`, `border-input`) | Bukan `bg-zinc-50` mentah — token yang membuat perubahan tema jadi satu tempat |
+| **Tanpa dark mode** | Di luar cakupan Phase 3; token `.dark` ada tetapi tidak dipakai |
+
+---
+
+## Bahasa & penamaan
+
+- **Seluruh teks antarmuka: Bahasa Indonesia.** Termasuk label tombol, header tabel, dan *empty state*.
+- **Kode, nama variabel, nama file: Inggris.**
+- Field API tetap `snake_case` (`full_name`, `lead_number`) — jangan diubah jadi camelCase saat parsing; itu menciptakan dua nama untuk satu hal.
+
+Ikuti `docs/product/glossary.md`. Yang paling sering keliru **di layar**:
+
+| ⛔ Jangan | ✅ Pakai |
+|---|---|
+| "Workspace" | "Organization" |
+| "Team" / "Tim saya" | "Semua lead" / "seluruh organisasi" — entity `Team` belum ada |
+| `employee_id`, `member_id` | `membership_id` |
+| Angka uang / revenue / nilai deal | — (Deal belum ada, jangan ditampilkan) |
+
+Lead ditampilkan sebagai **nomor urut** (`#1024`), bukan UUID.
+
+---
+
+## Testing
+
+| Jenis | Cara |
+|---|---|
+| Lapisan klien API | **Vitest** — mock `global.fetch`, uji perilaku yang gagal tanpa terlihat |
+| Konkurensi (refresh single-flight) | **Wajib benar-benar paralel** — lihat di bawah |
+| Pemetaan `error.code` → perilaku | Vitest |
+| `version` ikut terkirim di form edit | Vitest |
+| Test UI visual (snapshot, e2e penuh) | **Di luar cakupan Phase 3** (TD §9) — bentuk layar paling mungkin berubah setelah demo pertama |
+
+**Test konkurensi harus benar-benar konkuren.** Test berurutan akan hijau meski logikanya salah total — persis jebakan yang sama seperti alokasi `lead_number` di backend issue #19. Polanya: tahan panggilan refresh dengan promise yang bisa di-resolve manual, biarkan **seluruh** pemanggil paralel mencapai titik single-flight, baru lepaskan.
+
+```ts
+const gate = deferred<Response>();                       // refresh ditahan
+const calls = Array.from({ length: 6 }, () => apiFetch("/v1/widgets"));
+await new Promise((r) => setTimeout(r, 0));              // biarkan keenam 401 mendarat
+expect(refreshCallCount).toBe(1);                        // ← asersi yang sebenarnya
+gate.resolve(okResponse);
+```
+
+---
+
+## Jebakan yang sudah pernah kena
+
+Tercatat supaya tidak didiagnosis dari nol dua kali (`notes.md` `## #31`):
+
+| Jebakan | Yang benar |
+|---|---|
+| `LayoutProps<"/">` di layout | Pakai `{ children: React.ReactNode }`. Tipe generated bergantung pada `.next/types` yang belum ada di checkout bersih — `npm run typecheck` gagal di CI sebelum `npm run build` sempat jalan. |
+| `vitest.config.ts` + `__dirname` | Berkasnya **`.mts`**, dan pakai `import.meta.dirname`. `package.json` tidak `"type": "module"`. |
+| Test tidak terdeteksi | Vitest hanya memuat `src/**/*.test.ts` — **`.test.tsx` tidak ikut**. Ubah `vitest.config.mts` bila benar-benar butuh test komponen. |
+| `useSearchParams()` membuat build gagal | Bungkus komponennya dengan `<Suspense>`; pola yang sudah dipakai `verify-email/` dan `reset-password/`. |
+| Warning ESLint `no-location-assign-relative-destination` | Hanya dikecualikan di `api-client.ts` (di luar React tree, tidak punya `useRouter`). Di dalam komponen, pakai `useRouter().push()`. |
+
+---
+
+## Sebelum menyatakan sebuah layar selesai
+
+- [ ] `npm run typecheck` bersih
+- [ ] `npm run lint` bersih — **0 error, 0 warning**
+- [ ] `npm run test` lolos; test konkurensi diulang beberapa kali (bukan sekali lalu diasumsikan stabil)
+- [ ] `npm run build` sukses
+- [ ] Seluruh teks Bahasa Indonesia; `error.message` backend tampil **apa adanya**
+- [ ] `validation_failed` tampil **di bawah field**, bukan sebagai banner global
+- [ ] Form edit `lead`/`task` membawa `version`, dan `409` ditangani tanpa menimpa otomatis
+- [ ] Keadaan kosong membedakan **"belum ada data"** dari **"tidak cocok filter"**
+- [ ] Keadaan memuat dan gagal memuat punya tampilan
+- [ ] Aksi yang role-nya tidak izinkan tidak ditawarkan
+- [ ] Tidak ada `fetch` mentah, tidak ada akses token, tidak ada CSRF manual
+- [ ] Jumlah total dari `meta.total`, bukan `data.length`
+- [ ] Diverifikasi terhadap `crm_be` sungguhan (`docker compose up` + `make migrate-up`), bukan hanya mock
+- [ ] `docs/phases/03-owner-dashboard/notes.md` ditulis
+- [ ] `docs/STATUS.md` diperbarui
+
+---
+
+## Alur kerja
+
+Sama seperti seluruh repository ini: **1 issue = 1 session = 1 PR** (`docs/workflow.md`, ADR-008).
+Dokumentasi ditulis **di dalam PR yang sama**, bukan menyusul. PR memakai `Refs #N`, **bukan** `Closes #N`.
+
+Desain visual datang dari `docs/phases/03-owner-dashboard/design-brief.md`. Bila hasil desain
+bertentangan dengan `prd.md`/`td.md`, **laporkan** — jangan diam-diam mengikuti salah satunya.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Dokumentasi produk dan teknis untuk **Jualin CRM** — CRM SaaS multi-tenant sta
 | Ingin tahu sudah sampai mana | [`STATUS.md`](./STATUS.md) |
 | Perlu keputusan arsitektur yang mengikat | [`architecture/freeze.md`](./architecture/freeze.md) |
 | Menulis kode Go | `.claude/skills/jualin-backend/` |
+| Menulis kode dashboard (Next.js) | `.claude/skills/jualin-dashboard/` |
 | Ragu sebuah fitur masuk scope | [`product/scope.md`](./product/scope.md) |
 | Ragu penamaan | [`product/glossary.md`](./product/glossary.md) |
 
@@ -40,7 +41,8 @@ docs/
 └── brainstorming/           arsip, bukan acuan
 
 .claude/skills/
-└── jualin-backend/          konvensi menulis kode Go
+├── jualin-backend/          konvensi menulis kode Go
+└── jualin-dashboard/        konvensi menulis kode Next.js
 ```
 
 ---

--- a/docs/phases/03-owner-dashboard/design-brief.md
+++ b/docs/phases/03-owner-dashboard/design-brief.md
@@ -1,0 +1,329 @@
+# Design Brief — Jualin CRM Owner Dashboard
+
+> **Dokumen ini untuk desainer (Claude Design), bukan untuk implementor.**
+>
+> Sumbernya: [`prd.md`](./prd.md) (apa & kenapa) dan [`td.md`](./td.md) (bagaimana). Bila brief ini
+> bertentangan dengan keduanya, **prd.md dan td.md yang menang** — laporkan pertentangannya, jangan
+> diam-diam memilih salah satu (Aturan #30).
+>
+> Hasil desain akan diimplementasikan di `crm_dashboard/` (Next.js App Router + Tailwind v4 +
+> shadcn/ui). Fondasi teknis, klien API, dan lima layar auth **sudah jadi** (issue #31) — desain
+> untuk layar auth berarti **memperbaiki yang sudah ada**, bukan mendesain dari nol.
+
+---
+
+## 1. Yang diminta
+
+Desain antarmuka untuk **±15 layar** dashboard CRM yang dipakai setiap hari oleh pemilik usaha kecil-menengah Indonesia dan timnya.
+
+Prioritas usaha **tidak dibagi rata**. Freeze arsitektur menyatakan: *"Lead list & detail adalah produknya. Layar itu dibuka ratusan kali sehari; sisanya sesekali."* Dua layar itu layak mendapat porsi terbesar perhatian desain; layar admin dan settings cukup rapi dan jelas.
+
+---
+
+## 2. Produk dalam satu paragraf
+
+Jualin CRM mencatat **lead** (seseorang menunjukkan minat), menugaskannya ke anggota tim, merekam apa yang terjadi padanya, dan mengubah yang berhasil menjadi **customer**. Alurnya: **Capture → Manage → Assign → Follow-up → Customer**. Produk SaaS multi-tenant berharga terjangkau — satu akun bisnis = satu *organization*, dan biaya infrastruktur per tenant harus tetap rendah.
+
+**Bukan** produk ini: HRIS, akuntansi, inventory, payroll, invoice, email campaign, chat inbox WhatsApp/IG/FB, payment gateway. Bila sebuah ide desain menyentuh domain itu, hentikan dan tandai sebagai *scope discussion*.
+
+---
+
+## 3. Pengguna & konteks pemakaian
+
+| Peran | Yang dilakukan di dashboard | Frekuensi |
+|---|---|---|
+| **Owner** | Semuanya. Pemilik usaha, sering bukan orang teknis. | Harian |
+| **Admin** | Hampir semuanya kecuali beberapa aksi kepemilikan | Harian |
+| **Manager** | Kelola lead & tim-nya; tidak bisa hapus lead, konversi, atau ubah customer | Harian |
+| **Employee** | **Tidak memakai dashboard ini** — mereka dapat aplikasi mobile di Phase 5 | — |
+
+**Konteks nyata:** dibuka di laptop di toko/kantor kecil, kadang di tablet. Koneksi tidak selalu cepat. Pengguna membuka daftar lead puluhan kali sehari untuk menjawab satu pertanyaan: *"mana yang belum ditangani?"*
+
+**Desktop-first**, tetapi layar tidak boleh rusak di tablet. Mobile bukan target dashboard ini.
+
+---
+
+## 4. Yang sudah dikunci — jangan didesain ulang
+
+Ini keputusan yang sudah diambil dan diimplementasikan. Mengubahnya berarti membongkar kode yang sudah jalan.
+
+| Hal | Keputusan | Konsekuensi untuk desain |
+|---|---|---|
+| **Bahasa** | **Bahasa Indonesia saja**, tanpa library i18n | Tidak ada language switcher. Tidak ada teks Inggris di antarmuka — termasuk label tombol, header tabel, dan *empty state*. Nama field API tetap Inggris, tetapi itu tidak pernah terlihat pengguna. |
+| **Design system** | **shadcn/ui** (style `base-nova`, base color `neutral`) + **Tailwind v4** | Desain harus bisa dibangun dari komponen shadcn/ui. Token warna sudah ada dalam format `oklch` (lihat §5). Primitive-nya `@base-ui/react`, ikon **lucide**. |
+| **Radius** | `--radius: 0.625rem` | Bahasa bentuk sudah ditentukan; jangan usulkan sudut tajam atau pil penuh sebagai gaya global. |
+| **Tema** | **Terang saja.** Dark mode di luar cakupan | Tidak perlu desain varian gelap. Token gelap ada di kode tetapi tidak dipakai. |
+| **Font** | Geist Sans + Geist Mono — **lihat catatan di bawah** | Boleh diusulkan diganti, tetapi sertakan alasan — bukan preferensi. |
+| **Navigasi antar-organization** | Pengguna memilih organization **saat login**, bukan lewat switcher di dalam aplikasi | Tidak ada dropdown "pindah workspace" di header. |
+
+### 4.1 Token warna yang sudah terpasang
+
+```
+--background      oklch(1 0 0)            --foreground        oklch(0.145 0 0)
+--card            oklch(1 0 0)            --card-foreground   oklch(0.145 0 0)
+--primary         oklch(0.205 0 0)        --primary-foreground oklch(0.985 0 0)
+--secondary       oklch(0.97 0 0)         --muted-foreground  oklch(0.556 0 0)
+--muted           oklch(0.97 0 0)         --accent            oklch(0.97 0 0)
+--destructive     oklch(0.577 0.245 27.325)
+--border          oklch(0.922 0 0)        --input             oklch(0.922 0 0)
+--ring            oklch(0.708 0 0)        --radius            0.625rem
+```
+
+Palet saat ini **netral abu-abu murni tanpa warna aksen** — itu default shadcn, bukan keputusan desain. **Menentukan warna aksen/brand adalah bagian dari pekerjaan ini.** Bila mengusulkan aksen, berikan nilai `oklch` untuk `--primary` dan `--ring`, dan pastikan kontrasnya lolos WCAG AA terhadap `--primary-foreground`.
+
+### 4.2 Catatan font — ada yang belum benar
+
+Geist Sans dan Geist Mono **dimuat** di root layout, tetapi Geist Sans **belum benar-benar diterapkan**: `globals.css` memetakan `--font-sans: var(--font-sans)` (menunjuk ke dirinya sendiri) sementara layout mendefinisikan `--font-geist-sans`. Akibatnya `font-sans` jatuh ke font bawaan browser. `--font-mono` sudah benar.
+
+Ini bug satu baris dari hasil scaffold, sudah dilaporkan dan akan diperbaiki terpisah — **bukan** hal yang perlu diselesaikan lewat desain. Disebut di sini supaya tipografi tidak dinilai dari tampilan yang sekarang.
+
+---
+
+## 5. Prinsip desain untuk produk ini
+
+1. **Alat kerja, bukan etalase.** Kepadatan informasi lebih berharga daripada ruang kosong yang lapang. Owner memindai puluhan baris lead, bukan mengagumi hero section.
+2. **Jawab pertanyaan dalam hitungan detik.** Setiap layar utama punya satu pertanyaan yang harus terjawab tanpa scroll: daftar lead → *"mana yang belum ditangani?"*; detail lead → *"apa yang sudah terjadi pada orang ini?"*; home → *"bagaimana keadaan bisnis minggu ini?"*
+3. **Yang berbahaya harus terasa berbeda.** Menonaktifkan anggota, menghapus lead, dan menimpa data orang lain bukan aksi rutin — perlakuannya harus berbeda dari tombol biasa (lihat §8).
+4. **Ringan.** Sales membuka dashboard dari koneksi lambat. Hindari desain yang mewajibkan gambar besar, banyak font, atau animasi berat.
+5. **Benar dulu, cantik kemudian.** PRD menyatakannya eksplisit: *"layar yang benar dan bisa dipakai lebih penting daripada layar yang cantik"*. Tetapi phase ini akan **didemokan ke calon pelanggan** — jadi ia tetap harus terlihat seperti produk yang layak dibayar, bukan prototipe internal.
+
+---
+
+## 6. Kosakata wajib
+
+Konsistensi penamaan dijaga [`docs/product/glossary.md`](../../product/glossary.md). Ini **bukan preferensi gaya** — istilah yang salah di layar menjanjikan fitur yang tidak ada.
+
+| ⛔ Jangan pakai di UI | ✅ Pakai | Alasan |
+|---|---|---|
+| "Workspace" | **Organization** | Satu istilah saja di seluruh produk |
+| "Team" / "Tim saya" | "Semua lead" / "seluruh organisasi" | Entity `Team` **belum ada** — UI tidak boleh menjanjikannya |
+| "Karyawan" / "Staff" sebagai entity | "Anggota" (organization) | Employee = anggota dengan role `employee`, bukan tabel tersendiri |
+| "Pipeline" sebagai papan Kanban | Status lead | Tidak ada entity pipeline sampai Phase 9 |
+| "Deal" / "Nilai deal" / "Revenue" | — (jangan tampilkan) | Deal belum ada. Angka uang **tidak boleh** muncul di manapun. |
+
+Istilah yang dipakai di layar: **Lead · Customer · Activity · Task · Anggota · Undangan · Organization · Notifikasi**.
+
+Lead ditampilkan ke pengguna dengan **nomor urut per organization** (`#1024`), bukan UUID.
+
+---
+
+## 7. Inventaris layar
+
+Dikelompokkan per issue implementasi. Endpoint API-nya **sudah ada semua** — desain tidak boleh mengandaikan data yang tidak tersedia.
+
+### 7.1 Auth — sudah diimplementasikan, butuh perbaikan visual
+
+Lima layar berdiri sendiri, lebarnya sempit (kartu di tengah). Sudah berfungsi; yang dibutuhkan adalah kualitas visual dan kejelasan.
+
+| Layar | Isi | Catatan |
+|---|---|---|
+| **Masuk** | Email, password, tautan "Lupa password?" dan "Daftar organization baru" | Juga menampung **pemilihan organization** — lihat §8.2 |
+| **Daftar** | Nama organization, nama lengkap, email, password (min. 12 karakter) | Sukses → layar "cek email", bukan langsung masuk |
+| **Verifikasi email** | Otomatis memproses token dari tautan email. Tiga keadaan: sedang memverifikasi / berhasil / gagal + form kirim ulang | |
+| **Lupa password** | Satu field email → layar "cek email" | Selalu menampilkan hasil yang sama, apakah email terdaftar atau tidak (mencegah penebakan akun) |
+| **Atur ulang password** | Password baru + konfirmasi, token dari tautan email | |
+
+### 7.2 Daftar lead — layar terpenting
+
+Menjawab *"mana yang belum ditangani?"*
+
+**Data per baris:** nomor lead (`#1024`), nama, status, pemilik (nama anggota), sumber, tanggal masuk. Kontak (email/telepon) berguna tetapi opsional bila ruang tidak cukup.
+
+**Filter yang harus muat semua sekaligus dan bisa dikombinasikan:**
+- Status (multi-pilih, 8 nilai)
+- Sumber (multi-pilih, 4 nilai)
+- Pemilik (pilih anggota) — **termasuk opsi "tanpa pemilik aktif"**
+- Periode masuk (rentang tanggal)
+- Kata kunci (nama, email, telepon)
+
+> **Filter "lead tanpa pemilik aktif" wajib terlihat permanen** — bukan tersembunyi di balik menu "filter lanjutan". Ini jaring pengaman: saat seorang anggota dinonaktifkan, lead-nya bisa tetap tercatat atas namanya dan **tidak muncul di daftar "belum ter-assign" siapa pun**. Kalau filter ini sulit ditemukan, lead menghilang diam-diam. Beri ia perlakuan yang membuatnya ditemukan tanpa dicari — misalnya chip/tab yang selalu tampil dengan jumlahnya.
+
+**Juga di layar ini:** tombol buat lead baru, pagination dengan **jumlah total**, dan indikator filter aktif (pengguna harus bisa melihat dan menghapus filter yang sedang berlaku — filter juga tercermin di URL agar bisa dibagikan).
+
+**Dua keadaan kosong yang berbeda:** "belum ada lead sama sekali" (ajakan membuat lead pertama) vs "tidak ada yang cocok dengan filter" (ajakan menghapus filter). Menyamakan keduanya membuat pengguna baru mengira produknya rusak.
+
+### 7.3 Detail lead — layar terpenting kedua
+
+Menjawab *"apa yang sudah terjadi pada orang ini, dan apa berikutnya?"* Hampir seluruh aksi tulis produk ada di sini.
+
+| Bagian | Isi |
+|---|---|
+| **Header** | `#1024`, nama, kontak, sumber, pemilik, status |
+| **Aksi status** | Ubah status — hanya transisi yang sah yang ditawarkan (§9.1). Memilih `lost` **mewajibkan** alasan (6 pilihan) |
+| **Assignment** | Tugaskan ke anggota, atau lepaskan |
+| **Timeline** | Riwayat activity, **terbaru di atas**. 10 tipe, masing-masing perlu tampil terbaca manusia — `status_changed` harus terbaca "Status: Baru → Dihubungi", bukan JSON |
+| **Tambah catatan** | Hanya tiga tipe yang boleh dibuat pengguna: catatan, log telepon, WhatsApp dibuka |
+| **Task** | Daftar task pada lead ini: buat, ubah, tandai selesai, hapus. Punya judul, deskripsi, jatuh tempo, penanggung jawab |
+| **Konversi** | Ubah jadi customer — **hanya ditawarkan saat status `won`** |
+| **Hapus lead** | Aksi merusak, perlakuan berbeda |
+
+Setiap aksi tulis harus memperbarui timeline tanpa reload manual.
+
+### 7.4 Tim — anggota, undangan, penonaktifan, notifikasi
+
+| Bagian | Isi |
+|---|---|
+| **Daftar anggota** | Nama, email, role, tanggal bergabung. Ubah role. |
+| **Undangan** | Undang lewat email + role. Daftar undangan tertunda, bisa dicabut. |
+| **Halaman terima undangan** | Layar publik (dari tautan email), **dua cabang**: pengguna baru (isi nama + password) dan pengguna yang sudah punya akun |
+| **Penonaktifan anggota** | **Alur tiga cabang** — lihat §8.1. Ini layar paling rawan disederhanakan secara salah. |
+| **Notifikasi** | Daftar notifikasi, penanda belum dibaca, tandai satu / tandai semua. Diambil saat halaman dimuat — **tidak realtime**, dan tidak boleh didesain seolah-olah realtime. |
+
+Beberapa aturan kepemilikan tercermin di UI: tidak bisa mengubah role sendiri; Admin tidak bisa menyentuh Owner; Owner terakhir tidak bisa menonaktifkan dirinya. Aksi yang tidak diizinkan **tidak ditawarkan**, bukan ditawarkan lalu ditolak.
+
+### 7.5 Home metrik · Customer · Task lintas lead · Settings
+
+**Home (metrik):**
+- Lead masuk pada periode, jumlah per status, lead belum ter-assign, **conversion rate**
+- Tabel performa per anggota: jumlah lead, waktu respons rata-rata, jumlah konversi
+- Pemilih periode
+- Angka harus bisa diklik menuju daftar lead yang sudah ter-filter (mis. "belum ter-assign" → daftar ter-filter)
+
+> **Angka, bukan grafik.** Grafik tren dan deret waktu adalah Phase 9. Sparkline sederhana boleh diusulkan, tetapi bukan bagian yang diminta.
+>
+> **`conversion rate` bisa bernilai "belum ada data"**, dan itu **harus tampil berbeda dari 0%**. "Belum ada yang bisa dihitung" bukan "sudah dicoba, gagal semua". Ini butuh perlakuan visual, bukan sekadar teks.
+
+**Customer:** daftar + pencarian + pagination; detail dengan tautan ke lead asalnya; ubah/hapus (hanya Owner/Admin — Manager melihat tanpa tombol itu).
+
+**Task lintas lead:** daftar semua task dengan filter penanggung jawab, status, dan jatuh tempo. Bisa ditandai selesai langsung dari daftar. Task yang lewat jatuh tempo perlu terlihat.
+
+**Settings:** profil organization dan pengguna. Sederhana.
+
+### 7.6 Kerangka aplikasi
+
+Belum ada dan dibutuhkan: **navigasi utama** yang menampung Home, Lead, Customer, Task, Tim, Settings — plus notifikasi dan identitas pengguna (nama, organization, keluar). Sidebar atau top bar adalah keputusan desain; sertakan alasannya.
+
+---
+
+## 8. Empat pola yang tidak boleh disederhanakan
+
+Ini bukan preferensi. Masing-masing melindungi kegagalan yang **tidak terlihat** kalau salah.
+
+### 8.1 Menonaktifkan anggota yang masih memegang lead terbuka
+
+Backend menolak penonaktifan dan mengembalikan **jumlah lead terbuka** milik anggota itu.
+
+**Dialog wajib memaksa pengguna memilih secara sadar** di antara tiga:
+1. **Lepas assignment** — lead menjadi tanpa pemilik, masuk daftar "belum ter-assign"
+2. **Pindahkan ke anggota lain** — dengan pemilih anggota
+3. **Batal**
+
+> ⛔ **Tidak boleh** disederhanakan menjadi *"Yakin ingin menonaktifkan? [Ya] [Batal]"*.
+>
+> Kenapa: lead yang tetap ter-assign ke orang yang tidak bisa login lagi **tidak muncul di daftar siapa pun** dan **tidak tertangkap filter "belum ter-assign"** — karena secara teknis ia masih punya pemilik. Itu persis kegagalan senyap yang aturan ini dibangun untuk mencegah. Menyembunyikan pilihan di balik satu tombol membuang seluruh alasannya ada.
+
+Anggota **tanpa** lead terbuka boleh dinonaktifkan tanpa dialog tambahan.
+
+### 8.2 Pengguna dengan lebih dari satu organization
+
+Saat masuk, backend bisa menjawab *"pilih organization dulu"* beserta daftarnya. Layar masuk berubah menjadi pemilih organization, lalu melanjutkan. Saat ini diimplementasikan sebagai perubahan keadaan pada form masuk yang sama — desain boleh mengusulkan bentuk lain selama pengguna tidak perlu mengetik ulang email/password.
+
+### 8.3 Data sudah diubah orang lain (konflik penyimpanan)
+
+Bila dua orang menyunting lead atau task yang sama, penyimpanan kedua ditolak dan backend mengirim **keadaan terkini**.
+
+Layar harus: memberi tahu bahwa data sudah berubah, memuat ulang keadaan terkini, dan **tidak pernah menimpa otomatis**. Pengguna memutuskan.
+
+> Ini satu-satunya tempat di seluruh produk pengguna **harus** memilih secara sadar sebelum melanjutkan. Perlakuannya tidak boleh sama dengan notifikasi kesalahan biasa yang bisa diabaikan.
+
+### 8.4 Kesalahan validasi per field
+
+Kesalahan validasi datang dengan **nama field**-nya. Tampilkan **di bawah field yang bersangkutan**, bukan sebagai pesan global di atas form. Pesan global hanya untuk kesalahan yang bukan milik satu field (mis. email/password salah, terlalu banyak percobaan).
+
+---
+
+## 9. Nilai yang butuh perlakuan visual
+
+Ini enumerasi lengkap dari database — tidak akan bertambah tanpa perubahan skema.
+
+### 9.1 Status lead (8) — dan transisi yang sah
+
+```
+new → contacted → qualified → proposal → won
+```
+- Maju/mundur **satu langkah** di jalur utama
+- **`lost`, `unqualified`, `spam`** bisa dicapai dari status non-final manapun
+- **`unqualified` dan `spam` bersifat final** — tidak ada jalan keluar
+- `lost` boleh diperbarui alasannya, dan boleh keluar kembali ke jalur utama
+
+Label Indonesia belum ditetapkan — **usulkan**. `won`/`lost` perlu terbaca jelas; `unqualified` (tidak memenuhi syarat) berbeda dari `spam` (sampah), dan perbedaan itu harus terlihat karena **keduanya dikecualikan dari perhitungan conversion rate**.
+
+Delapan status perlu bisa dibedakan sekilas dalam tabel padat, dan tetap terbaca oleh pengguna dengan gangguan penglihatan warna — **warna saja tidak cukup**.
+
+### 9.2 Alasan `lost` (6)
+`price` · `competitor` · `timing` · `no_response` · `not_interested` · `other`
+
+### 9.3 Sumber lead (4)
+`manual` · `api` · `form` · `webhook` — **metode capture**, bukan channel marketing.
+
+### 9.4 Tipe activity (10) — timeline
+
+Dibuat sistem otomatis: `lead_created` · `lead_assigned` · `lead_unassigned` · `status_changed` · `lead_converted` · `task_created` · `task_completed`
+
+Dibuat pengguna: `note_added` · `call_logged` · `whatsapp_opened`
+
+Timeline perlu membedakan **peristiwa sistem** dari **catatan manusia** — keduanya bercampur dalam satu aliran waktu, dan pengguna membaca timeline untuk mencari jejak manusia.
+
+### 9.5 Role (4)
+`owner` · `admin` · `manager` · `employee`
+
+---
+
+## 10. Keadaan yang wajib punya desain
+
+Sering terlewat, dan justru itu yang dilihat pengguna baru di hari pertama.
+
+| Keadaan | Catatan |
+|---|---|
+| **Kosong — belum ada data** | Berbeda dari kosong karena filter. Ajak membuat yang pertama. |
+| **Kosong — tidak cocok filter** | Ajak menghapus filter. |
+| **Memuat** | Daftar lead dan timeline paling sering terlihat memuat. |
+| **Gagal memuat** | Termasuk kehilangan koneksi. |
+| **Sesi berakhir** | Pengguna dikembalikan ke layar masuk. |
+| **Tidak diizinkan** | Manager membuka aksi Owner/Admin — tombolnya tidak ditawarkan sejak awal. |
+| **Terlalu banyak percobaan** | Login dan pengiriman email dibatasi; pesannya perlu tempat. |
+| **Notifikasi belum dibaca** | Penanda jumlah. |
+
+---
+
+## 11. Di luar cakupan desain
+
+Jangan desain, jangan sertakan sebagai "bonus":
+
+- **Dark mode / tema / kustomisasi tampilan**
+- **Grafik tren, deret waktu, laporan lanjutan** (Phase 9)
+- **Angka uang** — revenue, nilai deal, target penjualan (Deal belum ada)
+- **Papan Kanban / drag-and-drop pipeline** (entity pipeline tidak ada)
+- **Realtime** — jangan desain sesuatu yang mengandaikan pembaruan langsung tanpa refresh
+- **Layar untuk Employee** (Phase 5, aplikasi mobile terpisah)
+- **Landing page / halaman marketing** (repository terpisah, belum dijadwalkan)
+- **Manajemen API key & dokumentasi integrator** (Phase 4)
+- **Export/import CSV**
+- **Onboarding tour, empty-state ilustratif bergerak, dan sejenisnya** — bila terasa perlu, usulkan terpisah dengan alasan
+
+---
+
+## 12. Bentuk keluaran yang diharapkan
+
+Agar bisa langsung diimplementasikan tanpa menebak:
+
+1. **Token desain** — nilai `oklch` untuk warna yang diubah/ditambah, agar bisa masuk langsung ke `globals.css`. Sebutkan token shadcn mana yang diganti.
+2. **Peta komponen** — untuk tiap elemen, sebutkan komponen shadcn/ui yang dipakai (`button`, `input`, `card`, `alert`, `table`, `select`, `dialog`, `badge`, `tabs`, …). Bila sebuah elemen tidak ada padanannya di shadcn/ui, tandai eksplisit sebagai komponen kustom.
+3. **Desain layar** untuk seluruh §7, dengan keadaan §10 yang relevan.
+4. **Empat pola §8** didesain eksplisit — terutama dialog penonaktifan tiga cabang dan konflik penyimpanan.
+5. **Label Indonesia** untuk 8 status, 6 alasan `lost`, 4 sumber, 4 role, dan 10 tipe activity.
+6. **Catatan aksesibilitas** — kontras dan cara membedakan status tanpa mengandalkan warna.
+
+Bila sebuah layar terasa membutuhkan data yang tidak disebut di §7, **tanyakan** — kemungkinan besar data itu tidak ada di API, dan menambah endpoint di tengah phase UI berarti dua aplikasi berubah dalam satu PR tanpa direncanakan.
+
+---
+
+## 13. Referensi
+
+| Dokumen | Isi |
+|---|---|
+| [`prd.md`](./prd.md) | Tujuan phase, 10 kebutuhan pengguna, 13 acceptance criteria, di luar cakupan |
+| [`td.md`](./td.md) | §5 penanganan error, §7 endpoint yang tersedia, §8 peta layar |
+| [`issues.md`](./issues.md) | Pembagian pekerjaan implementasi (#30–#35) |
+| [`../../product/glossary.md`](../../product/glossary.md) | Kosakata mengikat — §6 di atas adalah ringkasannya |
+| [`../../architecture/freeze.md`](../../architecture/freeze.md) | Bagian 3.2 (cakupan dashboard & metrik), 2.3 (jaring pengaman) |


### PR DESCRIPTION
## Summary

Two artifacts ahead of handing Phase 3's UI to an external design pass. Both are **derived from the existing `prd.md`/`td.md`/`issues.md`** — no new product or architecture decisions are introduced here.

## `design-brief.md` — the handoff document

Written to be self-contained for someone with no access to this repo, carrying the things a designer cannot infer and would otherwise get wrong:

| Section | Why it's in there |
|---|---|
| **What's already locked** | Indonesian-only (C1), shadcn/ui `base-nova` + Tailwind v4 (C3), light theme only, existing `oklch` tokens. Redesigning these means tearing out working code. |
| **Mandatory vocabulary** | From `product/glossary.md`. "Workspace", "Team", and **any money figure** are forbidden on screen — `Team` and `Deal` are entities that don't exist, and naming them promises a feature the product doesn't have. |
| **Complete enumerations** | 8 lead statuses *with their legal transitions*, 6 lost reasons, 4 sources, 10 activity types, 4 roles. A designer guessing "4 statuses" produces a table that can't render real data. |
| **Four patterns that must not be simplified** | Each protects a silent failure — see below. |
| **Empty / loading / error / permission states** | What a new user sees on day one, and the most commonly skipped part of any design. |

The brief also states the priority split explicitly rather than letting effort spread evenly: freeze 3.2 says *"Lead list & detail adalah produknya"*, so those two screens get the largest share and settings gets "tidak apa-apa sederhana".

### The four non-negotiable patterns

Most important is member deactivation. Backend returns the count of open leads and refuses; the dialog must **force a conscious choice** between unassign / reassign / cancel. Collapsing it to "Yakin? [Ya]/[Batal]" throws away the entire reason the rule exists — a lead still assigned to someone who can't log in appears in nobody's list **and isn't caught by the "unassigned" filter**, because technically it still has an owner. The brief spells that reasoning out so it survives the handoff.

The other three: org selection on login, save conflicts that must never auto-overwrite, and per-field validation errors landing under their field rather than in a global banner.

## `jualin-dashboard` skill

The frontend counterpart to the existing `jualin-backend` skill, encoding what #31 actually established rather than generic Next.js advice:

- **`apiFetch` is the only path to the API.** It already handles `credentials`, CSRF, and refresh single-flight — the skill lists what call sites must *not* re-implement, including the specific reason calling `/v1/auth/refresh` directly gets the whole session revoked.
- Session via `GET /v1/me` through `SessionGate`; no `middleware.ts`, because the token is `HttpOnly` and there's nothing to read.
- `error.code` drives behavior, `error.message` is displayed verbatim (backend has emitted Indonesian since #9 — re-translating creates two sources of truth for one sentence).
- `version` must round-trip through every lead/task edit form.
- The **five scaffold traps already hit once during #31** (`LayoutProps<"/">` breaking CI typecheck, `.mts` config, `.test.tsx` not being picked up, `useSearchParams` needing Suspense, the one ESLint exception) — recorded so they aren't re-diagnosed from scratch.

## One bug found while verifying, not fixed here

Writing the "what's locked" section meant checking the claim that Geist Sans is applied. It isn't: `globals.css` maps `--font-sans: var(--font-sans)` (self-referential) while `layout.tsx` defines `--font-geist-sans`, so `font-sans` falls back to the browser default. `--font-mono` is wired correctly.

A one-line scaffold bug. **Left unfixed in this docs PR** rather than mixed in — the brief documents the actual current state (§4.2) so typography isn't judged against a font that isn't rendering. Happy to fix it separately.

## Also

`docs/README.md` now lists the new skill. The rest of that file is significantly stale — it still claims *"Belum ada kode"*, shows every roadmap phase unchecked, and its ADR table stops at 007 (we're at 011). That's **pre-existing drift, reported rather than silently rewritten** here, per Rule #30.

Refs #32, #33, #34, #35