### PR TITLE
feat(dashboard): apply design foundation — tokens, Indonesian labels, app shell

### DIFF
--- a/crm_dashboard/src/app/(protected)/customers/page.tsx
+++ b/crm_dashboard/src/app/(protected)/customers/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderScreen } from "@/components/placeholder-screen";
+
+export default function CustomersPage() {
+  return (
+    <PlaceholderScreen
+      title="Customer"
+      description="Daftar customer hasil konversi lead, dengan pencarian dan tautan ke lead asalnya."
+      issue={35}
+    />
+  );
+}

--- a/crm_dashboard/src/app/(protected)/layout.tsx
+++ b/crm_dashboard/src/app/(protected)/layout.tsx
@@ -1,8 +1,17 @@
+import { AppShell } from "@/components/app-shell";
 import { SessionGate } from "@/lib/session-context";
 
 // Route protection lives HERE, not in middleware.ts — middleware can't
 // read the HttpOnly access token to verify it, so the only real check
 // is asking the API (TD phase 3 §4.1). SessionGate calls GET /v1/me.
+//
+// AppShell sits inside SessionGate, not outside: it renders the
+// organization name and the signed-in user, so it can only be built once
+// the session actually resolved.
 export default function ProtectedLayout({ children }: { children: React.ReactNode }) {
-  return <SessionGate>{children}</SessionGate>;
+  return (
+    <SessionGate>
+      <AppShell>{children}</AppShell>
+    </SessionGate>
+  );
 }

--- a/crm_dashboard/src/app/(protected)/leads/page.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderScreen } from "@/components/placeholder-screen";
+
+export default function LeadsPage() {
+  return (
+    <PlaceholderScreen
+      title="Lead"
+      description="Daftar lead dengan filter status, sumber, pemilik, periode, dan pencarian kata kunci — termasuk filter permanen “lead tanpa pemilik aktif”."
+      issue={32}
+    />
+  );
+}

--- a/crm_dashboard/src/app/(protected)/page.tsx
+++ b/crm_dashboard/src/app/(protected)/page.tsx
@@ -1,37 +1,12 @@
-"use client";
+import { PlaceholderScreen } from "@/components/placeholder-screen";
 
-import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/button";
-import { logout } from "@/lib/auth";
-import { useSession } from "@/lib/session-context";
-
-// Deliberately minimal — issue #31's boundary is "bisa login, belum ada
-// layar lead" (docs/phases/03-owner-dashboard/issues.md). Lead list
-// lands in #32. A working logout control is still required here: it's
-// the other half of #31's own acceptance criterion ("mendaftar →
-// verifikasi → masuk → KELUAR, seluruhnya lewat layar").
-export default function DashboardHomePage() {
-  const router = useRouter();
-  const session = useSession();
-
-  async function handleLogout() {
-    await logout().catch(() => {
-      // logout always succeeds from the client's perspective — crm_be's
-      // handler answers 204 unconditionally (see internal/auth's
-      // not-found-is-success reasoning).
-    });
-    router.push("/login");
-  }
-
+// Metrik home mengonsumsi GET /v1/metrics/* — dibangun di issue #35.
+export default function BerandaPage() {
   return (
-    <div className="flex flex-1 flex-col gap-4 p-8">
-      <h1 className="text-lg font-medium">
-        Selamat datang, {session.full_name}
-      </h1>
-      <p className="text-sm text-muted-foreground">{session.organization_name}</p>
-      <Button variant="outline" className="w-fit" onClick={handleLogout}>
-        Keluar
-      </Button>
-    </div>
+    <PlaceholderScreen
+      title="Beranda"
+      description="Ringkasan metrik — lead masuk, jumlah per status, lead belum ter-assign, dan conversion rate."
+      issue={35}
+    />
   );
 }

--- a/crm_dashboard/src/app/(protected)/settings/page.tsx
+++ b/crm_dashboard/src/app/(protected)/settings/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderScreen } from "@/components/placeholder-screen";
+
+export default function SettingsPage() {
+  return (
+    <PlaceholderScreen
+      title="Pengaturan"
+      description="Profil organization dan pengguna."
+      issue={35}
+    />
+  );
+}

--- a/crm_dashboard/src/app/(protected)/tasks/page.tsx
+++ b/crm_dashboard/src/app/(protected)/tasks/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderScreen } from "@/components/placeholder-screen";
+
+export default function TasksPage() {
+  return (
+    <PlaceholderScreen
+      title="Tugas"
+      description="Daftar task lintas lead dengan filter penanggung jawab, status, dan jatuh tempo."
+      issue={35}
+    />
+  );
+}

--- a/crm_dashboard/src/app/(protected)/team/page.tsx
+++ b/crm_dashboard/src/app/(protected)/team/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderScreen } from "@/components/placeholder-screen";
+
+export default function TeamPage() {
+  return (
+    <PlaceholderScreen
+      title="Tim"
+      description="Anggota organization, undangan, dan penonaktifan anggota — termasuk alur tiga cabang saat anggota masih memegang lead terbuka."
+      issue={34}
+    />
+  );
+}

--- a/crm_dashboard/src/app/globals.css
+++ b/crm_dashboard/src/app/globals.css
@@ -7,9 +7,13 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
+  /* --font-geist-sans, not --font-sans: next/font defines the former on
+     <html> (layout.tsx). Pointing --font-sans at itself, as the scaffold
+     did, left `font-sans` resolving to nothing and Geist never actually
+     applied — issue #40. */
+  --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
+  --font-heading: var(--font-geist-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -27,6 +31,8 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-accent-strong: var(--accent-strong);
+  --color-accent-tint: var(--accent-tint);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -55,8 +61,20 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
+  /* Warm amber accent, derived from the Jualin logo (Claude Design,
+     issue #40). The design proposed oklch(0.58 0.19 41), but that
+     measures 4.45:1 against --primary-foreground — just under WCAG AA's
+     4.5:1 for normal text, and this color's whole job is being a button
+     background under 14px label text. Darkened to 0.56, which measures
+     4.83:1 and is visually indistinguishable (#D14400 → #CA3C00). */
+  --primary: oklch(0.56 0.19 41);
   --primary-foreground: oklch(0.985 0 0);
+  /* Accent as TEXT on a light background — active nav, links, inline
+     emphasis. 7.04:1 on white. Never use --primary for this: at 0.56 it
+     is tuned for white-on-color, not color-on-white. */
+  --accent-strong: oklch(0.48 0.17 41);
+  /* Tinted accent background — active nav row, avatar, badge. */
+  --accent-tint: oklch(0.56 0.19 41 / 10%);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
@@ -66,7 +84,7 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: oklch(0.56 0.19 41);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
@@ -83,6 +101,12 @@
   --sidebar-ring: oklch(0.708 0 0);
 }
 
+/* Dark mode is out of scope for Phase 3 (prd.md, "Di luar cakupan") and
+   nothing toggles this class. These are shadcn's untouched defaults —
+   the amber accent above is deliberately NOT ported here, because a dark
+   palette that has never been checked against a real screen is a guess,
+   not a design. --accent-strong / --accent-tint simply cascade from
+   :root if dark is ever switched on. */
 .dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);

--- a/crm_dashboard/src/components/app-shell.tsx
+++ b/crm_dashboard/src/components/app-shell.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+// The frame every protected screen renders inside — sidebar, page title,
+// and the logout control. Built from the Claude Design output (issue
+// #40); the screens themselves land in #32–#35.
+//
+// Which item is active and which title shows lives in @/lib/nav, so that
+// logic is unit-tested without rendering React.
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  Home,
+  Users,
+  UserRound,
+  SquareCheckBig,
+  UsersRound,
+  Settings,
+  LogOut,
+  type LucideIcon,
+} from "lucide-react";
+
+import { logout } from "@/lib/auth";
+import { ROLE_LABELS, type Role } from "@/lib/labels";
+import { initialsOf, isActive, NAV_ITEMS, pageTitle } from "@/lib/nav";
+import { useSession } from "@/lib/session-context";
+import { cn } from "@/lib/utils";
+
+// Icons live here rather than in nav.ts to keep that module free of
+// React/JSX imports — it stays plain data plus pure functions.
+const NAV_ICONS: Record<string, LucideIcon> = {
+  "/": Home,
+  "/leads": Users,
+  "/customers": UserRound,
+  "/tasks": SquareCheckBig,
+  "/team": UsersRound,
+  "/settings": Settings,
+};
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const session = useSession();
+
+  async function handleLogout() {
+    // logout always succeeds from the client's side — crm_be answers 204
+    // unconditionally (internal/auth's not-found-is-success reasoning).
+    await logout().catch(() => {});
+    router.push("/login");
+  }
+
+  return (
+    <div className="flex min-h-screen">
+      <aside className="sticky top-0 flex h-screen w-58 shrink-0 flex-col border-r border-border bg-background">
+        <div className="flex items-center gap-2.5 px-4.5 pt-4.5 pb-3.5">
+          <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-linear-to-br from-[oklch(0.72_0.17_55)] to-[oklch(0.52_0.19_35)] text-sm font-bold text-white">
+            J
+          </div>
+          <span className="text-[15px] font-semibold tracking-tight">Jualin CRM</span>
+        </div>
+
+        <div className="mb-1.5 border-b border-border px-4.5 pb-3.5 text-xs text-muted-foreground">
+          {session.organization_name}
+        </div>
+
+        <nav className="flex flex-1 flex-col gap-px overflow-y-auto p-2.5">
+          {NAV_ITEMS.map((item) => {
+            const active = isActive(pathname, item.href);
+            const Icon = NAV_ICONS[item.href];
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={active ? "page" : undefined}
+                className={cn(
+                  "flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-[13.5px] transition-colors",
+                  active
+                    ? "bg-accent-tint font-semibold text-accent-strong"
+                    : "font-medium text-foreground/80 hover:bg-muted"
+                )}
+              >
+                {Icon ? <Icon className="size-4 shrink-0" aria-hidden /> : null}
+                <span className="flex-1">{item.label}</span>
+                {item.badge ? (
+                  <span className="min-w-4 rounded-full bg-accent-tint px-1.5 text-center text-[10.5px] font-semibold text-accent-strong">
+                    {item.badge}
+                  </span>
+                ) : null}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div className="border-t border-border p-3">
+          <div className="flex items-center gap-2.5 px-2.5 py-1.5">
+            <div className="flex size-6.5 shrink-0 items-center justify-center rounded-full bg-accent-tint text-[11.5px] font-semibold text-accent-strong">
+              {initialsOf(session.full_name)}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[13px] font-medium">{session.full_name}</div>
+              <div className="text-[11.5px] text-muted-foreground">
+                {ROLE_LABELS[session.role as Role]}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={handleLogout}
+              title="Keluar"
+              aria-label="Keluar"
+              className="flex cursor-pointer rounded-sm p-1 text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <LogOut className="size-4" aria-hidden />
+            </button>
+          </div>
+        </div>
+      </aside>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="sticky top-0 z-10 flex h-14 shrink-0 items-center justify-between border-b border-border bg-background px-6">
+          <h1 className="text-[15px] font-semibold">{pageTitle(pathname)}</h1>
+          {/* Notification bell + dropdown land in #34, alongside the
+              screens that consume /v1/notifications. */}
+        </header>
+
+        <main className="flex-1 bg-muted/30 p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/crm_dashboard/src/components/placeholder-screen.tsx
+++ b/crm_dashboard/src/components/placeholder-screen.tsx
@@ -1,0 +1,25 @@
+// Temporary. The app shell (issue #40) ships all six nav destinations at
+// once, but the screens behind them land one issue at a time (#32–#35) —
+// without these, five nav items would 404 for several PR cycles.
+//
+// Each of these is deleted outright by the issue that builds its screen.
+// Naming the issue here is what keeps that from being forgotten.
+export function PlaceholderScreen({
+  title,
+  description,
+  issue,
+}: {
+  title: string;
+  description: string;
+  issue: number;
+}) {
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-2 text-center">
+      <h2 className="text-base font-medium">{title}</h2>
+      <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Layar ini dibangun di issue #{issue}.
+      </p>
+    </div>
+  );
+}

--- a/crm_dashboard/src/lib/labels.ts
+++ b/crm_dashboard/src/lib/labels.ts
@@ -1,0 +1,135 @@
+// Backend enum values → what the user actually reads. One place, so the
+// same status can't end up as "Menang" on one screen and "Won" on
+// another (Aturan #12: seluruh teks antarmuka Bahasa Indonesia).
+//
+// Labels and colors come from the Claude Design output (issue #40). The
+// colors are NOT CSS tokens: each one belongs to exactly one enum value
+// rather than to the theme, and Tailwind can't generate classes from a
+// runtime value anyway — these are applied as inline styles by whatever
+// renders the badge.
+
+// --- Lead status -------------------------------------------------------
+
+export const LEAD_STATUSES = [
+  "new",
+  "contacted",
+  "qualified",
+  "proposal",
+  "won",
+  "lost",
+  "unqualified",
+  "spam",
+] as const;
+
+export type LeadStatus = (typeof LEAD_STATUSES)[number];
+
+export interface StatusMeta {
+  label: string;
+  /** Badge text color. Also the dot/border color where a badge isn't used. */
+  color: string;
+  /** Badge background — the same hue at 15% over white. */
+  background: string;
+}
+
+// Every `color` below is verified to reach at least 4.5:1 (WCAG AA,
+// normal text) against its own `background`. The design's original
+// values missed that bar on five of the eight — `proposal` worst at
+// 3.14:1 — so lightness is nudged down while hue and chroma are kept
+// exactly as designed. Backgrounds are still mixed from the design's
+// original lightness, so the badges look as drawn.
+export const STATUS_META: Record<LeadStatus, StatusMeta> = {
+  new: {
+    label: "Baru",
+    color: "oklch(0.52 0.18 255)",
+    background: "color-mix(in oklch, oklch(0.55 0.18 255), white 85%)",
+  },
+  contacted: {
+    label: "Dihubungi",
+    color: "oklch(0.535 0.16 300)",
+    background: "color-mix(in oklch, oklch(0.55 0.16 300), white 85%)",
+  },
+  qualified: {
+    label: "Memenuhi Syarat",
+    color: "oklch(0.49 0.12 195)",
+    background: "color-mix(in oklch, oklch(0.5 0.12 195), white 85%)",
+  },
+  proposal: {
+    label: "Penawaran",
+    color: "oklch(0.53 0.15 75)",
+    background: "color-mix(in oklch, oklch(0.62 0.15 75), white 85%)",
+  },
+  won: {
+    label: "Menang",
+    color: "oklch(0.5 0.15 145)",
+    background: "color-mix(in oklch, oklch(0.5 0.15 145), white 85%)",
+  },
+  lost: {
+    label: "Kalah",
+    color: "oklch(0.54 0.2 25)",
+    background: "color-mix(in oklch, oklch(0.55 0.2 25), white 85%)",
+  },
+  unqualified: {
+    label: "Tidak Memenuhi Syarat",
+    color: "oklch(0.5 0 0)",
+    background: "color-mix(in oklch, oklch(0.5 0 0), white 85%)",
+  },
+  spam: {
+    label: "Spam",
+    color: "oklch(0.42 0.03 30)",
+    background: "color-mix(in oklch, oklch(0.42 0.03 30), white 85%)",
+  },
+};
+
+// --- Lost reason -------------------------------------------------------
+
+export const LOST_REASONS = [
+  "price",
+  "competitor",
+  "timing",
+  "no_response",
+  "not_interested",
+  "other",
+] as const;
+
+export type LostReason = (typeof LOST_REASONS)[number];
+
+export const LOST_REASON_LABELS: Record<LostReason, string> = {
+  price: "Harga",
+  competitor: "Kompetitor",
+  timing: "Waktu Tidak Tepat",
+  no_response: "Tidak Merespons",
+  not_interested: "Tidak Tertarik",
+  other: "Lainnya",
+};
+
+// --- Lead source -------------------------------------------------------
+
+export const LEAD_SOURCES = ["manual", "api", "form", "webhook"] as const;
+
+export type LeadSource = (typeof LEAD_SOURCES)[number];
+
+// "Formulir", not "Form" — this is the one source with a natural
+// Indonesian word. API and Webhook stay as-is; they're proper nouns to
+// the integrator who sees them.
+export const SOURCE_LABELS: Record<LeadSource, string> = {
+  manual: "Manual",
+  api: "API",
+  form: "Formulir",
+  webhook: "Webhook",
+};
+
+// --- Role --------------------------------------------------------------
+
+export const ROLES = ["owner", "admin", "manager", "employee"] as const;
+
+export type Role = (typeof ROLES)[number];
+
+// Left in English on purpose: these are the exact terms glossary.md
+// fixes for the role enum, and the product speaks about "Owner" and
+// "Admin" that way throughout.
+export const ROLE_LABELS: Record<Role, string> = {
+  owner: "Owner",
+  admin: "Admin",
+  manager: "Manager",
+  employee: "Employee",
+};

--- a/crm_dashboard/src/lib/nav.test.ts
+++ b/crm_dashboard/src/lib/nav.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { initialsOf, isActive, NAV_ITEMS, pageTitle } from "./nav";
+
+describe("isActive", () => {
+  it('matches "/" only exactly — otherwise every page highlights Beranda', () => {
+    expect(isActive("/", "/")).toBe(true);
+    expect(isActive("/leads", "/")).toBe(false);
+    expect(isActive("/settings", "/")).toBe(false);
+  });
+
+  it("keeps the section active on its detail pages", () => {
+    expect(isActive("/leads/01931f2e-abcd", "/leads")).toBe(true);
+    expect(isActive("/leads", "/leads")).toBe(true);
+  });
+
+  it("does not match a different section that merely shares a prefix", () => {
+    // Guards the naive startsWith: "/team" must not light up for
+    // "/teams-report" if such a route is ever added.
+    expect(isActive("/teams-report", "/team")).toBe(false);
+    expect(isActive("/customers", "/customer")).toBe(false);
+  });
+});
+
+describe("pageTitle", () => {
+  it("picks the most specific section, not the first that matches", () => {
+    expect(pageTitle("/")).toBe("Beranda");
+    expect(pageTitle("/leads")).toBe("Lead");
+    expect(pageTitle("/leads/01931f2e-abcd")).toBe("Lead");
+    expect(pageTitle("/team")).toBe("Tim");
+    expect(pageTitle("/settings")).toBe("Pengaturan");
+  });
+
+  it("falls back for an unknown path rather than rendering empty", () => {
+    expect(pageTitle("/tidak-ada")).toBe("Jualin CRM");
+  });
+});
+
+describe("NAV_ITEMS", () => {
+  // Acceptance criterion #12 — the interface is Indonesian throughout.
+  // "Lead" and "Customer" are the exceptions glossary.md fixes as the
+  // product's own vocabulary; the design's "Home"/"Task"/"Settings" are
+  // not, and must not creep back in.
+  it("uses Indonesian labels except for the two glossary terms", () => {
+    const labels = NAV_ITEMS.map((item) => item.label);
+    expect(labels).toEqual(["Beranda", "Lead", "Customer", "Tugas", "Tim", "Pengaturan"]);
+    expect(labels).not.toContain("Home");
+    expect(labels).not.toContain("Task");
+    expect(labels).not.toContain("Settings");
+  });
+});
+
+describe("initialsOf", () => {
+  it("takes first and last initial", () => {
+    expect(initialsOf("Budi Santoso")).toBe("BS");
+    expect(initialsOf("Budi Rahmat Santoso")).toBe("BS");
+  });
+
+  it("handles a single name and messy whitespace", () => {
+    expect(initialsOf("Budi")).toBe("BU");
+    expect(initialsOf("  Budi   Santoso  ")).toBe("BS");
+  });
+
+  it("never renders empty for an empty name", () => {
+    expect(initialsOf("")).toBe("?");
+    expect(initialsOf("   ")).toBe("?");
+  });
+});

--- a/crm_dashboard/src/lib/nav.ts
+++ b/crm_dashboard/src/lib/nav.ts
@@ -1,0 +1,46 @@
+// Navigation metadata and the pure logic around it. Split out of
+// app-shell.tsx so the parts that can be silently wrong — which item is
+// active, which title shows — are testable without rendering React.
+
+export interface NavItemConfig {
+  href: string;
+  label: string;
+  /** Optional count shown as a pill. Wired to unassigned leads in #32. */
+  badge?: number;
+}
+
+// "Lead" and "Customer" stay as-is — glossary.md fixes both as the
+// product's own terms. "Home"/"Task"/"Settings" from the design are
+// translated: those have ordinary Indonesian words, and acceptance
+// criterion #12 requires the interface to be Indonesian throughout.
+export const NAV_ITEMS: NavItemConfig[] = [
+  { href: "/", label: "Beranda" },
+  { href: "/leads", label: "Lead" },
+  { href: "/customers", label: "Customer" },
+  { href: "/tasks", label: "Tugas" },
+  { href: "/team", label: "Tim" },
+  { href: "/settings", label: "Pengaturan" },
+];
+
+// Exact match for "/" so it isn't active on every page; prefix match for
+// the rest so /leads/{id} keeps "Lead" highlighted on a detail screen.
+export function isActive(pathname: string, href: string): boolean {
+  if (href === "/") return pathname === "/";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+// Longest href first: without it, "/" would win for every path and every
+// page would be titled "Beranda".
+export function pageTitle(pathname: string): string {
+  const match = [...NAV_ITEMS]
+    .sort((a, b) => b.href.length - a.href.length)
+    .find((item) => isActive(pathname, item.href));
+  return match?.label ?? "Jualin CRM";
+}
+
+export function initialsOf(fullName: string): string {
+  const parts = fullName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 26 Agustus 2026 — Issue #31 selesai (setup Next.js, klien API, sesi, auth UI)
-**Phase sekarang:** Phase 3 — Owner Dashboard (2/6 issue selesai)
+**Last updated:** 26 Agustus 2026 — Issue #40 selesai (fondasi desain: token, label, app shell)
+**Phase sekarang:** Phase 3 — Owner Dashboard (3/7 issue selesai — #40 ditambahkan setelah hasil desain masuk)
 
 ---
 
@@ -36,6 +36,7 @@
 | **Issue #23 — Customer, konversi dari lead, kasus `lead` pada harness isolasi tenant** | — | 2 | `internal/customer` baru — `POST /v1/leads/{id}/convert` (satu `INSERT ... SELECT ... FROM leads WHERE status='won'`, menyalin field lead ke customer baru dalam satu statement, bukan lewat bridge Go — deviasi sadar dari asumsi awal bahwa konversi akan menambah field ke `lead.Repos`, yang ternyata tidak diperlukan). `uq_customers_org_lead` menegakkan konversi tunggal (`409 lead_already_converted`); lead bukan `won` → `422` (memakai ulang `invalid_status_transition`, tidak ada kode baru). Lead **tidak pernah** berubah oleh konversi atau oleh edit customer setelahnya — dibuktikan langsung, bukan diasumsikan. **Penutup Phase 2**: harness isolasi tenant (`cmd/api/tenant_isolation_test.go`) bertambah entri `lead`/`task`/`customer`/`activity` ke slice `[]isolationCase` yang sama sejak #11 (13 subtest, semua `404`), **terbukti bisa gagal** diulang untuk `lead` (predikat tenant-scoping dihapus sementara → kebocoran data nyata 200, bukan sekadar 500). `docs/architecture/authorization.md` matriks Phase 2 ditulis lengkap (Aturan #1 "belum berlaku" → terwujud); `multi-tenancy.md` lapis 4 kasus #1 & #4 → ✅; `api.md` menambah `lead_already_converted` plus membackfill dua kode yang luput dicatat di #21/#22. Empat `Action` RBAC baru. Smoke test manual end-to-end lolos seluruh acceptance criteria Phase 2. **Phase 2 selesai.** |
 | **Issue #30 — CORS + endpoint metrik** | — | 3 | Pembuka Phase 3, murni Go, **tidak ada UI**. `internal/shared/httpx/cors.go` baru — origin di-echo eksplisit (tidak pernah `*`), `OPTIONS` → `204` tanpa menyentuh handler, dipasang sebelum route manapun dan sebelum `authn.Middleware`. `CORS_ALLOWED_ORIGINS` di `internal/shared/config`, wajib non-kosong saat `APP_ENV=production` (Aturan #36). `internal/metrics` baru — **read-only, sengaja tanpa `Store`/`InTx`** (TD §2, penyimpangan sadar dari bentuk lima berkas). `GET /v1/metrics/summary` (`total_new`, `by_status`, `unassigned`, `conversion_rate`) dan `GET /v1/metrics/employees` (per membership: `lead_count`, `avg_response_seconds`, `converted_count`). `conversion_rate` mengecualikan `spam`/`unqualified` dari **penyebut** (menegakkan acceptance criterion #5 Phase 2 yang sampai sekarang hanya "kedua status ada") dan mengirim `null` (bukan `0`) saat penyebut nol. `avg_response_seconds` mengecualikan lead yang belum tersentuh dari rata-rata lewat perilaku native `avg()` mengabaikan `NULL` — tidak ada cabang logic tambahan, dibuktikan lewat test yang menaruh activity `lead_created` di lead yang sama untuk memastikan tipe itu benar-benar tidak ikut terhitung. `ActionMetricsRead` baru (Owner/Admin/Manager, bukan Employee). Harness isolasi tenant bertambah `TestTenantIsolation_MetricsAggregate_ScopedToOrganization` (bentuk terpisah dari slice `isolationCase` karena endpoint agregat tidak punya `:id`) — **terbukti bisa gagal** (predikat tenant di-tautologi-kan → kebocoran nyata 3 vs 1). 18 test baru di `internal/metrics` (unit + Postgres asli + HTTP), semuanya lolos tanpa perubahan asersi lama. |
 | **Issue #31 — Setup Next.js, klien API, sesi, auth UI** | — | 3 | `crm_dashboard/` dari `README.md` saja menjadi aplikasi utuh — Next.js App Router + TypeScript + Tailwind v4 + shadcn/ui (`components.json` dengan `registries: {}` kosong, tanpa registry privat). `src/lib/api-client.ts`: `credentials:'include'`, `X-CSRF-Token` di setiap non-GET, dan **refresh single-flight** — satu `refreshPromise` modul-level yang ditetapkan sinkron sebelum `await` apa pun, sehingga request paralel yang 401 bersamaan memakai ulang Promise yang sama, bukan masing-masing memanggil refresh sendiri. Route group `(auth)` vs `(protected)` — layar protected memanggil `GET /v1/me` di layout-nya (`SessionGate`), **tanpa** `middleware.ts` (tidak bisa baca token `HttpOnly`). 5 layar auth (login, register, verifikasi email, lupa/reset password) + pilih organization (`409 organization_selection_required`, ADR-007) ditangani inline di form login, bukan route terpisah. Test runner **Vitest** (dikonfirmasi pemilik produk) — 6 test di `api-client.test.ts`, termasuk **test konkurensi genuine** (refresh sengaja ditahan lewat `deferred()` sampai 6 panggilan paralel semuanya mencapai titik single-flight) yang membuktikan tepat 1 panggilan `/v1/auth/refresh`, diulang 5× tanpa flaky. Kontrak backend (`src/lib/auth.ts`) dibangun dari pembacaan literal `crm_be/internal/auth/*.go`, **diverifikasi end-to-end lewat `curl`** terhadap `crm_be` sungguhan (register → verify → login → cookie flags persis benar → CSRF terbukti aktif → logout) — bukan diasumsikan dari baca kode saja. `.github/workflows/ci-dashboard.yml` baru (`paths: crm_dashboard/**`). **Phase 3 sekarang punya UI** — #32 (daftar lead) bisa mulai. |
+| **Issue #40 — Fondasi desain: token warna, label Indonesia, app shell** | — | 3 | **Issue di luar rencana awal**, dibuka setelah hasil Claude Design masuk: desainnya mencakup ~15 layar (seluruh #32–#35) sementara token, label, dan kerangka aplikasi dipakai bersama dan tidak dimiliki satu pun dari mereka (design brief §7.6 sudah menandainya "belum ada dan dibutuhkan"). Hasil desain dibaca lewat `DesignSync` dari project `5ac090ad`. **Aksen desain gagal WCAG AA dan diperbaiki, bukan disalin apa adanya**: `oklch(0.58 0.19 41)` dipakai sebagai latar tombol dengan teks putih 14px = **4.45:1**, di bawah ambang 4.5:1 — diturunkan ke `oklch(0.56 0.19 41)` (**4.83:1**, `#D14400`→`#CA3C00`, tak terlihat mata). **Lima dari delapan badge status juga gagal**, terburuk `proposal` **3.14:1** → 4.55:1; diperbaiki dengan menurunkan *lightness* saja sehingga hue/chroma desain dan tampilan badge tetap sebagaimana digambar. Dua token aksen dipisah karena tugasnya berlawanan: `--primary` (0.56) untuk putih-di-atas-warna, `--accent-strong` (0.48, 7.04:1) untuk warna-di-atas-putih. `src/lib/labels.ts` baru — 8 status + 6 alasan kalah + 4 sumber + 4 role, satu tempat supaya tidak ada layar yang menuliskan ulang peta yang sama. Label nav desain ("Home"/"Task"/"Settings") **diterjemahkan** jadi Beranda/Tugas/Pengaturan (acceptance criterion #12); "Lead"/"Customer" tetap karena keduanya istilah `glossary.md` — dikunci test. Logika nav (`isActive`/`pageTitle`) dipisah ke `lib/nav.ts` agar bisa diuji tanpa merender React — jebakannya nyata (prefix-match naif membuat `/` aktif di setiap halaman). **Bug font sejak #31 diperbaiki**: `--font-sans` menunjuk dirinya sendiri sehingga Geist tidak pernah diterapkan; dibuktikan dari CSS hasil build. 9 test baru (15 total). Lima halaman placeholder bertanggal, masing-masing menyebut issue penggantinya. |
 
 ---
 
@@ -56,10 +57,17 @@ _(kosong)_
 - Sesi, klien API (`apiFetch`, refresh single-flight), dan proteksi route sudah ada sejak #31 —
   `apiFetch<T>` saat ini hanya mengembalikan `data`, membuang `meta`; endpoint list butuh varian baru
   yang mengembalikan `{data, meta}` untuk `meta.total` (jangan ubah signature `apiFetch` yang ada).
+- **App shell, token warna, dan `labels.ts` sudah siap sejak #40** — `/leads` saat ini berisi halaman
+  placeholder yang tinggal diganti. `STATUS_META` dan `SOURCE_LABELS` dipakai langsung untuk badge.
+- `NavItemConfig.badge` sudah ada tetapi belum ada yang mengisinya — sambungkan ke jumlah lead tanpa
+  pemilik aktif, sesuai desain yang menaruh angka itu di item nav "Lead".
 - **Filter "lead tanpa pemilik aktif" (`assigned_to=none`) wajib terlihat permanen**, bukan tersembunyi
   di menu lanjutan — kewajiban warisan Phase 2 (`02-crm-core/td.md` §19, freeze 2.3 ketentuan #3).
 - Jumlah total wajib dari `meta.total`, bukan dari panjang array halaman yang terlihat.
-- Berurutan: #30 ✅ → #31 ✅ → #32 → #33 → #34 → #35. Rincian di `docs/phases/03-owner-dashboard/issues.md`.
+- Desain layar ini ada di project `5ac090ad` (`DesignSync` → `get_file`), bagian
+  `<!-- ===== LEADS LIST ===== -->`.
+- Berurutan: #30 ✅ → #31 ✅ → #40 ✅ → #32 → #33 → #34 → #35. Rincian di
+  `docs/phases/03-owner-dashboard/issues.md`.
 
 ---
 
@@ -137,7 +145,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 0 | Foundation | ✅ | ✅ | ✅ #1–#3 | ✅ |
 | 1 | Auth & Organization | ✅ | ✅ | ✅ #8–#11, #15 | ✅ |
 | 2 | CRM Core | ✅ | ✅ | ✅ #19–#23 | ✅ |
-| 3 | Owner Dashboard | ✅ | ✅ | ✅ #30–#35 | ⬜ |
+| 3 | Owner Dashboard | ✅ | ✅ | ✅ #30–#35, #40 | ⬜ |
 | 4 | Public API | ⬜ | ⬜ | ⬜ | ⬜ |
 | 5 | Employee Mobile | ⬜ | ⬜ | ⬜ | ⬜ |
 

--- a/docs/phases/03-owner-dashboard/issues.md
+++ b/docs/phases/03-owner-dashboard/issues.md
@@ -18,13 +18,20 @@
 | [33](https://github.com/Pravasta/jualin-crm/issues/33) | Detail lead: timeline, activity, task, status, assignment, konversi | `crm_dashboard` | Layar traffic tertinggi kedua; hampir seluruh aksi tulis | §5, §6, §8 |
 | [34](https://github.com/Pravasta/jualin-crm/issues/34) | Tim: anggota, undangan, penonaktifan, notifikasi | `crm_dashboard` | Area admin. Penonaktifan dengan alur `on_open_leads` tiga cabang | §5, §8 |
 | [35](https://github.com/Pravasta/jualin-crm/issues/35) | Home metrik, customer, daftar task, settings | `crm_dashboard` | Layar top-level tersisa; mengonsumsi endpoint dari #30. **Penutup phase** | §2.1, §8 |
+| [40](https://github.com/Pravasta/jualin-crm/issues/40) | Fondasi desain: token warna, label Indonesia, app shell | `crm_dashboard` | **Ditambahkan setelah hasil desain masuk.** Dikerjakan setelah #31, sebelum #32 | design-brief §4, §6, §7.6 |
+
+> **#40 tidak ada saat phase ini dibuka.** Ia muncul ketika hasil Claude Design masuk: desainnya
+> mencakup seluruh layar #32–#35 sekaligus, sementara token warna, peta label, dan kerangka aplikasi
+> dipakai bersama oleh semuanya dan tidak dimiliki satu pun dari mereka — design brief §7.6 memang
+> sudah menandai kerangka aplikasi sebagai *"belum ada dan dibutuhkan"*. Dipisah agar empat issue
+> berikutnya tinggal mengisi layar. Urutannya: **#31 → #40 → #32**.
 
 ---
 
 ## Urutan
 
 ```
-#30 backend ──► #31 fondasi + auth ──► #32 daftar lead ──► #33 detail lead ──► #34 tim ──► #35 penutup
+#30 backend ──► #31 fondasi + auth ──► #40 fondasi desain ──► #32 daftar lead ──► #33 detail lead ──► #34 tim ──► #35 penutup
 ```
 
 | Dependensi | Sifat |

--- a/docs/phases/03-owner-dashboard/notes.md
+++ b/docs/phases/03-owner-dashboard/notes.md
@@ -200,3 +200,114 @@ verifikasi karena `curl` tidak menegakkan CORS (itu mekanisme browser).
   ada karena akan memaksa setiap pemanggil non-list menangani `meta` yang tidak mereka butuhkan.
 - `auth-errors.ts` sengaja **belum** menangani `version_conflict`/`membership_has_open_leads` — tidak
   ada layar yang membutuhkannya di issue ini. #33/#34 menambah handler-nya saat layarnya sungguhan ada.
+
+---
+
+## #40 — Fondasi desain: token warna, label Indonesia, app shell
+
+Issue ini **tidak ada di rencana awal Phase 3**. Ia muncul setelah hasil Claude Design masuk: desainnya
+mencakup ~15 layar sekaligus (seluruh #32–#35), sementara token warna, peta label, dan kerangka aplikasi
+dipakai bersama oleh semuanya dan tidak dimiliki satu pun dari mereka. Design brief §7.6 memang sudah
+menandai kerangka aplikasi sebagai *"belum ada dan dibutuhkan"*. Dipisah supaya empat issue berikutnya
+tinggal mengisi layar, bukan masing-masing ikut memindahkan fondasi.
+
+Sumber desain: project `5ac090ad-4737-47cf-8fb1-7866eb0d865c`, file `Jualin CRM Dashboard.dc.html`
+(dibaca lewat `DesignSync`). `github.md` di project itu mencatat ia disinkronkan dari commit `7b88273`
+— merge design brief kita, jadi desainnya memang dibangun di atas brief itu.
+
+### Aksen desain gagal WCAG AA — diperbaiki, bukan disalin apa adanya
+
+Design brief §12 meminta *"pastikan kontrasnya lolos WCAG AA terhadap `--primary-foreground`"*.
+Diperiksa dengan menghitung langsung (oklch → sRGB → luminansi relatif → rasio kontras), bukan
+dikira-kira:
+
+| Warna | Dipakai untuk | Rasio | |
+|---|---|---|---|
+| `oklch(0.58 0.19 41)` — usulan desain | latar tombol, teks putih 14px | **4.45:1** | ⛔ di bawah 4.5:1 |
+| `oklch(0.56 0.19 41)` — dipakai | sama | **4.83:1** | ✅ |
+
+Selisihnya tidak terlihat mata (`#D14400` → `#CA3C00`), tetapi 4.45 vs 4.50 adalah beda antara lolos
+dan tidak. Desain memakai warna itu sebagai **latar tombol dengan teks putih 14px** (terverifikasi dari
+markup-nya, bukan diasumsikan) — persis kasus "teks normal" yang ambangnya 4.5:1.
+
+**Lima dari delapan badge status juga gagal**, terburuk `proposal` di **3.14:1**. Diperbaiki dengan
+menurunkan *lightness* saja — hue dan chroma desain dipertahankan persis, dan latar badge tetap
+dicampur dari nilai desain asli sehingga badge-nya terlihat sebagaimana digambar:
+
+```
+new 4.05→4.58 · contacted 4.24→4.53 · qualified 4.33→4.51
+proposal 3.14→4.55 (0.62→0.53, satu-satunya perubahan yang terlihat) · lost 4.37→4.56
+won 4.54 · unqualified 4.81 · spam 6.62   (ketiganya sudah lolos, tidak disentuh)
+```
+
+### Keputusan implementasi
+
+- **`--primary` diganti amber, `--accent-strong` token baru.** Keduanya perlu ada karena tugasnya
+  berlawanan: `--primary` (0.56) disetel untuk **putih di atas warna**, `--accent-strong` (0.48) untuk
+  **warna di atas putih** (nav aktif, tautan — 7.04:1). Memakai satu nilai untuk keduanya berarti salah
+  satunya gagal kontras.
+- **Warna status tinggal di `labels.ts`, bukan jadi token CSS.** Masing-masing milik satu nilai enum,
+  bukan milik tema; dan Tailwind tidak bisa membuat class dari nilai runtime, jadi ia jadi inline style
+  apa pun caranya. Menaruhnya sebagai 8 variabel CSS hanya menambah lapisan tanpa menambah kemampuan.
+- **Label nav diterjemahkan.** Desain mengusulkan "Home"/"Task"/"Settings" — tiga kata Inggris yang
+  punya padanan wajar, sementara acceptance criterion #12 mewajibkan seluruh antarmuka Bahasa
+  Indonesia. Dipakai **Beranda/Tugas/Pengaturan**; "Lead" dan "Customer" tetap karena keduanya istilah
+  yang `glossary.md` kunci sebagai kosakata produk. Dikunci test, bukan hanya konvensi.
+- **Logika nav dipisah ke `lib/nav.ts`.** `isActive`/`pageTitle` punya jebakan nyata: prefix-match naif
+  membuat `/` aktif di setiap halaman, dan urutan pencarian yang salah membuat setiap halaman berjudul
+  "Beranda". Dipisah dari komponen supaya bisa diuji tanpa merender React.
+- **Lima halaman placeholder** (`/leads`, `/customers`, `/tasks`, `/team`, `/settings`). Shell
+  mengirim enam tujuan nav sekaligus; tanpa ini lima di antaranya `404` selama beberapa siklus PR.
+  Masing-masing menyebut issue yang akan menggantinya, dan dihapus utuh oleh issue itu.
+- **Lonceng notifikasi sengaja belum ada** di topbar — ia milik #34 bersama layar yang memakai
+  `/v1/notifications`. Membuat lonceng yang tidak berfungsi lebih buruk daripada tidak ada.
+- **`.dark` tidak disentuh.** Dark mode di luar cakupan Phase 3; palet gelap yang belum pernah diperiksa
+  di layar sungguhan adalah tebakan, bukan desain. `--accent-strong`/`--accent-tint` tetap mengalir dari
+  `:root` bila suatu saat dinyalakan.
+
+### Bug yang diperbaiki di sini
+
+`--font-sans: var(--font-sans)` — menunjuk dirinya sendiri, sementara `layout.tsx` mendefinisikan
+`--font-geist-sans`. Akibatnya Geist Sans **tidak pernah benar-benar diterapkan**; seluruh dashboard
+jatuh ke font bawaan browser sejak #31. Ditemukan saat memverifikasi klaim "font sudah terpasang" untuk
+design brief. Diperbaiki di sini karena `globals.css` memang sedang disentuh — dibuktikan dari CSS hasil
+build: `html{font-family:var(--font-geist-sans)}`.
+
+### Verifikasi
+
+```
+npm run typecheck · lint · build   → bersih; 12 route ter-generate
+npm run test                        → 15/15 PASS (6 lama + 9 baru di nav.test.ts)
+
+CSS hasil build (bukan hanya sumbernya):
+  .bg-accent-tint{background-color:var(--accent-tint)}    ← class benar-benar ter-generate
+  .text-accent-strong{color:var(--accent-strong)}
+  --primary:#c54300                                        ← amber, bukan netral lama
+  html{font-family:var(--font-geist-sans)}                 ← bug font terperbaiki
+
+Terhadap crm_be sungguhan (docker compose + migrate):
+  seluruh 7 route → 200
+  POST /v1/auth/login → 200
+  GET  /v1/me → organization_name "Toko Budi", full_name "Budi Santoso", role "owner"
+       — persis tiga field yang dirender shell (sidebar, inisial "BS", label "Owner")
+```
+
+**Batas verifikasi, dicatat apa adanya:** shell dirender di sisi klien di balik `SessionGate`, jadi
+`curl` hanya membuktikan route-nya hidup dan datanya benar — **bukan** bahwa tata letaknya terlihat
+seperti desain. Tidak ada tool otomasi browser di sesi ini. Yang bisa dibuktikan otomatis sudah
+dibuktikan (token ter-generate, logika nav diuji, data API cocok); penilaian visual perlu dibuka di
+browser.
+
+### Utang teknis
+
+- Lima halaman placeholder adalah utang yang **disengaja dan bertanggal** — masing-masing menyebut issue
+  penggantinya. Bila #32–#35 selesai dan masih ada `placeholder-screen.tsx`, berarti ada yang terlewat.
+
+### Catatan untuk session berikutnya
+
+- **#32 tinggal mengisi `/leads`** — shell, token, dan `STATUS_META`/`SOURCE_LABELS` sudah siap pakai.
+- `NavItemConfig.badge` sudah ada tetapi **belum ada yang mengisinya**. #32 menyambungkannya ke jumlah
+  lead tanpa pemilik aktif (`assigned_to=none`) — desainnya menaruh angka itu di item nav "Lead".
+- Sisa desain (#33–#35) ada di project `5ac090ad`, dibaca lewat `DesignSync` — `get_file` pada
+  `Jualin CRM Dashboard.dc.html`. Berkasnya 111KB; petakan dulu dengan mencari penanda
+  `<!-- ===== NAMA ===== -->` daripada memuat seluruhnya ke context.


### PR DESCRIPTION
## Summary

Lands the parts of the Claude Design output that **every remaining Phase 3 screen shares but none of them owns**. After this, #32–#35 only have to fill in their screen.

Design source: project `5ac090ad`, read via `DesignSync`. Its `github.md` records a sync from commit `7b88273` — the design-brief merge — so it was genuinely built on that brief.

## The design's accent fails WCAG AA — corrected, not copied

The brief (§12) asked to *"pastikan kontrasnya lolos WCAG AA terhadap `--primary-foreground`"*. Checked by computing it (oklch → sRGB → relative luminance → contrast ratio), not by eye:

| Color | Used for | Ratio | |
|---|---|---|---|
| `oklch(0.58 0.19 41)` — as designed | button background, 14px white label | **4.45:1** | ⛔ under 4.5:1 |
| `oklch(0.56 0.19 41)` — shipped | same | **4.83:1** | ✅ |

That it's a button background under white text is verified from the design's own markup, not assumed. `#D14400` → `#CA3C00` is invisible to the eye; 4.45 vs 4.50 is the difference between passing and not.

**Five of the eight status badges also fell short**, worst `proposal` at **3.14:1**:

```
new 4.05→4.58 · contacted 4.24→4.53 · qualified 4.33→4.51
proposal 3.14→4.55 (0.62→0.53, the only visible change) · lost 4.37→4.56
won 4.54 · unqualified 4.81 · spam 6.62   (already passing, untouched)
```

Fixed by lowering **lightness only** — hue and chroma are kept exactly as designed, and badge backgrounds still mix from the original values, so the badges look as drawn.

**Two accent tokens, because their jobs are opposite:** `--primary` (0.56) is tuned for white-on-color; `--accent-strong` (0.48, 7.04:1) for color-on-white (active nav, links). A single value would fail one of the two.

## Also in here

- **`src/lib/labels.ts`** — 8 statuses, 6 lost reasons, 4 sources, 4 roles in one place, so the same enum can't read "Menang" on one screen and "Won" on another. Status colors live here rather than as CSS tokens: each belongs to one enum value rather than to the theme, and Tailwind can't build classes from runtime values regardless — they'd be inline styles either way.
- **Nav labels translated.** The design proposed "Home"/"Task"/"Settings"; acceptance criterion #12 requires an Indonesian interface and those three have ordinary Indonesian words → **Beranda/Tugas/Pengaturan**. "Lead"/"Customer" stay — both are terms `glossary.md` fixes as product vocabulary. Locked by a test so they can't creep back.
- **`lib/nav.ts`** holds `isActive`/`pageTitle` so they're testable without rendering React. The trap is real: naive prefix matching makes `/` active on every page, and the wrong search order titles every page "Beranda". Both are covered.
- **Notification bell deliberately absent** from the topbar — it belongs to #34 with the screens that consume `/v1/notifications`. A bell that does nothing is worse than no bell.
- **`.dark` untouched.** Dark mode is out of scope for Phase 3, and a dark palette never checked on a real screen is a guess, not a design.

## Bug fixed from #31

`--font-sans: var(--font-sans)` pointed at itself while `layout.tsx` defines `--font-geist-sans` — **Geist was never actually applied**, and the whole dashboard has been falling back to the browser default since #31. Found while verifying a claim for the design brief. Confirmed fixed in the built CSS, not just the source: `html{font-family:var(--font-geist-sans)}`.

## Five placeholder pages

The shell ships all six nav destinations at once; without these, five would 404 for several PR cycles. Each names the issue that deletes it. If #32–#35 are done and `placeholder-screen.tsx` still exists, something was missed.

## Test plan

- [x] `typecheck` · `lint` · `test` · `build` — clean, exit codes actually checked
- [x] **15 tests** (6 existing + 9 new in `nav.test.ts`)
- [x] Built CSS verified, not just source: `.bg-accent-tint` / `.text-accent-strong` really generate, `--primary:#c54300`, font fix applied
- [x] Against a real `crm_be`: all 7 routes 200; `GET /v1/me` returns exactly the three fields the shell renders (`organization_name` "Toko Budi", `full_name` "Budi Santoso", `role` "owner" → initials "BS", label "Owner")

**Verification limit, stated plainly:** the shell is client-rendered behind `SessionGate`, so curl proves the routes and the data but **not the layout**. No browser automation was available here. Everything automatable was automated; the visual judgement needs a browser. Recorded the same way in `notes.md`.

Refs #40