### PR TITLE
feat(dashboard): add lead list with filters, search, and pagination

### DIFF
--- a/crm_dashboard/src/app/(protected)/leads/leads-list.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/leads-list.tsx
@@ -1,0 +1,457 @@
+"use client";
+
+// Highest-traffic screen in the product (freeze 3.2) — filters combine,
+// the "tanpa pemilik aktif" chip is permanent (freeze 2.3 ketentuan #3),
+// and the URL is the source of truth for filter state so the page can be
+// reloaded or shared without losing context (issue #32 acceptance
+// criteria).
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { FormErrorBanner } from "@/components/form-error-banner";
+import { dateInputToEndOfDayUTC, dateInputToStartOfDayUTC, formatDateID } from "@/lib/date";
+import { hasAnyLeadFilter, parseCSVParam, toggleCSVValue } from "@/lib/lead-filters";
+import { listLeads, type Lead } from "@/lib/leads";
+import { listMemberships, type Member } from "@/lib/memberships";
+import { getMetricsSummary, statusCount, type MetricsSummary } from "@/lib/metrics";
+import { LEAD_SOURCES, LEAD_STATUSES, SOURCE_LABELS, STATUS_META } from "@/lib/labels";
+import { useDebouncedValue } from "@/lib/use-debounced-value";
+import { globalMessage } from "@/lib/auth-errors";
+import { NewLeadDialog } from "./new-lead-dialog";
+
+const PER_PAGE = 25;
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+export function LeadsList() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const statusFilter = useMemo(() => parseCSVParam(searchParams.get("status")), [searchParams]);
+  const sourceFilter = useMemo(() => parseCSVParam(searchParams.get("source")), [searchParams]);
+  const assignedTo = searchParams.get("assigned_to") ?? "";
+  const createdFromInput = searchParams.get("created_from") ?? "";
+  const createdToInput = searchParams.get("created_to") ?? "";
+  const page = Math.max(1, Number(searchParams.get("page")) || 1);
+  const urlKeyword = searchParams.get("q") ?? "";
+
+  // Local — debounced OUT to the URL below. Keeping this separate from
+  // urlKeyword avoids a two-way sync loop; the only place that resets it
+  // FROM the URL is handleClearFilters.
+  const [keywordInput, setKeywordInput] = useState(urlKeyword);
+  const debouncedKeyword = useDebouncedValue(keywordInput, 300);
+
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [total, setTotal] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  // "loading" is derived, not a setState the fetch effect calls directly —
+  // react-hooks/set-state-in-effect forbids synchronous setState at the
+  // top of an effect body (only inside .then/.catch is fine, since that
+  // runs after a real async gap). Comparing "what we last successfully
+  // rendered" against "what the current filters ask for" gives the same
+  // signal without that call.
+  const [loadedKey, setLoadedKey] = useState<string | null>(null);
+
+  const [members, setMembers] = useState<Member[]>([]);
+  const [summary, setSummary] = useState<MetricsSummary | null>(null);
+
+  const [newLeadOpen, setNewLeadOpen] = useState(false);
+  // Bumped after a successful create to force the list effect to re-run
+  // even when the URL (and therefore searchParams) doesn't change — a
+  // new lead may or may not match the current filters, and re-running
+  // the real query is what keeps the table and meta.total honest,
+  // rather than optimistically inserting a row that might not belong.
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  function updateParams(patch: Record<string, string | null>) {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === null || value === "") params.delete(key);
+      else params.set(key, value);
+    }
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }
+
+  // Any filter change resets to page 1 — staying on page 4 of a filter
+  // that now has 2 results shows an empty page that looks like a bug.
+  function updateFilterParams(patch: Record<string, string | null>) {
+    updateParams({ ...patch, page: null });
+  }
+
+  useEffect(() => {
+    if (debouncedKeyword !== urlKeyword) {
+      updateFilterParams({ q: debouncedKeyword || null });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedKeyword]);
+
+  const hasAnyFilter = hasAnyLeadFilter({
+    status: statusFilter,
+    source: sourceFilter,
+    assignedTo,
+    keyword: urlKeyword,
+    createdFrom: createdFromInput,
+    createdTo: createdToInput,
+  });
+
+  function handleClearFilters() {
+    setKeywordInput("");
+    router.replace(pathname, { scroll: false });
+  }
+
+  // Memberships: fetched once, independent of every filter — used for
+  // the owner dropdown and to resolve assigned_to_membership_id to a name.
+  useEffect(() => {
+    const controller = new AbortController();
+    listMemberships(controller.signal)
+      .then(setMembers)
+      .catch((err) => {
+        if (!isAbortError(err)) {
+          // Non-fatal for this screen: the table still works with
+          // membership_id shown as "—" for every row rather than a name.
+        }
+      });
+    return () => controller.abort();
+  }, []);
+
+  // Status/unassigned chip counts come from the aggregate endpoint, not
+  // from the current page — org-wide for the selected period, not
+  // narrowed by source/owner/keyword (see @/lib/metrics's doc comment).
+  useEffect(() => {
+    const controller = new AbortController();
+    getMetricsSummary(
+      {
+        createdFrom: dateInputToStartOfDayUTC(createdFromInput),
+        createdTo: dateInputToEndOfDayUTC(createdToInput),
+      },
+      controller.signal
+    )
+      .then(setSummary)
+      .catch((err) => {
+        if (!isAbortError(err)) setSummary(null);
+      });
+    return () => controller.abort();
+  }, [createdFromInput, createdToInput]);
+
+  const requestKey = JSON.stringify([
+    statusFilter,
+    sourceFilter,
+    assignedTo,
+    urlKeyword,
+    createdFromInput,
+    createdToInput,
+    page,
+    refreshKey,
+  ]);
+  const loading = loadedKey !== requestKey;
+
+  // The list itself. Keyed on every filter + page — an AbortController
+  // cancels the in-flight request when a newer one starts, so a slow
+  // response for a filter the user already changed away from can't
+  // clobber a faster, newer one. Every setState here runs inside
+  // .then/.catch, after a real async gap — never synchronously in the
+  // effect body (react-hooks/set-state-in-effect).
+  useEffect(() => {
+    const controller = new AbortController();
+    listLeads(
+      {
+        status: statusFilter.length ? (statusFilter as Lead["status"][]) : undefined,
+        source: sourceFilter.length ? (sourceFilter as Lead["source"][]) : undefined,
+        assignedTo: assignedTo || undefined,
+        q: urlKeyword || undefined,
+        createdFrom: dateInputToStartOfDayUTC(createdFromInput),
+        createdTo: dateInputToEndOfDayUTC(createdToInput),
+        page,
+        perPage: PER_PAGE,
+      },
+      controller.signal
+    )
+      .then(({ data, meta }) => {
+        setLeads(data);
+        setTotal(meta.total);
+        setError(null);
+        setLoadedKey(requestKey);
+      })
+      .catch((err) => {
+        if (isAbortError(err)) return;
+        setError(globalMessage(err));
+        setLoadedKey(requestKey);
+      });
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter.join(","), sourceFilter.join(","), assignedTo, urlKeyword, createdFromInput, createdToInput, page, refreshKey]);
+
+  const membersById = useMemo(() => new Map(members.map((m) => [m.id, m])), [members]);
+
+  const isEmptyNoData = !loading && total === 0 && !hasAnyFilter;
+  const isEmptyFiltered = !loading && total === 0 && hasAnyFilter;
+  const showTable = !loading && total > 0;
+
+  const totalPages = Math.max(1, Math.ceil(total / PER_PAGE));
+  const rangeStart = total === 0 ? 0 : (page - 1) * PER_PAGE + 1;
+  const rangeEnd = Math.min(page * PER_PAGE, total);
+
+  return (
+    <div>
+      <div className="mb-3.5 flex items-center justify-between gap-3">
+        <Input
+          value={keywordInput}
+          onChange={(e) => setKeywordInput(e.target.value)}
+          placeholder="Cari nama, email, atau telepon…"
+          className="h-8.5 max-w-80"
+        />
+        <div className="flex items-center gap-2">
+          <input
+            type="date"
+            value={createdFromInput}
+            onChange={(e) => updateFilterParams({ created_from: e.target.value || null })}
+            aria-label="Tanggal masuk dari"
+            className="h-8.5 rounded-md border border-input bg-background px-2.5 text-[13px] outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          />
+          <span className="text-xs text-muted-foreground">s/d</span>
+          <input
+            type="date"
+            value={createdToInput}
+            onChange={(e) => updateFilterParams({ created_to: e.target.value || null })}
+            aria-label="Tanggal masuk sampai"
+            className="h-8.5 rounded-md border border-input bg-background px-2.5 text-[13px] outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          />
+          <select
+            value={assignedTo}
+            onChange={(e) => updateFilterParams({ assigned_to: e.target.value || null })}
+            className="h-8.5 rounded-md border border-input bg-background px-2.5 text-[13px] outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+          >
+            <option value="">Semua pemilik</option>
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.full_name}
+              </option>
+            ))}
+          </select>
+          <Button onClick={() => setNewLeadOpen(true)}>+ Lead baru</Button>
+        </div>
+      </div>
+
+      <div className="mb-2 flex flex-wrap items-center gap-1.5">
+        <button
+          type="button"
+          onClick={() =>
+            updateFilterParams({ assigned_to: assignedTo === "none" ? null : "none" })
+          }
+          className="flex items-center gap-1.5 rounded-full border-[1.5px] px-2.5 py-1 text-xs font-semibold transition-colors"
+          style={{
+            borderColor:
+              assignedTo === "none"
+                ? "oklch(0.55 0.2 25)"
+                : summary && summary.unassigned > 0
+                  ? "oklch(0.55 0.2 25 / 45%)"
+                  : "oklch(0.922 0 0)",
+            background: assignedTo === "none" ? "oklch(0.55 0.2 25 / 10%)" : "#fff",
+            color:
+              assignedTo === "none"
+                ? "oklch(0.5 0.2 25)"
+                : summary && summary.unassigned > 0
+                  ? "oklch(0.5 0.2 25)"
+                  : "oklch(0.35 0 0)",
+          }}
+        >
+          Tanpa pemilik aktif
+          <span className="rounded-full bg-black/8 px-1.5">{summary?.unassigned ?? "…"}</span>
+        </button>
+        <span className="mx-1 h-4 w-px bg-border" aria-hidden />
+        {LEAD_STATUSES.map((status) => {
+          const active = statusFilter.includes(status);
+          const meta = STATUS_META[status];
+          return (
+            <button
+              key={status}
+              type="button"
+              onClick={() => updateFilterParams({ status: toggleCSVValue(statusFilter, status).join(",") || null })}
+              className="flex items-center gap-1.5 rounded-full border-[1.5px] px-2.5 py-1 text-xs font-medium transition-colors"
+              style={{
+                borderColor: active ? meta.color : "oklch(0.922 0 0)",
+                background: active ? `color-mix(in oklch, ${meta.color}, white 82%)` : "#fff",
+                color: active ? meta.color : "oklch(0.35 0 0)",
+              }}
+            >
+              {meta.label}
+              <span className="opacity-60">{statusCount(summary, status)}</span>
+            </button>
+          );
+        })}
+      </div>
+      <div className="mb-3.5 flex flex-wrap items-center gap-1.5">
+        {LEAD_SOURCES.map((source) => {
+          const active = sourceFilter.includes(source);
+          return (
+            <button
+              key={source}
+              type="button"
+              onClick={() => updateFilterParams({ source: toggleCSVValue(sourceFilter, source).join(",") || null })}
+              className="rounded-full border-[1.5px] px-2.5 py-1 text-xs font-medium transition-colors"
+              style={{
+                borderColor: active ? "oklch(0.56 0.19 41)" : "oklch(0.922 0 0)",
+                background: active ? "oklch(0.56 0.19 41 / 10%)" : "#fff",
+                color: active ? "oklch(0.48 0.17 41)" : "oklch(0.35 0 0)",
+              }}
+            >
+              {SOURCE_LABELS[source]}
+            </button>
+          );
+        })}
+        {hasAnyFilter && (
+          <button
+            type="button"
+            onClick={handleClearFilters}
+            className="rounded-full px-2.5 py-1 text-xs font-medium text-accent-strong underline"
+          >
+            Hapus semua filter
+          </button>
+        )}
+      </div>
+
+      {error && <FormErrorBanner message={error} />}
+
+      {isEmptyNoData && (
+        <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-background px-6 py-12 text-center">
+          <div className="mb-1.5 text-[14.5px] font-semibold">Belum ada lead</div>
+          <div className="mb-4 text-[13px] text-muted-foreground">
+            Buat lead pertama Anda untuk mulai melacak calon pelanggan.
+          </div>
+          <Button onClick={() => setNewLeadOpen(true)}>+ Buat lead pertama</Button>
+        </div>
+      )}
+
+      {isEmptyFiltered && (
+        <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-background px-6 py-12 text-center">
+          <div className="mb-1.5 text-[14.5px] font-semibold">Tidak ada lead yang cocok</div>
+          <div className="mb-4 text-[13px] text-muted-foreground">
+            Tidak ada lead yang sesuai dengan filter saat ini.
+          </div>
+          <Button variant="outline" onClick={handleClearFilters}>
+            Hapus filter
+          </Button>
+        </div>
+      )}
+
+      {loading && leads.length === 0 && !error && (
+        <div className="rounded-lg border border-border bg-background px-6 py-12 text-center text-sm text-muted-foreground">
+          Memuat…
+        </div>
+      )}
+
+      {showTable && (
+        <div className="overflow-hidden rounded-lg border border-border bg-background">
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse">
+              <thead>
+                <tr className="bg-muted/40">
+                  <th className="px-3.5 py-2 text-left text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+                    Lead
+                  </th>
+                  <th className="px-3.5 py-2 text-left text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+                    Status
+                  </th>
+                  <th className="px-3.5 py-2 text-left text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+                    Pemilik
+                  </th>
+                  <th className="px-3.5 py-2 text-left text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+                    Sumber
+                  </th>
+                  <th className="px-3.5 py-2 text-left text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+                    Tanggal masuk
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {leads.map((lead) => {
+                  const owner = lead.assigned_to_membership_id
+                    ? membersById.get(lead.assigned_to_membership_id)?.full_name
+                    : null;
+                  const statusMeta = STATUS_META[lead.status];
+                  return (
+                    <tr key={lead.id} className="border-t border-border/70">
+                      <td className="px-3.5 py-2.5">
+                        <div className="text-[13px] font-medium">{lead.name}</div>
+                        <div className="text-[11.5px] text-muted-foreground">
+                          #{lead.lead_number}
+                          {lead.email ? ` · ${lead.email}` : ""}
+                        </div>
+                      </td>
+                      <td className="px-3.5 py-2.5">
+                        <span
+                          className="inline-block rounded-full px-2.5 py-0.5 text-xs font-medium"
+                          style={{ background: statusMeta.background, color: statusMeta.color }}
+                        >
+                          {statusMeta.label}
+                        </span>
+                      </td>
+                      <td
+                        className="px-3.5 py-2.5 text-[13px]"
+                        style={owner ? undefined : { color: "oklch(0.65 0 0)", fontStyle: "italic" }}
+                      >
+                        {owner ?? "—"}
+                      </td>
+                      <td className="px-3.5 py-2.5 text-[13px] text-foreground/70">
+                        {SOURCE_LABELS[lead.source]}
+                      </td>
+                      <td className="px-3.5 py-2.5 text-[13px] text-foreground/70">
+                        {formatDateID(lead.created_at)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex items-center justify-between border-t border-border px-3.5 py-2.5 text-[12.5px] text-muted-foreground">
+            <span>
+              Menampilkan {rangeStart}–{rangeEnd} dari {total} lead
+            </span>
+            {totalPages > 1 && (
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => updateParams({ page: String(page - 1) })}
+                >
+                  Sebelumnya
+                </Button>
+                <span>
+                  Halaman {page} dari {totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => updateParams({ page: String(page + 1) })}
+                >
+                  Berikutnya
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <NewLeadDialog
+        open={newLeadOpen}
+        onOpenChange={setNewLeadOpen}
+        onCreated={() => {
+          // A created lead always matches the current filters or not —
+          // either way, re-running the real query (rather than
+          // optimistically inserting a row) is what keeps the table and
+          // meta.total consistent with the server's actual state. The
+          // URL doesn't change here, so refreshKey is what re-triggers
+          // the fetch effect.
+          setRefreshKey((k) => k + 1);
+        }}
+      />
+    </div>
+  );
+}

--- a/crm_dashboard/src/app/(protected)/leads/new-lead-dialog.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/new-lead-dialog.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { FieldError } from "@/components/field-error";
+import { FormErrorBanner } from "@/components/form-error-banner";
+import { createLead } from "@/lib/leads";
+import { fieldErrorsFrom, globalMessage, type FieldErrors } from "@/lib/auth-errors";
+
+export function NewLeadDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function reset() {
+    setName("");
+    setEmail("");
+    setPhone("");
+    setFieldErrors({});
+    setError(null);
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setFieldErrors({});
+    setLoading(true);
+    try {
+      await createLead({ name, email: email || undefined, phone: phone || undefined });
+      reset();
+      onOpenChange(false);
+      onCreated();
+    } catch (err) {
+      const fields = fieldErrorsFrom(err);
+      if (Object.keys(fields).length > 0) setFieldErrors(fields);
+      else setError(globalMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) reset();
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Lead baru</DialogTitle>
+          <DialogDescription>Isi data kontak untuk lead ini.</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <FormErrorBanner message={error} />
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="lead-name">Nama</Label>
+            <Input
+              id="lead-name"
+              required
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <FieldError message={fieldErrors.name} />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="lead-email">Email</Label>
+            <Input
+              id="lead-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <FieldError message={fieldErrors.email} />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="lead-phone">Telepon</Label>
+            <Input
+              id="lead-phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+            />
+            <FieldError message={fieldErrors.phone} />
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Batal
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Menyimpan…" : "Buat lead"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/crm_dashboard/src/app/(protected)/leads/page.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/page.tsx
@@ -1,11 +1,10 @@
-import { PlaceholderScreen } from "@/components/placeholder-screen";
+import { Suspense } from "react";
+import { LeadsList } from "./leads-list";
 
 export default function LeadsPage() {
   return (
-    <PlaceholderScreen
-      title="Lead"
-      description="Daftar lead dengan filter status, sumber, pemilik, periode, dan pencarian kata kunci — termasuk filter permanen “lead tanpa pemilik aktif”."
-      issue={32}
-    />
+    <Suspense fallback={null}>
+      <LeadsList />
+    </Suspense>
   );
 }

--- a/crm_dashboard/src/components/app-shell.tsx
+++ b/crm_dashboard/src/components/app-shell.tsx
@@ -6,6 +6,7 @@
 //
 // Which item is active and which title shows lives in @/lib/nav, so that
 // logic is unit-tested without rendering React.
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
@@ -21,6 +22,7 @@ import {
 
 import { logout } from "@/lib/auth";
 import { ROLE_LABELS, type Role } from "@/lib/labels";
+import { getMetricsSummary } from "@/lib/metrics";
 import { initialsOf, isActive, NAV_ITEMS, pageTitle } from "@/lib/nav";
 import { useSession } from "@/lib/session-context";
 import { cn } from "@/lib/utils";
@@ -40,6 +42,19 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const session = useSession();
+
+  // All-time unassigned count (no period filter) — shown regardless of
+  // which page is open, since it's a safety-net signal (freeze 2.3
+  // ketentuan #3), not something scoped to whatever the lead list's own
+  // filters currently are.
+  const [unassignedCount, setUnassignedCount] = useState<number | null>(null);
+  useEffect(() => {
+    const controller = new AbortController();
+    getMetricsSummary({}, controller.signal)
+      .then((s) => setUnassignedCount(s.unassigned))
+      .catch(() => {});
+    return () => controller.abort();
+  }, []);
 
   async function handleLogout() {
     // logout always succeeds from the client's side — crm_be answers 204
@@ -66,6 +81,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           {NAV_ITEMS.map((item) => {
             const active = isActive(pathname, item.href);
             const Icon = NAV_ICONS[item.href];
+            const badge = item.href === "/leads" ? (unassignedCount ?? undefined) : item.badge;
             return (
               <Link
                 key={item.href}
@@ -80,9 +96,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               >
                 {Icon ? <Icon className="size-4 shrink-0" aria-hidden /> : null}
                 <span className="flex-1">{item.label}</span>
-                {item.badge ? (
+                {badge ? (
                   <span className="min-w-4 rounded-full bg-accent-tint px-1.5 text-center text-[10.5px] font-semibold text-accent-strong">
-                    {item.badge}
+                    {badge}
                   </span>
                 ) : null}
               </Link>

--- a/crm_dashboard/src/components/ui/dialog.tsx
+++ b/crm_dashboard/src/components/ui/dialog.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/crm_dashboard/src/lib/api-client.ts
+++ b/crm_dashboard/src/lib/api-client.ts
@@ -10,7 +10,7 @@
 //    reads the second call's already-rotated token as a reuse attack
 //    and revokes the whole family_id, logging the user out from under
 //    them.
-import { ApiError, type ApiErrorBody } from "./api-types";
+import { ApiError, type ApiErrorBody, type Meta } from "./api-types";
 import { CSRF_HEADER_NAME, readCsrfToken } from "./csrf";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
@@ -88,7 +88,7 @@ const sessionExpiredError = new ApiError(401, {
   message: "Sesi Anda berakhir. Silakan masuk kembali.",
 });
 
-async function parseResponse<T>(response: Response): Promise<T> {
+async function parseJSON(response: Response): Promise<{ data: unknown; meta?: Meta }> {
   const text = await response.text();
   const json = text ? JSON.parse(text) : undefined;
 
@@ -102,24 +102,47 @@ async function parseResponse<T>(response: Response): Promise<T> {
 
   // 204 No Content (e.g. logout) has no body — callers that don't need
   // a return value simply get undefined.
-  return (json?.data ?? undefined) as T;
+  return json ?? { data: undefined };
 }
 
-export async function apiFetch<T>(
+// Shared by apiFetch and apiFetchList — the 401/refresh/retry dance
+// (module doc comment above) doesn't care whether the caller wants
+// `data` alone or `{data, meta}`, so it lives in exactly one place.
+async function fetchWithAuth(
   path: string,
-  options: InternalApiFetchOptions = {}
-): Promise<T> {
+  options: InternalApiFetchOptions
+): Promise<Response> {
   const response = await rawFetch(path, options);
 
   const isRefreshCall = path === REFRESH_PATH;
   if (response.status === 401 && !isRefreshCall && !options._isRetry) {
     const refreshed = await doRefresh();
     if (refreshed) {
-      return apiFetch<T>(path, { ...options, _isRetry: true });
+      return fetchWithAuth(path, { ...options, _isRetry: true });
     }
     redirectToLogin();
     throw sessionExpiredError;
   }
+  return response;
+}
 
-  return parseResponse<T>(response);
+export async function apiFetch<T>(
+  path: string,
+  options: InternalApiFetchOptions = {}
+): Promise<T> {
+  const response = await fetchWithAuth(path, options);
+  const { data } = await parseJSON(response);
+  return data as T;
+}
+
+// For paginated list endpoints, where the total the UI shows must come
+// from `meta.total` — never from `data.length`, which is only the
+// current page (Aturan/acceptance criterion repeated across #32-#35).
+export async function apiFetchList<T>(
+  path: string,
+  options: InternalApiFetchOptions = {}
+): Promise<{ data: T[]; meta: Meta }> {
+  const response = await fetchWithAuth(path, options);
+  const { data, meta } = await parseJSON(response);
+  return { data: (data ?? []) as T[], meta: meta ?? { page: 1, per_page: 0, total: 0 } };
 }

--- a/crm_dashboard/src/lib/date.test.ts
+++ b/crm_dashboard/src/lib/date.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { dateInputToEndOfDayUTC, dateInputToStartOfDayUTC, formatDateID } from "./date";
+
+describe("dateInputToStartOfDayUTC / dateInputToEndOfDayUTC", () => {
+  it("anchors the FROM bound to the start of the day and TO to the end", () => {
+    // Without this, a lead created late on the last day of a
+    // created_to=2026-08-31 range would be silently excluded — the
+    // bound would land at 2026-08-31T00:00:00Z instead of end-of-day.
+    expect(dateInputToStartOfDayUTC("2026-08-01")).toBe("2026-08-01T00:00:00.000Z");
+    expect(dateInputToEndOfDayUTC("2026-08-31")).toBe("2026-08-31T23:59:59.999Z");
+  });
+
+  it("returns undefined for an empty input rather than an invalid timestamp", () => {
+    expect(dateInputToStartOfDayUTC("")).toBeUndefined();
+    expect(dateInputToEndOfDayUTC("")).toBeUndefined();
+  });
+});
+
+describe("formatDateID", () => {
+  it("formats as day-shortmonth-year Indonesian", () => {
+    expect(formatDateID("2026-08-17T09:30:00Z")).toBe("17 Agu 2026");
+  });
+});

--- a/crm_dashboard/src/lib/date.ts
+++ b/crm_dashboard/src/lib/date.ts
@@ -1,0 +1,23 @@
+// `<input type="date">` gives a bare "YYYY-MM-DD" with no timezone.
+// crm_be's created_from/created_to are ISO 8601 UTC (Aturan #33) and
+// filter leads.created_at directly — so the FROM bound must be the
+// start of that day and the TO bound the end of it, or a lead created
+// on the last day of the range gets silently excluded.
+export function dateInputToStartOfDayUTC(value: string): string | undefined {
+  if (!value) return undefined;
+  return `${value}T00:00:00.000Z`;
+}
+
+export function dateInputToEndOfDayUTC(value: string): string | undefined {
+  if (!value) return undefined;
+  return `${value}T23:59:59.999Z`;
+}
+
+// Same format the design uses (fmtDate): "17 Agu 2026".
+export function formatDateID(iso: string): string {
+  return new Date(iso).toLocaleDateString("id-ID", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}

--- a/crm_dashboard/src/lib/lead-filters.test.ts
+++ b/crm_dashboard/src/lib/lead-filters.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { hasAnyLeadFilter, parseCSVParam, toggleCSVValue } from "./lead-filters";
+
+describe("parseCSVParam", () => {
+  it("splits a comma-separated URL param", () => {
+    expect(parseCSVParam("new,contacted,won")).toEqual(["new", "contacted", "won"]);
+  });
+
+  it("returns an empty array for null/empty, not [\"\"]", () => {
+    // A naive "".split(",") returns [""], which would make every
+    // isActive-style check think exactly one (bogus) filter is active.
+    expect(parseCSVParam(null)).toEqual([]);
+    expect(parseCSVParam("")).toEqual([]);
+  });
+});
+
+describe("toggleCSVValue", () => {
+  it("adds a value not yet present", () => {
+    expect(toggleCSVValue(["new"], "won")).toEqual(["new", "won"]);
+  });
+
+  it("removes a value already present, preserving the rest", () => {
+    expect(toggleCSVValue(["new", "contacted", "won"], "contacted")).toEqual(["new", "won"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const original = ["new"];
+    toggleCSVValue(original, "won");
+    expect(original).toEqual(["new"]);
+  });
+});
+
+describe("hasAnyLeadFilter", () => {
+  const empty = {
+    status: [],
+    source: [],
+    assignedTo: "",
+    keyword: "",
+    createdFrom: "",
+    createdTo: "",
+  };
+
+  it("is false when nothing is set — the no-data empty state depends on this", () => {
+    expect(hasAnyLeadFilter(empty)).toBe(false);
+  });
+
+  it("is true for exactly one filter set, whichever it is", () => {
+    expect(hasAnyLeadFilter({ ...empty, status: ["won"] })).toBe(true);
+    expect(hasAnyLeadFilter({ ...empty, source: ["manual"] })).toBe(true);
+    expect(hasAnyLeadFilter({ ...empty, assignedTo: "none" })).toBe(true);
+    expect(hasAnyLeadFilter({ ...empty, keyword: "budi" })).toBe(true);
+    expect(hasAnyLeadFilter({ ...empty, createdFrom: "2026-01-01" })).toBe(true);
+    expect(hasAnyLeadFilter({ ...empty, createdTo: "2026-01-31" })).toBe(true);
+  });
+});

--- a/crm_dashboard/src/lib/lead-filters.ts
+++ b/crm_dashboard/src/lib/lead-filters.ts
@@ -1,0 +1,32 @@
+// Pure logic for the lead list's URL-as-filter-state (issue #32
+// acceptance criterion: filters reflected in the URL, reload/share-safe)
+// — split out of leads-list.tsx so it's testable without rendering React,
+// same pattern @/lib/nav used in #40.
+
+export function parseCSVParam(value: string | null): string[] {
+  return value ? value.split(",").filter(Boolean) : [];
+}
+
+export function toggleCSVValue(current: string[], value: string): string[] {
+  return current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
+}
+
+export interface LeadFilterState {
+  status: string[];
+  source: string[];
+  assignedTo: string;
+  keyword: string;
+  createdFrom: string;
+  createdTo: string;
+}
+
+export function hasAnyLeadFilter(filter: LeadFilterState): boolean {
+  return (
+    filter.status.length > 0 ||
+    filter.source.length > 0 ||
+    filter.assignedTo !== "" ||
+    filter.keyword !== "" ||
+    filter.createdFrom !== "" ||
+    filter.createdTo !== ""
+  );
+}

--- a/crm_dashboard/src/lib/leads.test.ts
+++ b/crm_dashboard/src/lib/leads.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildQuery } from "./leads";
+
+describe("buildQuery", () => {
+  it("returns empty string for no filters — never a bare '?'", () => {
+    expect(buildQuery({})).toBe("");
+  });
+
+  it("joins multi-select filters as comma-separated values, matching crm_be's splitCSV", () => {
+    const qs = buildQuery({ status: ["new", "contacted"], source: ["manual", "form"] });
+    const params = new URLSearchParams(qs.slice(1));
+    expect(params.get("status")).toBe("new,contacted");
+    expect(params.get("source")).toBe("manual,form");
+  });
+
+  it('passes assignedTo "none" through unchanged — the permanent safety-net filter', () => {
+    const qs = buildQuery({ assignedTo: "none" });
+    expect(new URLSearchParams(qs.slice(1)).get("assigned_to")).toBe("none");
+  });
+
+  it("omits every param the caller didn't set, rather than sending empty values", () => {
+    const qs = buildQuery({ q: "budi" });
+    const params = new URLSearchParams(qs.slice(1));
+    expect(params.has("status")).toBe(false);
+    expect(params.has("source")).toBe(false);
+    expect(params.has("assigned_to")).toBe(false);
+    expect(params.has("created_from")).toBe(false);
+    expect(params.has("created_to")).toBe(false);
+    expect(params.get("q")).toBe("budi");
+  });
+
+  it("carries page/per_page for pagination", () => {
+    const qs = buildQuery({ page: 3, perPage: 25 });
+    const params = new URLSearchParams(qs.slice(1));
+    expect(params.get("page")).toBe("3");
+    expect(params.get("per_page")).toBe("25");
+  });
+});

--- a/crm_dashboard/src/lib/leads.ts
+++ b/crm_dashboard/src/lib/leads.ts
@@ -1,0 +1,82 @@
+// Typed wrapper for /v1/leads — shapes verified against
+// crm_be/internal/lead/{handler_http,entity}.go's leadJSON, not guessed.
+import { apiFetch, apiFetchList } from "./api-client";
+import type { Meta } from "./api-types";
+import type { LeadSource, LeadStatus, LostReason } from "./labels";
+
+export interface Lead {
+  id: string;
+  lead_number: number;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  phone_e164: string | null;
+  company: string | null;
+  notes: string | null;
+  status: LeadStatus;
+  lost_reason: LostReason | null;
+  source: LeadSource;
+  assigned_to_membership_id: string | null;
+  version: number;
+  created_by_membership_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// undefined fields are simply omitted from the query string — a filter
+// the user hasn't touched shouldn't send an empty/misleading param.
+export interface ListLeadsFilter {
+  status?: LeadStatus[];
+  source?: LeadSource[];
+  /** A membership id, or the literal "none" for "tanpa pemilik aktif". */
+  assignedTo?: string;
+  q?: string;
+  /** ISO 8601 UTC, e.g. from dateInputToUTCRange in @/lib/date. */
+  createdFrom?: string;
+  createdTo?: string;
+  page?: number;
+  perPage?: number;
+}
+
+export function buildQuery(filter: ListLeadsFilter): string {
+  const params = new URLSearchParams();
+  if (filter.status?.length) params.set("status", filter.status.join(","));
+  if (filter.source?.length) params.set("source", filter.source.join(","));
+  if (filter.assignedTo) params.set("assigned_to", filter.assignedTo);
+  if (filter.q) params.set("q", filter.q);
+  if (filter.createdFrom) params.set("created_from", filter.createdFrom);
+  if (filter.createdTo) params.set("created_to", filter.createdTo);
+  if (filter.page) params.set("page", String(filter.page));
+  if (filter.perPage) params.set("per_page", String(filter.perPage));
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
+
+export function listLeads(
+  filter: ListLeadsFilter,
+  signal?: AbortSignal
+): Promise<{ data: Lead[]; meta: Meta }> {
+  return apiFetchList<Lead>(`/v1/leads${buildQuery(filter)}`, { signal });
+}
+
+export interface CreateLeadInput {
+  name: string;
+  email?: string;
+  phone?: string;
+}
+
+// source is always "manual" — the only source a human typing into this
+// screen can produce (glossary.md: source is the CAPTURE method, and a
+// dashboard form is exactly that). api/form/webhook leads are never
+// created here.
+export function createLead(input: CreateLeadInput): Promise<Lead> {
+  return apiFetch<Lead>("/v1/leads", {
+    method: "POST",
+    body: {
+      name: input.name,
+      email: input.email || undefined,
+      phone: input.phone || undefined,
+      source: "manual",
+    },
+  });
+}

--- a/crm_dashboard/src/lib/memberships.ts
+++ b/crm_dashboard/src/lib/memberships.ts
@@ -1,0 +1,19 @@
+// Typed wrapper for GET /v1/memberships — used here to populate the
+// owner filter and resolve assigned_to_membership_id to a display name.
+// Not paginated (crm_be/internal/membership/handler_http.go returns a
+// plain array), unlike /v1/leads.
+import { apiFetch } from "./api-client";
+import type { Role } from "./labels";
+
+export interface Member {
+  id: string;
+  user_id: string;
+  email: string;
+  full_name: string;
+  role: Role;
+  created_at: string;
+}
+
+export function listMemberships(signal?: AbortSignal): Promise<Member[]> {
+  return apiFetch<Member[]>("/v1/memberships", { signal });
+}

--- a/crm_dashboard/src/lib/metrics.test.ts
+++ b/crm_dashboard/src/lib/metrics.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { statusCount, type MetricsSummary } from "./metrics";
+
+describe("statusCount", () => {
+  it('shows the loading placeholder while summary itself has not loaded', () => {
+    expect(statusCount(null, "new")).toBe("…");
+  });
+
+  // Found verifying against a real crm_be (notes.md "## #32"): by_status
+  // is a Go map, and a status with zero leads is OMITTED from the JSON
+  // entirely — GET /v1/metrics/summary returned
+  // {"by_status":{"contacted":1,"new":4}} for an org with 5 leads across
+  // only two statuses. A naive `summary.by_status[status] ?? "…"` would
+  // render "…" forever for "won", "lost", and every status nobody has
+  // used yet — indistinguishable from a stuck loading state.
+  it("resolves a status ABSENT from a loaded summary to 0, not the loading placeholder", () => {
+    const summary: MetricsSummary = {
+      total_new: 5,
+      by_status: { new: 4, contacted: 1 },
+      unassigned: 4,
+      conversion_rate: 0,
+    };
+    expect(statusCount(summary, "won")).toBe(0);
+    expect(statusCount(summary, "spam")).toBe(0);
+  });
+
+  it("resolves a status present in a loaded summary to its real count", () => {
+    const summary: MetricsSummary = {
+      total_new: 5,
+      by_status: { new: 4, contacted: 1 },
+      unassigned: 4,
+      conversion_rate: 0,
+    };
+    expect(statusCount(summary, "new")).toBe(4);
+    expect(statusCount(summary, "contacted")).toBe(1);
+  });
+});

--- a/crm_dashboard/src/lib/metrics.ts
+++ b/crm_dashboard/src/lib/metrics.ts
@@ -1,0 +1,47 @@
+// Typed wrapper for GET /v1/metrics/summary — shape verified against
+// crm_be/internal/metrics/handler_http.go's summaryJSON.
+//
+// Used here only for the status/unassigned chip counts on the lead list
+// (and the sidebar's unassigned badge). Those counts are org-wide for
+// the selected period — NOT narrowed by source/owner/keyword, since the
+// endpoint doesn't support that combination. That's a deliberate
+// simplification (see notes.md "## #32"), not a bug: getting an exact
+// per-combination count would mean one request per chip.
+import { apiFetch } from "./api-client";
+import type { LeadStatus } from "./labels";
+
+export interface MetricsSummary {
+  total_new: number;
+  by_status: Partial<Record<LeadStatus, number>>;
+  unassigned: number;
+  conversion_rate: number | null;
+}
+
+export interface MetricsSummaryFilter {
+  createdFrom?: string;
+  createdTo?: string;
+}
+
+export function getMetricsSummary(
+  filter: MetricsSummaryFilter = {},
+  signal?: AbortSignal
+): Promise<MetricsSummary> {
+  const params = new URLSearchParams();
+  if (filter.createdFrom) params.set("from", filter.createdFrom);
+  if (filter.createdTo) params.set("to", filter.createdTo);
+  const qs = params.toString();
+  return apiFetch<MetricsSummary>(`/v1/metrics/summary${qs ? `?${qs}` : ""}`, { signal });
+}
+
+// by_status is a Go map — a status with zero leads is OMITTED from the
+// JSON entirely (verified against a real crm_be), not sent as 0.
+// `summary.by_status[status] ?? "…"` would show the loading placeholder
+// forever for any status nobody has ever used. "…" is correct ONLY while
+// summary itself hasn't loaded yet; once it has, a missing key means 0.
+export function statusCount(
+  summary: MetricsSummary | null,
+  status: LeadStatus
+): number | "…" {
+  if (!summary) return "…";
+  return summary.by_status[status] ?? 0;
+}

--- a/crm_dashboard/src/lib/use-debounced-value.ts
+++ b/crm_dashboard/src/lib/use-debounced-value.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Used for the keyword search box — without this, every keystroke would
+// fire a request, and out-of-order responses would race (fixed by the
+// AbortController in leads-list.tsx, but there's no reason to send the
+// requests in the first place).
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 26 Agustus 2026 — Issue #40 selesai (fondasi desain: token, label, app shell)
-**Phase sekarang:** Phase 3 — Owner Dashboard (3/7 issue selesai — #40 ditambahkan setelah hasil desain masuk)
+**Last updated:** 26 Agustus 2026 — Issue #32 selesai (daftar lead: filter, pencarian, pagination)
+**Phase sekarang:** Phase 3 — Owner Dashboard (4/7 issue selesai — #40 ditambahkan setelah hasil desain masuk)
 
 ---
 
@@ -37,6 +37,7 @@
 | **Issue #30 — CORS + endpoint metrik** | — | 3 | Pembuka Phase 3, murni Go, **tidak ada UI**. `internal/shared/httpx/cors.go` baru — origin di-echo eksplisit (tidak pernah `*`), `OPTIONS` → `204` tanpa menyentuh handler, dipasang sebelum route manapun dan sebelum `authn.Middleware`. `CORS_ALLOWED_ORIGINS` di `internal/shared/config`, wajib non-kosong saat `APP_ENV=production` (Aturan #36). `internal/metrics` baru — **read-only, sengaja tanpa `Store`/`InTx`** (TD §2, penyimpangan sadar dari bentuk lima berkas). `GET /v1/metrics/summary` (`total_new`, `by_status`, `unassigned`, `conversion_rate`) dan `GET /v1/metrics/employees` (per membership: `lead_count`, `avg_response_seconds`, `converted_count`). `conversion_rate` mengecualikan `spam`/`unqualified` dari **penyebut** (menegakkan acceptance criterion #5 Phase 2 yang sampai sekarang hanya "kedua status ada") dan mengirim `null` (bukan `0`) saat penyebut nol. `avg_response_seconds` mengecualikan lead yang belum tersentuh dari rata-rata lewat perilaku native `avg()` mengabaikan `NULL` — tidak ada cabang logic tambahan, dibuktikan lewat test yang menaruh activity `lead_created` di lead yang sama untuk memastikan tipe itu benar-benar tidak ikut terhitung. `ActionMetricsRead` baru (Owner/Admin/Manager, bukan Employee). Harness isolasi tenant bertambah `TestTenantIsolation_MetricsAggregate_ScopedToOrganization` (bentuk terpisah dari slice `isolationCase` karena endpoint agregat tidak punya `:id`) — **terbukti bisa gagal** (predikat tenant di-tautologi-kan → kebocoran nyata 3 vs 1). 18 test baru di `internal/metrics` (unit + Postgres asli + HTTP), semuanya lolos tanpa perubahan asersi lama. |
 | **Issue #31 — Setup Next.js, klien API, sesi, auth UI** | — | 3 | `crm_dashboard/` dari `README.md` saja menjadi aplikasi utuh — Next.js App Router + TypeScript + Tailwind v4 + shadcn/ui (`components.json` dengan `registries: {}` kosong, tanpa registry privat). `src/lib/api-client.ts`: `credentials:'include'`, `X-CSRF-Token` di setiap non-GET, dan **refresh single-flight** — satu `refreshPromise` modul-level yang ditetapkan sinkron sebelum `await` apa pun, sehingga request paralel yang 401 bersamaan memakai ulang Promise yang sama, bukan masing-masing memanggil refresh sendiri. Route group `(auth)` vs `(protected)` — layar protected memanggil `GET /v1/me` di layout-nya (`SessionGate`), **tanpa** `middleware.ts` (tidak bisa baca token `HttpOnly`). 5 layar auth (login, register, verifikasi email, lupa/reset password) + pilih organization (`409 organization_selection_required`, ADR-007) ditangani inline di form login, bukan route terpisah. Test runner **Vitest** (dikonfirmasi pemilik produk) — 6 test di `api-client.test.ts`, termasuk **test konkurensi genuine** (refresh sengaja ditahan lewat `deferred()` sampai 6 panggilan paralel semuanya mencapai titik single-flight) yang membuktikan tepat 1 panggilan `/v1/auth/refresh`, diulang 5× tanpa flaky. Kontrak backend (`src/lib/auth.ts`) dibangun dari pembacaan literal `crm_be/internal/auth/*.go`, **diverifikasi end-to-end lewat `curl`** terhadap `crm_be` sungguhan (register → verify → login → cookie flags persis benar → CSRF terbukti aktif → logout) — bukan diasumsikan dari baca kode saja. `.github/workflows/ci-dashboard.yml` baru (`paths: crm_dashboard/**`). **Phase 3 sekarang punya UI** — #32 (daftar lead) bisa mulai. |
 | **Issue #40 — Fondasi desain: token warna, label Indonesia, app shell** | — | 3 | **Issue di luar rencana awal**, dibuka setelah hasil Claude Design masuk: desainnya mencakup ~15 layar (seluruh #32–#35) sementara token, label, dan kerangka aplikasi dipakai bersama dan tidak dimiliki satu pun dari mereka (design brief §7.6 sudah menandainya "belum ada dan dibutuhkan"). Hasil desain dibaca lewat `DesignSync` dari project `5ac090ad`. **Aksen desain gagal WCAG AA dan diperbaiki, bukan disalin apa adanya**: `oklch(0.58 0.19 41)` dipakai sebagai latar tombol dengan teks putih 14px = **4.45:1**, di bawah ambang 4.5:1 — diturunkan ke `oklch(0.56 0.19 41)` (**4.83:1**, `#D14400`→`#CA3C00`, tak terlihat mata). **Lima dari delapan badge status juga gagal**, terburuk `proposal` **3.14:1** → 4.55:1; diperbaiki dengan menurunkan *lightness* saja sehingga hue/chroma desain dan tampilan badge tetap sebagaimana digambar. Dua token aksen dipisah karena tugasnya berlawanan: `--primary` (0.56) untuk putih-di-atas-warna, `--accent-strong` (0.48, 7.04:1) untuk warna-di-atas-putih. `src/lib/labels.ts` baru — 8 status + 6 alasan kalah + 4 sumber + 4 role, satu tempat supaya tidak ada layar yang menuliskan ulang peta yang sama. Label nav desain ("Home"/"Task"/"Settings") **diterjemahkan** jadi Beranda/Tugas/Pengaturan (acceptance criterion #12); "Lead"/"Customer" tetap karena keduanya istilah `glossary.md` — dikunci test. Logika nav (`isActive`/`pageTitle`) dipisah ke `lib/nav.ts` agar bisa diuji tanpa merender React — jebakannya nyata (prefix-match naif membuat `/` aktif di setiap halaman). **Bug font sejak #31 diperbaiki**: `--font-sans` menunjuk dirinya sendiri sehingga Geist tidak pernah diterapkan; dibuktikan dari CSS hasil build. 9 test baru (15 total). Lima halaman placeholder bertanggal, masing-masing menyebut issue penggantinya. |
+| **Issue #32 — Daftar lead: filter, pencarian, pagination** | — | 3 | Layar traffic tertinggi di seluruh produk (freeze 3.2). URL adalah sumber kebenaran filter (`useSearchParams` + `router.replace`); setiap perubahan filter mereset `page` ke 1. Kata kunci di-debounce 300ms; `AbortController` di setiap fetch (leads, memberships, metrics) mencegah respons lambat untuk filter yang ditinggalkan menimpa yang baru. **Bug nyata ditemukan saat verifikasi terhadap `crm_be` sungguhan**: `GET /v1/metrics/summary`'s `by_status` adalah Go map — status dengan nol lead **dihilangkan dari JSON**, bukan dikirim `0`; kode naif (`summary?.by_status[status] ?? "…"`) akan menampilkan "…" **selamanya** untuk status yang belum pernah dipakai, tak bisa dibedakan dari sedang memuat. Diperbaiki dengan fungsi murni `statusCount()` di `lib/metrics.ts` yang memisahkan "summary belum dimuat" dari "key tidak ada di summary yang sudah dimuat" — dikunci test yang membangun ulang response asli sebagai fixture. `loading` adalah *derived state* (`loadedKey !== requestKey`), bukan `setState` sinkron di effect — ESLint rule `react-hooks/set-state-in-effect` (baru di toolchain React 19) menolaknya. Hitungan chip status/tanpa-pemilik dari `GET /v1/metrics/summary`, di-scope periode saja (bukan dipersempit sumber/pemilik/kata kunci — satu request untuk delapan angka, didokumentasikan sebagai simplifikasi sadar). Kolom Pemilik diselesaikan di klien: `leadJSON` backend hanya kirim `assigned_to_membership_id`, di-lookup lewat `GET /v1/memberships` yang diambil sekali. Baris tabel **sengaja tidak bisa diklik** — issue eksplisit "detail lead belum ada di sini" (#33). `source` selalu `"manual"` saat buat lead dari layar ini. Badge nav "Lead" (kosong sejak #40) tersambung ke jumlah lead tanpa pemilik aktif. Logika murni dipisah & diuji mengikuti pola `lib/nav.ts`: `lib/lead-filters.ts`, `lib/date.ts`, `buildQuery` di `lib/leads.ts`. 18 test baru (33 total). Diverifikasi lewat `curl` terhadap `crm_be` sungguhan dengan 5 lead nyata (status/assignment/pencarian semua menghasilkan `meta.total` yang benar) — bukan hanya lewat mock. |
 
 ---
 
@@ -48,25 +49,25 @@ _(kosong)_
 
 ## Berikutnya
 
-**Issue #32 — Daftar lead: filter, pencarian, pagination** (`crm_dashboard`)
+**Issue #33 — Detail lead: timeline, activity, task, status, assignment, konversi** (`crm_dashboard`)
 
-- Cakupan & acceptance: [issue #32](https://github.com/Pravasta/jualin-crm/issues/32)
-- TD: `docs/phases/03-owner-dashboard/td.md` §7.1, §8
-- Layar traffic tertinggi di seluruh produk (freeze 3.2). Seluruh filter sudah didukung `GET /v1/leads`
-  sejak #20 — issue ini membangun layarnya, **tidak** menambah endpoint baru.
-- Sesi, klien API (`apiFetch`, refresh single-flight), dan proteksi route sudah ada sejak #31 —
-  `apiFetch<T>` saat ini hanya mengembalikan `data`, membuang `meta`; endpoint list butuh varian baru
-  yang mengembalikan `{data, meta}` untuk `meta.total` (jangan ubah signature `apiFetch` yang ada).
-- **App shell, token warna, dan `labels.ts` sudah siap sejak #40** — `/leads` saat ini berisi halaman
-  placeholder yang tinggal diganti. `STATUS_META` dan `SOURCE_LABELS` dipakai langsung untuk badge.
-- `NavItemConfig.badge` sudah ada tetapi belum ada yang mengisinya — sambungkan ke jumlah lead tanpa
-  pemilik aktif, sesuai desain yang menaruh angka itu di item nav "Lead".
-- **Filter "lead tanpa pemilik aktif" (`assigned_to=none`) wajib terlihat permanen**, bukan tersembunyi
-  di menu lanjutan — kewajiban warisan Phase 2 (`02-crm-core/td.md` §19, freeze 2.3 ketentuan #3).
-- Jumlah total wajib dari `meta.total`, bukan dari panjang array halaman yang terlihat.
+- Cakupan & acceptance: [issue #33](https://github.com/Pravasta/jualin-crm/issues/33)
+- TD: `docs/phases/03-owner-dashboard/td.md` §5, §6, §8
+- Layar traffic tertinggi kedua, dan tempat **hampir seluruh aksi tulis** produk berada. Seluruh
+  endpoint sudah ada sejak #20–#23 — issue ini membangun layarnya, tidak menambah endpoint.
+- Baris tabel di `/leads` **belum navigasi kemana pun** (sengaja, per batas #32) — sambungkan ke
+  `/leads/{id}` saat halaman ini ada, dan hapus komentar terkait di `leads-list.tsx`.
+- **`version` wajib ikut terkirim di setiap form edit** (lead dan task), TD §6 — lupa membawanya bekerja
+  tepat sekali lalu gagal `409` di setiap penyimpanan berikutnya.
+- **`409 version_conflict` → tampilkan konflik, muat ulang dari `error.current`, JANGAN PERNAH menimpa
+  otomatis** (Aturan #35) — satu-satunya tempat pengguna harus memilih secara sadar.
+- `auth-errors.ts` belum menangani `version_conflict` — tambahkan handler-nya di issue ini, saat
+  layar yang pertama benar-benar membutuhkannya.
+- `STATUS_META`/`LOST_REASON_LABELS` di `lib/labels.ts` (dari #40) sudah siap untuk pilihan transisi
+  status dan alasan `lost`.
 - Desain layar ini ada di project `5ac090ad` (`DesignSync` → `get_file`), bagian
-  `<!-- ===== LEADS LIST ===== -->`.
-- Berurutan: #30 ✅ → #31 ✅ → #40 ✅ → #32 → #33 → #34 → #35. Rincian di
+  `<!-- ===== LEAD DETAIL ===== -->`.
+- Berurutan: #30 ✅ → #31 ✅ → #40 ✅ → #32 ✅ → #33 → #34 → #35. Rincian di
   `docs/phases/03-owner-dashboard/issues.md`.
 
 ---

--- a/docs/phases/03-owner-dashboard/notes.md
+++ b/docs/phases/03-owner-dashboard/notes.md
@@ -311,3 +311,108 @@ browser.
 - Sisa desain (#33–#35) ada di project `5ac090ad`, dibaca lewat `DesignSync` — `get_file` pada
   `Jualin CRM Dashboard.dc.html`. Berkasnya 111KB; petakan dulu dengan mencari penanda
   `<!-- ===== NAMA ===== -->` daripada memuat seluruhnya ke context.
+
+---
+
+## #32 — Daftar lead: filter, pencarian, pagination
+
+Layar dibangun dari section `<!-- ===== LEADS LIST ===== -->` project `5ac090ad` (dibaca ulang, bukan
+dari cache lama, untuk memastikan tidak ada perubahan yang terlewat sejak #40). Desain memberi struktur
+visual (input pencarian, chip filter, tabel, empty state, modal "Lead baru") tetapi **tidak** menunjukkan
+filter periode atau kontrol pagination — keduanya wajib menurut TD §7.1/issue tapi tidak ada di mockup
+(prototipe render semua data sekaligus dari array in-memory, tidak benar-benar berpaginasi). Ditambahkan
+mengikuti bahasa visual yang sama (tinggi 34px, radius 8px/999px, warna token), dicatat sebagai perluasan
+sadar dari mockup — bukan penyimpangan diam-diam.
+
+### Bug nyata ditemukan saat verifikasi terhadap `crm_be` sungguhan
+
+`GET /v1/metrics/summary`'s `by_status` adalah **Go map** — status dengan nol lead **dihilangkan
+sepenuhnya** dari JSON, bukan dikirim sebagai `0`. Dibuktikan langsung: org dengan 5 lead di dua status
+mengembalikan `{"by_status":{"contacted":1,"new":4}}` — enam status lainnya sama sekali tidak ada di
+body. Kode awal menulis `summary?.by_status[status] ?? "…"` — untuk status manapun yang belum pernah
+dipakai satu organization pun, ini akan menampilkan "…" **selamanya**, tidak bisa dibedakan dari keadaan
+sedang memuat.
+
+Diperbaiki dengan memisahkan dua pertanyaan yang berbeda: *"apakah summary sudah dimuat?"* (baru boleh
+menampilkan "…") vs *"apakah status ini ADA di summary yang sudah dimuat?"* (key hilang = `0`, bukan
+"belum tahu"). Fungsi murni `statusCount(summary, status)` di `lib/metrics.ts`, dikunci test
+(`metrics.test.ts`) yang secara eksplisit membangun ulang response asli itu sebagai fixture.
+
+### Keputusan implementasi
+
+- **URL adalah sumber kebenaran filter** — dibaca dari `useSearchParams`, ditulis lewat
+  `router.replace(..., {scroll:false})`. Setiap perubahan filter mereset `page` ke 1: bertahan di
+  halaman 4 dari filter yang sekarang hanya punya 2 hasil menampilkan halaman kosong yang terlihat
+  seperti bug.
+- **Kata kunci pencarian di-debounce 300ms** sebelum ditulis ke URL — tanpa ini setiap ketikan memicu
+  request. State lokal (`keywordInput`) terpisah dari nilai URL (`urlKeyword`) supaya tidak ada sinkronisasi
+  dua arah yang bisa loop; satu-satunya tempat URL menimpa state lokal adalah `handleClearFilters`.
+- **`AbortController` di setiap fetch**, dibatalkan saat filter berganti sebelum respons sebelumnya
+  selesai — mencegah respons lambat untuk filter yang sudah ditinggalkan menimpa respons yang lebih baru
+  untuk filter saat ini. Berlaku untuk daftar lead, memberships, dan metrics summary.
+- **`loading` adalah derived state, bukan `setState` langsung di body effect.** ESLint (rule
+  `react-hooks/set-state-in-effect`, baru di React 19 toolchain) menolak `setLoading(true)` sinkron di
+  awal effect. Diselesaikan dengan membandingkan `requestKey` (serialisasi seluruh filter+page) terhadap
+  `loadedKey` (di-set hanya di dalam `.then`/`.catch`, yang diizinkan karena berjalan setelah jeda async
+  sungguhan) — `loading = loadedKey !== requestKey`. Tidak ada `setLoading` sama sekali.
+- **Hitungan chip status/tanpa-pemilik dari `GET /v1/metrics/summary`, di-scope periode saja** — bukan
+  dipersempit oleh sumber/pemilik/kata kunci, karena endpoint metrik tidak mendukung kombinasi itu. Satu
+  request untuk delapan angka, bukan delapan request. Didokumentasikan di `lib/metrics.ts`, bukan
+  disembunyikan sebagai perilaku tak terjelaskan.
+- **Chip sumber sengaja tanpa angka** — desain sendiri tidak memberi `sourceChips` field `count` (beda
+  dari `statusChips`/`unassignedChip`, diverifikasi dari kode sumbernya), dan tidak ada satu request
+  murah untuk itu. Konsisten dengan mockup, bukan kekurangan.
+- **Baris tabel tidak bisa diklik** — desain menaruh `onClick` di setiap baris menuju detail lead, tapi
+  issue #32 eksplisit: *"Detail lead (klik satu baris belum membuka apa pun) → #33"*. Membuatnya terlihat
+  bisa diklik padahal tidak kemana-mana lebih buruk daripada tidak sama sekali.
+- **Kolom Pemilik diselesaikan di klien** — `leadJSON` backend hanya mengirim
+  `assigned_to_membership_id` (uuid), bukan nama. `GET /v1/memberships` diambil sekali (tidak berpaginasi,
+  independen dari filter lead) dan di-lookup lewat `Map`. Lead tanpa pemilik → "—" miring, warna redup —
+  persis perlakuan desain (`ownerColor`/`ownerFontStyle` bersyarat).
+- **`source` selalu `"manual"` saat membuat lead dari layar ini** — modal desain hanya punya field
+  Nama/Email/Telepon, tidak ada pemilihan sumber. `manual` adalah satu-satunya metode capture yang
+  make sense untuk form yang diisi manusia (glossary: source = metode capture, bukan channel marketing).
+- **Badge nav "Lead" (dari #40, sebelumnya kosong) disambungkan** — `AppShell` mengambil
+  `getMetricsSummary({})` sendiri (tanpa filter periode) sekali saat mount, independen dari state layar
+  `/leads` mana pun. Duplikasi satu request kecil dengan layar lead saat keduanya aktif bersamaan,
+  diterima sadar — lebih sederhana daripada membuat context/state lifting untuk satu angka.
+- **Logika murni dipisah ke `lib/` dan diuji**, mengikuti pola `lib/nav.ts` dari #40:
+  `lib/lead-filters.ts` (parse/toggle CSV param, `hasAnyLeadFilter`), `lib/date.ts` (konversi
+  `<input type="date">` ↔ ISO 8601 UTC awal/akhir hari, format tampilan `id-ID`), `buildQuery` di
+  `lib/leads.ts` diekspor eksplisit untuk diuji.
+
+### Verifikasi
+
+```
+npm run typecheck · lint · build   → bersih; 12 route ter-generate
+npm run test                        → 33/33 PASS (15 lama + 18 baru: lead-filters, date, leads, metrics)
+
+Terhadap crm_be sungguhan (docker compose + migrate, organization baru "Toko Lead32"):
+  register → verify → login (client=dashboard) → GET /v1/me                    semua sesuai kontrak
+  POST /v1/leads × 5 (source=manual, bentuk request PERSIS createLead())        201 × 5
+  PATCH .../status new→contacted, PATCH .../assignment ke diri sendiri          200, 200
+  GET /v1/leads?status=new           → meta.total=4 (bukan 5 — transisi status ikut terhitung)
+  GET /v1/leads?assigned_to=none     → meta.total=4 (bukan 5 — assignment ikut terhitung)
+  GET /v1/leads?q=Test%202           → meta.total=1, lead yang benar
+  GET /v1/metrics/summary            → ditemukan bug by_status di atas
+  GET /leads, /leads?status=won (Next.js dev server)                            200, tanpa error render
+```
+
+**Batas verifikasi, dicatat apa adanya:** filter/chip/pagination/dialog dibuktikan lewat kontrak API
+(`curl` dengan query string persis yang dibangun `buildQuery`) dan lewat unit test logika murninya —
+**bukan** lewat interaksi klik di browser sungguhan. Tidak ada tool otomasi browser di sesi ini.
+
+### Utang teknis
+
+- Tidak ada item baru dari issue ini.
+
+### Catatan untuk session berikutnya
+
+- **#33 (detail lead) bisa mulai.** Baris tabel di `/leads` belum navigasi kemana pun — sambungkan ke
+  `/leads/{id}` saat halamannya ada, dan hapus komentar "Tidak termasuk" terkait di `leads-list.tsx`.
+- `getMetricsSummary` dipanggil dua kali secara independen saat berada di `/leads` (sekali oleh
+  `AppShell` untuk badge nav, sekali oleh `leads-list.tsx` untuk chip) — kalau kelak terasa perlu
+  disatukan, itu keputusan produk (mis. "badge nav harus ikut ter-filter periode juga?"), bukan sekadar
+  refactor teknis.
+- `apiFetchList`/`buildQuery` di `lib/leads.ts` adalah pola yang akan dipakai ulang oleh `/customers`
+  dan `/tasks` (#35) — keduanya endpoint list berpaginasi dengan bentuk yang sama.


### PR DESCRIPTION
## Summary

Highest-traffic screen in the product (freeze 3.2: *"Lead list & detail adalah produknya"*). Every filter TD §7.1 lists is already supported by `GET /v1/leads` since #20 — this issue builds the screen, adds no endpoint.

Built from the design's `<!-- ===== LEADS LIST ===== -->` section (project `5ac090ad`, re-read fresh rather than from cache to catch anything changed since #40). The mockup gave the visual language — search input, filter chips, table, empty states, "Lead baru" modal — but **not** a period filter or real pagination controls. Both are required by TD §7.1 but absent from the prototype, which renders a fixed in-memory array rather than paginating against a real API. Added following the same visual language (34px height, 8px/999px radius, existing tokens), recorded in `notes.md` as a deliberate extension, not a silent deviation.

## A real bug, found by verifying against a running backend, not assumed from reading code

`GET /v1/metrics/summary`'s `by_status` is a **Go map** — a status with zero leads is **omitted from the JSON entirely**, not sent as `0`. Proven directly: an org with 5 leads across two statuses returned `{"by_status":{"contacted":1,"new":4}}` — the other six statuses aren't in the body at all.

The naive `summary?.by_status[status] ?? "…"` would show the loading placeholder **forever** for any status nobody has used yet — indistinguishable from a stuck loading state. Fixed with a pure `statusCount(summary, status)` function (`lib/metrics.ts`) that separates two different questions: *"has summary loaded at all?"* (only then is `"…"` wrong) vs *"is this key present in a summary that HAS loaded?"* (missing key → `0`, not "unknown"). Locked by a test that rebuilds the exact response as a fixture, so it can't regress silently.

## Other decisions

- **URL is the source of truth for filter state** (`useSearchParams` + `router.replace`) — reload/share-safe per the acceptance criteria. Every filter change resets `page` to 1.
- **Keyword search debounced 300ms** into the URL, with local state kept separate from the URL value to avoid a two-way sync loop. **`AbortController` on every fetch** (leads, memberships, metrics) — a slow response for a filter the user already changed away from can't clobber a newer one.
- **`loading` is derived state**, not a `setState` called synchronously in the effect body. `react-hooks/set-state-in-effect` (new in the React 19 toolchain) forbids that — every `setState` here now runs inside `.then`/`.catch`, after a real async gap.
- **Status/unassigned chip counts come from `GET /v1/metrics/summary`, scoped to the period filter only** — not narrowed by source/owner/keyword, since the endpoint doesn't support that combination. One request for eight numbers instead of eight requests, documented as a deliberate simplification rather than hidden behavior.
- **Source chips deliberately have no counts** — the design itself never gave `sourceChips` a `count` field (unlike `statusChips`/`unassignedChip`, verified from the source), and there's no cheap request for it either. Matches the mockup; not a gap.
- **Table rows are not clickable.** The design wires row `onClick` to a lead detail screen, but issue #32 explicitly excludes it (*"Detail lead — klik satu baris belum membuka apa pun → #33"*). A row that looks clickable with nowhere to go is worse than one that doesn't.
- **Owner column resolved client-side** — `leadJSON` only sends `assigned_to_membership_id`, never a name. `GET /v1/memberships` fetched once (unpaginated, filter-independent) and looked up via a `Map`. Unassigned → "—", italic, muted — matches the design's conditional styling.
- **`source` is always `"manual"`** when creating a lead from this screen — the design's modal has no source field, and manual is the only capture method a human typing into a form can produce (glossary: source = capture method).
- **The "Lead" nav badge** (left empty in #40) now shows the all-time unassigned count — `AppShell` fetches it independently on mount.
- **Pure logic extracted to `lib/` and tested**, following `lib/nav.ts`'s pattern from #40: `lib/lead-filters.ts` (CSV param parse/toggle, `hasAnyLeadFilter`), `lib/date.ts` (`<input type="date">` ↔ ISO 8601 UTC start/end-of-day, `id-ID` display format), `buildQuery` in `lib/leads.ts` exported explicitly for testing.

## Test plan

- [x] `typecheck` · `lint` · `test` · `build` — clean, exit codes checked (not just tail'd)
- [x] **18 new tests** (33 total): `lead-filters`, `date`, `leads` (`buildQuery`), `metrics` (`statusCount`, including the exact bug fixture above)
- [x] Verified against a real `crm_be` (fresh org, 5 real leads created via the exact `createLead()` request shape):
  - `POST /v1/leads` × 5 → `201` × 5
  - `PATCH .../status` new→contacted, `PATCH .../assignment` to self → `200`, `200`
  - `GET /v1/leads?status=new` → `meta.total=4` (not 5 — the status transition is reflected)
  - `GET /v1/leads?assigned_to=none` → `meta.total=4` (assignment reflected)
  - `GET /v1/leads?q=Test%202` → `meta.total=1`, the correct lead
  - `GET /v1/metrics/summary` → surfaced the `by_status` bug above
  - `/leads`, `/leads?status=won` on the Next.js dev server → `200`, no render error

**Verification limit, stated plainly:** filters/chips/pagination/dialog are proven via the API contract (`curl` with the exact query strings `buildQuery` produces) and via unit tests of the pure logic — not via clicking through a real browser. No browser automation tool was available in this session.

Refs #32