### PR TITLE
feat(dashboard): add lead detail — timeline, activity, task, status, assignment, conversion

### DIFF
--- a/crm_dashboard/src/app/(protected)/leads/[id]/conflict-dialog.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/[id]/conflict-dialog.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+// Aturan #35 / issue #33's headline acceptance criterion: a save
+// conflict must show the conflict, reload the current state, and NEVER
+// auto-overwrite. This dialog is the only response to
+// version_conflict — every write path in lead-detail.tsx routes here
+// instead of quietly retrying with a stale version.
+export function ConflictDialog({
+  open,
+  onReload,
+}: {
+  open: boolean;
+  onReload: () => void;
+}) {
+  return (
+    <Dialog open={open}>
+      <DialogContent showCloseButton={false} className="border-t-4 border-t-[oklch(0.62_0.15_75)]">
+        <DialogHeader>
+          <DialogTitle>Data ini sudah diubah orang lain</DialogTitle>
+          <DialogDescription>
+            Lead ini berubah di tempat lain sejak Anda membukanya. Perubahan yang belum tersimpan
+            tidak akan ditimpakan secara otomatis — muat ulang untuk melihat versi terbaru sebelum
+            melanjutkan.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" onClick={onReload}>
+            Muat ulang data terkini
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/crm_dashboard/src/app/(protected)/leads/[id]/delete-lead-dialog.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/[id]/delete-lead-dialog.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { FormErrorBanner } from "@/components/form-error-banner";
+
+export function DeleteLeadDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => Promise<void>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleConfirm() {
+    setLoading(true);
+    setError(null);
+    try {
+      await onConfirm();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Terjadi kesalahan.");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="border-t-4 border-t-destructive">
+        <DialogHeader>
+          <DialogTitle>Hapus lead ini?</DialogTitle>
+          <DialogDescription>
+            Tindakan ini tidak bisa dibatalkan. Seluruh riwayat, catatan, dan task pada lead ini
+            akan ikut terhapus.
+          </DialogDescription>
+        </DialogHeader>
+        <FormErrorBanner message={error} />
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Batal
+          </Button>
+          {/* button.tsx's "destructive" variant is a soft/light style
+              (text-destructive on a tinted bg) — this needs the solid
+              red-with-white-text treatment the design gives a truly
+              destructive confirm, so it's styled directly rather than
+              introducing a second destructive variant for one button. */}
+          <Button
+            type="button"
+            disabled={loading}
+            onClick={handleConfirm}
+            className="bg-destructive text-white hover:bg-destructive/85"
+          >
+            {loading ? "Menghapus…" : "Ya, hapus lead"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/crm_dashboard/src/app/(protected)/leads/[id]/edit-lead-dialog.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/[id]/edit-lead-dialog.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { FormErrorBanner } from "@/components/form-error-banner";
+import { updateLead, type Lead } from "@/lib/leads";
+import { globalMessage, versionConflictCurrent } from "@/lib/auth-errors";
+
+// The design's LEAD DETAIL section never surfaces an edit form for
+// name/email/phone/company/notes at all — only status/assignment/notes-
+// as-timeline-entries. The checklist is explicit ("Ubah field umum —
+// PATCH /v1/leads/{id}, membawa version"), so this modal exists to cover
+// it; not a redesign of anything the mockup showed.
+export function EditLeadDialog({
+  open,
+  onOpenChange,
+  lead,
+  onSaved,
+  onConflict,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  lead: Lead;
+  onSaved: (updated: Lead) => void;
+  onConflict: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        {/* Keyed by lead.id + version so the form REMOUNTS — with fresh
+            useState initializers — every time the dialog opens against a
+            possibly-different `lead` (e.g. after a conflict reload
+            elsewhere on the screen changed it while this was closed).
+            That's the React-recommended way to reset state on a prop
+            change; a useEffect calling setState synchronously is what
+            react-hooks/set-state-in-effect (React 19 toolchain) forbids. */}
+        <EditLeadForm
+          key={`${lead.id}-${lead.version}`}
+          lead={lead}
+          onOpenChange={onOpenChange}
+          onSaved={onSaved}
+          onConflict={onConflict}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EditLeadForm({
+  lead,
+  onOpenChange,
+  onSaved,
+  onConflict,
+}: {
+  lead: Lead;
+  onOpenChange: (open: boolean) => void;
+  onSaved: (updated: Lead) => void;
+  onConflict: () => void;
+}) {
+  const [name, setName] = useState(lead.name);
+  const [email, setEmail] = useState(lead.email ?? "");
+  const [phone, setPhone] = useState(lead.phone ?? "");
+  const [company, setCompany] = useState(lead.company ?? "");
+  const [notes, setNotes] = useState(lead.notes ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const updated = await updateLead(lead.id, {
+        version: lead.version,
+        name,
+        email: email || null,
+        phone: phone || null,
+        company: company || null,
+        notes: notes || null,
+      });
+      onOpenChange(false);
+      onSaved(updated);
+    } catch (err) {
+      if (versionConflictCurrent<Lead>(err)) {
+        onOpenChange(false);
+        onConflict();
+      } else {
+        setError(globalMessage(err));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Ubah lead</DialogTitle>
+        <DialogDescription>Perbarui data kontak lead ini.</DialogDescription>
+      </DialogHeader>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <FormErrorBanner message={error} />
+
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="edit-name">Nama</Label>
+          <Input id="edit-name" required value={name} onChange={(e) => setName(e.target.value)} />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="edit-email">Email</Label>
+          <Input
+            id="edit-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="edit-phone">Telepon</Label>
+          <Input id="edit-phone" type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="edit-company">Perusahaan</Label>
+          <Input id="edit-company" value={company} onChange={(e) => setCompany(e.target.value)} />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="edit-notes">Catatan</Label>
+          <Textarea id="edit-notes" value={notes} onChange={(e) => setNotes(e.target.value)} />
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Batal
+          </Button>
+          <Button type="submit" disabled={loading}>
+            {loading ? "Menyimpan…" : "Simpan"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </>
+  );
+}

--- a/crm_dashboard/src/app/(protected)/leads/[id]/lead-detail.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/[id]/lead-detail.tsx
@@ -1,0 +1,603 @@
+"use client";
+
+// Where "hampir seluruh aksi tulis" of the product happens (issue #33).
+// Every mutation here follows the same shape: call the API with the
+// `version` currently on screen, and on 409 version_conflict, show
+// ConflictDialog rather than silently retrying (Aturan #35) — never
+// apply the server's `current` payload until the user consciously clicks
+// "Muat ulang".
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { FormErrorBanner } from "@/components/form-error-banner";
+import { ApiError } from "@/lib/api-types";
+import {
+  convertLead,
+  deleteLead,
+  getLead,
+  updateLeadAssignment,
+  updateLeadStatus,
+  type Lead,
+} from "@/lib/leads";
+import { createActivity, listActivities, type Activity, type UserActivityType } from "@/lib/activities";
+import { completeTask, deleteTask, listTasksByLead, type Task } from "@/lib/tasks";
+import { listMemberships, type Member } from "@/lib/memberships";
+import { activityToTimelineEntry, lostReasonDisplayLabel } from "@/lib/activity-text";
+import { canConvertLead, statusTransitionOptions } from "@/lib/lead-status";
+import { SOURCE_LABELS, STATUS_META, type LeadStatus, type LostReason } from "@/lib/labels";
+import { formatDateID } from "@/lib/date";
+import { globalMessage, versionConflictCurrent } from "@/lib/auth-errors";
+import { useSession } from "@/lib/session-context";
+import { ConflictDialog } from "./conflict-dialog";
+import { DeleteLeadDialog } from "./delete-lead-dialog";
+import { EditLeadDialog } from "./edit-lead-dialog";
+import { LostReasonDialog } from "./lost-reason-dialog";
+import { NewTaskDialog } from "./new-task-dialog";
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+const NOTE_TYPE_OPTIONS: { type: UserActivityType; label: string }[] = [
+  { type: "note_added", label: "📝 Catatan" },
+  { type: "call_logged", label: "📞 Log telepon" },
+  { type: "whatsapp_opened", label: "💬 WhatsApp dibuka" },
+];
+
+export function LeadDetail({ leadId }: { leadId: string }) {
+  const router = useRouter();
+  const session = useSession();
+
+  const [lead, setLead] = useState<Lead | null>(null);
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [notFound, setNotFound] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const reload = useCallback(() => setRefreshKey((k) => k + 1), []);
+
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [statusSaving, setStatusSaving] = useState(false);
+  const [assignSaving, setAssignSaving] = useState(false);
+  const [assignError, setAssignError] = useState<string | null>(null);
+  const [convertError, setConvertError] = useState<string | null>(null);
+  const [convertSaving, setConvertSaving] = useState(false);
+
+  const [noteType, setNoteType] = useState<UserActivityType>("note_added");
+  const [noteDraft, setNoteDraft] = useState("");
+  const [noteSaving, setNoteSaving] = useState(false);
+  const [noteError, setNoteError] = useState<string | null>(null);
+
+  const [lostDialogOpen, setLostDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [newTaskDialogOpen, setNewTaskDialogOpen] = useState(false);
+  const [conflictOpen, setConflictOpen] = useState(false);
+  const [taskError, setTaskError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    Promise.all([
+      getLead(leadId, controller.signal),
+      listActivities(leadId, controller.signal),
+      listTasksByLead(leadId, controller.signal),
+      listMemberships(controller.signal),
+    ])
+      .then(([leadData, activityData, taskData, memberData]) => {
+        setLead(leadData);
+        setActivities(activityData);
+        setTasks(taskData);
+        setMembers(memberData);
+        setNotFound(false);
+        setLoadError(null);
+      })
+      .catch((err) => {
+        if (isAbortError(err)) return;
+        if (err instanceof ApiError && err.code === "not_found") setNotFound(true);
+        else setLoadError(globalMessage(err));
+      });
+    return () => controller.abort();
+  }, [leadId, refreshKey]);
+
+  const namesById = useMemo(() => new Map(members.map((m) => [m.id, m.full_name])), [members]);
+  const timeline = useMemo(
+    () =>
+      [...activities]
+        .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+        .map((a) => ({ activity: a, entry: activityToTimelineEntry(a, namesById) })),
+    [activities, namesById]
+  );
+
+  function handleConflict(err: unknown): boolean {
+    if (versionConflictCurrent<Lead>(err)) {
+      setConflictOpen(true);
+      return true;
+    }
+    return false;
+  }
+
+  function handleReloadConflict() {
+    setConflictOpen(false);
+    reload();
+  }
+
+  async function handleChooseStatus(status: LeadStatus) {
+    if (!lead) return;
+    if (status === "lost") {
+      setLostDialogOpen(true);
+      return;
+    }
+    setStatusError(null);
+    setStatusSaving(true);
+    try {
+      const updated = await updateLeadStatus(lead.id, { version: lead.version, status });
+      setLead(updated);
+      reload();
+    } catch (err) {
+      if (!handleConflict(err)) setStatusError(globalMessage(err));
+    } finally {
+      setStatusSaving(false);
+    }
+  }
+
+  async function handleConfirmLost(reason: LostReason) {
+    if (!lead) return;
+    try {
+      const updated = await updateLeadStatus(lead.id, { version: lead.version, status: "lost", lostReason: reason });
+      setLead(updated);
+      setLostDialogOpen(false);
+      reload();
+    } catch (err) {
+      if (handleConflict(err)) {
+        setLostDialogOpen(false);
+        return;
+      }
+      throw err; // shown inside LostReasonDialog itself
+    }
+  }
+
+  async function handleAssignChange(membershipId: string) {
+    if (!lead) return;
+    setAssignError(null);
+    setAssignSaving(true);
+    try {
+      const updated = await updateLeadAssignment(lead.id, {
+        version: lead.version,
+        assignedToMembershipId: membershipId || null,
+      });
+      setLead(updated);
+      reload();
+    } catch (err) {
+      if (!handleConflict(err)) setAssignError(globalMessage(err));
+    } finally {
+      setAssignSaving(false);
+    }
+  }
+
+  async function handleSubmitNote() {
+    if (!lead || !noteDraft.trim()) return;
+    setNoteError(null);
+    setNoteSaving(true);
+    try {
+      await createActivity(lead.id, noteType, noteDraft.trim());
+      setNoteDraft("");
+      reload();
+    } catch (err) {
+      setNoteError(globalMessage(err));
+    } finally {
+      setNoteSaving(false);
+    }
+  }
+
+  async function handleConvert() {
+    if (!lead) return;
+    setConvertError(null);
+    setConvertSaving(true);
+    try {
+      // No customer detail screen exists yet (#35) — nothing to link to
+      // on success, so the return value is intentionally unused.
+      await convertLead(lead.id);
+      reload();
+    } catch (err) {
+      // lead_already_converted's backend message ("Lead ini sudah
+      // pernah dikonversi...") is already the clear message the
+      // acceptance criterion asks for — shown as-is, no special case.
+      setConvertError(globalMessage(err));
+    } finally {
+      setConvertSaving(false);
+    }
+  }
+
+  async function handleDeleteLead() {
+    if (!lead) return;
+    await deleteLead(lead.id);
+    router.push("/leads");
+  }
+
+  async function handleToggleTask(task: Task) {
+    setTaskError(null);
+    try {
+      if (task.status === "open") {
+        await completeTask(task.id, task.version);
+        reload();
+      }
+      // Un-completing a task isn't a supported action (no endpoint) —
+      // the checkbox only ever moves open -> done.
+    } catch (err) {
+      if (versionConflictCurrent<Task>(err)) {
+        // A task conflict is lower-stakes than a lead conflict — surface
+        // it inline and refetch, rather than a second modal pattern.
+        setTaskError("Task ini sudah diubah di tempat lain. Daftar dimuat ulang.");
+        reload();
+      } else {
+        setTaskError(globalMessage(err));
+      }
+    }
+  }
+
+  async function handleDeleteTask(task: Task) {
+    setTaskError(null);
+    try {
+      await deleteTask(task.id);
+      reload();
+    } catch (err) {
+      setTaskError(globalMessage(err));
+    }
+  }
+
+  if (notFound) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-16 text-center">
+        <p className="text-sm text-muted-foreground">Lead tidak ditemukan.</p>
+        <Button variant="outline" onClick={() => router.push("/leads")}>
+          Kembali ke daftar lead
+        </Button>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return <FormErrorBanner message={loadError} />;
+  }
+
+  if (!lead) {
+    return <div className="py-16 text-center text-sm text-muted-foreground">Memuat…</div>;
+  }
+
+  const statusMeta = STATUS_META[lead.status];
+  const lostReasonLabel = lostReasonDisplayLabel(lead.lost_reason);
+  const canDelete = session.role === "owner" || session.role === "admin";
+  // The Lead entity itself carries no "already converted" flag —
+  // converted_from_lead_id lives on Customer, not Lead (TD §12: the lead
+  // is never mutated by conversion). The timeline's own
+  // "lead_converted" entry is what's actually checked, so the button
+  // disappears once a conversion has genuinely happened rather than
+  // relying on convertSaving alone (which resets after a FAILED attempt
+  // too).
+  const alreadyConverted = activities.some((a) => a.type === "lead_converted");
+  const canConvert =
+    (session.role === "owner" || session.role === "admin") &&
+    canConvertLead(lead.status) &&
+    !alreadyConverted;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => router.push("/leads")}
+        className="mb-3.5 flex items-center gap-1 text-[13px] text-muted-foreground hover:text-foreground"
+      >
+        ← Kembali ke daftar lead
+      </button>
+
+      <div className="grid grid-cols-1 items-start gap-5 lg:grid-cols-[1fr_320px]">
+        <div className="flex flex-col gap-4">
+          {/* Header */}
+          <Card>
+            <CardContent>
+              <div className="mb-1 flex items-start justify-between">
+                <div>
+                  <div className="mb-0.5 text-xs text-muted-foreground">#{lead.lead_number}</div>
+                  <div className="flex items-center gap-2 text-[19px] font-semibold">
+                    {lead.name}
+                    <button
+                      type="button"
+                      onClick={() => setEditDialogOpen(true)}
+                      className="text-xs font-normal text-accent-strong underline"
+                    >
+                      Ubah
+                    </button>
+                  </div>
+                </div>
+                <span
+                  className="inline-block rounded-full px-3 py-1 text-[13px] font-semibold"
+                  style={{ background: statusMeta.background, color: statusMeta.color }}
+                >
+                  {statusMeta.label}
+                </span>
+              </div>
+              <div className="mt-2.5 flex flex-wrap gap-4 text-[13px] text-foreground/70">
+                {lead.email && <span>{lead.email}</span>}
+                {lead.phone && <span>{lead.phone}</span>}
+                <span>Sumber: {SOURCE_LABELS[lead.source]}</span>
+                <span>Masuk: {formatDateID(lead.created_at)}</span>
+                {lead.company && <span>{lead.company}</span>}
+              </div>
+              {lead.notes && (
+                <div className="mt-2.5 text-[13px] text-muted-foreground">{lead.notes}</div>
+              )}
+              {lostReasonLabel && (
+                <div
+                  className="mt-2.5 inline-block rounded-md px-2.5 py-1 text-[12.5px]"
+                  style={{ background: "oklch(0.55 0.2 25 / 7%)", color: "oklch(0.5 0.2 25)" }}
+                >
+                  Alasan kalah: {lostReasonLabel}
+                </div>
+              )}
+
+              <FormErrorBanner message={statusError} />
+              <div className="mt-3.5 flex flex-wrap gap-2">
+                {statusTransitionOptions(lead.status).map((opt) => (
+                  <button
+                    key={opt.status}
+                    type="button"
+                    disabled={statusSaving}
+                    onClick={() => handleChooseStatus(opt.status)}
+                    className="h-8 rounded-md px-3 text-[13px] font-medium disabled:opacity-50"
+                    style={
+                      opt.kind === "step"
+                        ? {
+                            border: "1px solid oklch(0.56 0.19 41 / 40%)",
+                            background: "oklch(0.56 0.19 41 / 8%)",
+                            color: "oklch(0.48 0.17 41)",
+                          }
+                        : {
+                            border: "1px solid oklch(0.922 0 0)",
+                            background: "#fff",
+                            color: "oklch(0.4 0 0)",
+                          }
+                    }
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Add note */}
+          <Card>
+            <CardContent>
+              <div className="mb-2.5 text-[13.5px] font-semibold">Tambah catatan</div>
+              <FormErrorBanner message={noteError} />
+              <div className="mb-2.5 flex gap-1.5">
+                {NOTE_TYPE_OPTIONS.map((nt) => (
+                  <button
+                    key={nt.type}
+                    type="button"
+                    onClick={() => setNoteType(nt.type)}
+                    className="h-7 rounded-md px-2.5 text-[12.5px]"
+                    style={{
+                      border: `1px solid ${noteType === nt.type ? "oklch(0.56 0.19 41)" : "oklch(0.922 0 0)"}`,
+                      background: noteType === nt.type ? "oklch(0.56 0.19 41 / 8%)" : "#fff",
+                    }}
+                  >
+                    {nt.label}
+                  </button>
+                ))}
+              </div>
+              <textarea
+                value={noteDraft}
+                onChange={(e) => setNoteDraft(e.target.value)}
+                placeholder="Tulis catatan…"
+                className="min-h-16 w-full rounded-md border border-input px-2.5 py-2 text-[13px] outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+              />
+              <Button
+                type="button"
+                size="sm"
+                className="mt-2"
+                disabled={noteSaving || !noteDraft.trim()}
+                onClick={handleSubmitNote}
+              >
+                {noteSaving ? "Menyimpan…" : "Simpan"}
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Timeline */}
+          <Card>
+            <CardContent>
+              <div className="mb-3 text-[13.5px] font-semibold">Riwayat</div>
+              {timeline.length === 0 && (
+                <p className="text-[12.5px] text-muted-foreground">Belum ada riwayat.</p>
+              )}
+              <div className="flex flex-col">
+                {timeline.map(({ activity, entry }) => (
+                  <div
+                    key={activity.id}
+                    className="flex gap-2.5 border-b border-border/60 py-2.5 last:border-b-0"
+                  >
+                    <span
+                      className="mt-0.5 flex size-5.5 shrink-0 items-center justify-center rounded-full text-[11px]"
+                      style={{
+                        background: entry.isHuman ? "oklch(0.56 0.19 41 / 10%)" : "oklch(0.96 0 0)",
+                        color: entry.isHuman ? "oklch(0.5 0.17 41)" : "oklch(0.6 0 0)",
+                      }}
+                    >
+                      {entry.isHuman
+                        ? activity.type === "call_logged"
+                          ? "📞"
+                          : activity.type === "whatsapp_opened"
+                            ? "💬"
+                            : "📝"
+                        : "•"}
+                    </span>
+                    <div className="flex-1">
+                      {entry.isHuman && entry.authorName && (
+                        <div className="text-[12.5px] font-semibold text-foreground/85">
+                          {entry.authorName}
+                        </div>
+                      )}
+                      <div
+                        className="text-[13px]"
+                        style={{ color: entry.isHuman ? "oklch(0.25 0 0)" : "oklch(0.5 0 0)" }}
+                      >
+                        {entry.text}
+                      </div>
+                      <div className="mt-0.5 text-[11.5px] text-muted-foreground">
+                        {new Date(activity.created_at).toLocaleString("id-ID", {
+                          day: "numeric",
+                          month: "short",
+                          year: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right column */}
+        <div className="flex flex-col gap-4">
+          <Card>
+            <CardContent>
+              <div className="mb-2.5 text-[13px] font-semibold">Penugasan</div>
+              <FormErrorBanner message={assignError} />
+              <select
+                value={lead.assigned_to_membership_id ?? ""}
+                disabled={assignSaving}
+                onChange={(e) => handleAssignChange(e.target.value)}
+                className="h-8 w-full rounded-md border border-input bg-background px-2.5 text-[13px] outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+              >
+                <option value="">Tanpa pemilik</option>
+                {members.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.full_name}
+                  </option>
+                ))}
+              </select>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardContent>
+              <div className="mb-2.5 flex items-center justify-between">
+                <span className="text-[13px] font-semibold">Task</span>
+                <button
+                  type="button"
+                  onClick={() => setNewTaskDialogOpen(true)}
+                  className="text-xs font-medium text-accent-strong"
+                >
+                  + Tambah
+                </button>
+              </div>
+              <FormErrorBanner message={taskError} />
+              {tasks.length === 0 && (
+                <p className="py-1.5 text-[12.5px] text-muted-foreground">Belum ada task.</p>
+              )}
+              {tasks.map((task) => {
+                const overdue =
+                  task.status === "open" && task.due_at && new Date(task.due_at) < new Date();
+                return (
+                  <div key={task.id} className="flex items-start gap-2 border-t border-border/60 py-2 first:border-t-0">
+                    <input
+                      type="checkbox"
+                      checked={task.status === "done"}
+                      disabled={task.status === "done"}
+                      onChange={() => handleToggleTask(task)}
+                      className="mt-0.5"
+                    />
+                    <div className="flex-1">
+                      <div
+                        className="text-[12.5px]"
+                        style={{
+                          textDecoration: task.status === "done" ? "line-through" : "none",
+                          color: task.status === "done" ? "oklch(0.65 0 0)" : "inherit",
+                        }}
+                      >
+                        {task.title}
+                      </div>
+                      <div
+                        className="text-[11px]"
+                        style={{ color: overdue ? "oklch(0.55 0.2 25)" : "oklch(0.6 0 0)" }}
+                      >
+                        {task.due_at ? formatDateID(task.due_at) : "Tanpa jatuh tempo"}
+                        {overdue ? " · Terlambat" : ""}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteTask(task)}
+                      className="text-muted-foreground hover:text-destructive"
+                      aria-label="Hapus task"
+                    >
+                      ×
+                    </button>
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+
+          {convertError && <FormErrorBanner message={convertError} />}
+          {canConvert && (
+            <Button
+              type="button"
+              disabled={convertSaving}
+              onClick={handleConvert}
+              className="h-9 bg-[oklch(0.5_0.15_145)] text-white hover:bg-[oklch(0.45_0.15_145)]"
+            >
+              {convertSaving ? "Mengonversi…" : "Konversi menjadi customer"}
+            </Button>
+          )}
+
+          {canDelete && (
+            <button
+              type="button"
+              onClick={() => setDeleteDialogOpen(true)}
+              className="h-8.5 rounded-md text-[13px] font-medium"
+              style={{
+                border: "1px solid oklch(0.577 0.245 27.325 / 35%)",
+                background: "oklch(0.577 0.245 27.325 / 6%)",
+                color: "oklch(0.55 0.22 27)",
+              }}
+            >
+              Hapus lead
+            </button>
+          )}
+        </div>
+      </div>
+
+      <LostReasonDialog open={lostDialogOpen} onOpenChange={setLostDialogOpen} onConfirm={handleConfirmLost} />
+      <DeleteLeadDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        onConfirm={handleDeleteLead}
+      />
+      <EditLeadDialog
+        open={editDialogOpen}
+        onOpenChange={setEditDialogOpen}
+        lead={lead}
+        onSaved={(updated) => {
+          setLead(updated);
+          setEditDialogOpen(false);
+        }}
+        onConflict={() => setConflictOpen(true)}
+      />
+      <NewTaskDialog
+        open={newTaskDialogOpen}
+        onOpenChange={setNewTaskDialogOpen}
+        leadId={lead.id}
+        members={members}
+        onCreated={reload}
+      />
+      <ConflictDialog open={conflictOpen} onReload={handleReloadConflict} />
+    </div>
+  );
+}

--- a/crm_dashboard/src/app/(protected)/leads/[id]/lost-reason-dialog.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/[id]/lost-reason-dialog.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { FormErrorBanner } from "@/components/form-error-banner";
+import { LOST_REASON_LABELS, LOST_REASONS, type LostReason } from "@/lib/labels";
+
+// lost_reason is mandatory the moment status becomes "lost" (TD phase 2
+// §5, ck_leads_lost_requires_reason) — this dialog is the only path to
+// that transition, so "lost" without a reason literally cannot be sent
+// from this screen (issue #33 acceptance criterion).
+export function LostReasonDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (reason: LostReason) => Promise<void>;
+}) {
+  const [reason, setReason] = useState<LostReason | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleConfirm() {
+    if (!reason) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await onConfirm(reason);
+      setReason(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Terjadi kesalahan.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setReason(null);
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Tandai sebagai Kalah</DialogTitle>
+          <DialogDescription>Pilih alasan lead ini kalah.</DialogDescription>
+        </DialogHeader>
+
+        <FormErrorBanner message={error} />
+
+        <div className="flex flex-col gap-1.5">
+          {LOST_REASONS.map((r) => (
+            <button
+              key={r}
+              type="button"
+              onClick={() => setReason(r)}
+              className="rounded-md border px-3 py-2 text-left text-sm transition-colors"
+              style={{
+                borderColor: reason === r ? "oklch(0.55 0.2 25)" : "oklch(0.922 0 0)",
+                background: reason === r ? "oklch(0.55 0.2 25 / 6%)" : "#fff",
+              }}
+            >
+              {LOST_REASON_LABELS[r]}
+            </button>
+          ))}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Batal
+          </Button>
+          <Button
+            type="button"
+            disabled={!reason || loading}
+            onClick={handleConfirm}
+            className="bg-[oklch(0.55_0.2_25)] text-white hover:bg-[oklch(0.5_0.2_25)]"
+          >
+            {loading ? "Menyimpan…" : "Tandai kalah"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/crm_dashboard/src/app/(protected)/leads/[id]/new-task-dialog.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/[id]/new-task-dialog.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { FieldError } from "@/components/field-error";
+import { FormErrorBanner } from "@/components/form-error-banner";
+import { createTask } from "@/lib/tasks";
+import { fieldErrorsFrom, globalMessage, type FieldErrors } from "@/lib/auth-errors";
+import type { Member } from "@/lib/memberships";
+
+// The design's own "+ Tambah" creates a hardcoded "Task baru" with no
+// form at all (visual-only placeholder in the mockup's own code). A real
+// task needs at least a title — this is a straightforward addition
+// following the same modal pattern as new-lead-dialog.tsx, not a design
+// deviation worth belaboring.
+export function NewTaskDialog({
+  open,
+  onOpenChange,
+  leadId,
+  members,
+  onCreated,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  leadId: string;
+  members: Member[];
+  onCreated: () => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [dueAt, setDueAt] = useState("");
+  const [assignedTo, setAssignedTo] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function reset() {
+    setTitle("");
+    setDescription("");
+    setDueAt("");
+    setAssignedTo("");
+    setFieldErrors({});
+    setError(null);
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setFieldErrors({});
+    setLoading(true);
+    try {
+      await createTask(leadId, {
+        title,
+        description: description || undefined,
+        dueAt: dueAt ? `${dueAt}T00:00:00.000Z` : undefined,
+        assignedToMembershipId: assignedTo || undefined,
+      });
+      reset();
+      onOpenChange(false);
+      onCreated();
+    } catch (err) {
+      const fields = fieldErrorsFrom(err);
+      if (Object.keys(fields).length > 0) setFieldErrors(fields);
+      else setError(globalMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) reset();
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Task baru</DialogTitle>
+          <DialogDescription>Tambahkan follow-up untuk lead ini.</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <FormErrorBanner message={error} />
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="task-title">Judul</Label>
+            <Input
+              id="task-title"
+              required
+              autoFocus
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <FieldError message={fieldErrors.title} />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="task-description">Deskripsi</Label>
+            <Textarea
+              id="task-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="task-due">Jatuh tempo</Label>
+            <input
+              id="task-due"
+              type="date"
+              value={dueAt}
+              onChange={(e) => setDueAt(e.target.value)}
+              className="h-8 rounded-md border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="task-assignee">Penanggung jawab</Label>
+            <select
+              id="task-assignee"
+              value={assignedTo}
+              onChange={(e) => setAssignedTo(e.target.value)}
+              className="h-8 rounded-md border border-input bg-transparent px-2.5 text-sm outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+            >
+              <option value="">Tanpa penanggung jawab</option>
+              {members.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.full_name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Batal
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Menyimpan…" : "Buat task"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/crm_dashboard/src/app/(protected)/leads/[id]/page.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/[id]/page.tsx
@@ -1,0 +1,13 @@
+import { LeadDetail } from "./lead-detail";
+
+// A Server Component only to unwrap the async `params` (Next.js 15+) —
+// everything below it is client-rendered, same as every other screen in
+// this app (session comes from GET /v1/me via SessionGate, not SSR).
+export default async function LeadDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <LeadDetail leadId={id} />;
+}

--- a/crm_dashboard/src/app/(protected)/leads/leads-list.tsx
+++ b/crm_dashboard/src/app/(protected)/leads/leads-list.tsx
@@ -374,7 +374,11 @@ export function LeadsList() {
                     : null;
                   const statusMeta = STATUS_META[lead.status];
                   return (
-                    <tr key={lead.id} className="border-t border-border/70">
+                    <tr
+                      key={lead.id}
+                      onClick={() => router.push(`/leads/${lead.id}`)}
+                      className="cursor-pointer border-t border-border/70 hover:bg-muted/40"
+                    >
                       <td className="px-3.5 py-2.5">
                         <div className="text-[13px] font-medium">{lead.name}</div>
                         <div className="text-[11.5px] text-muted-foreground">

--- a/crm_dashboard/src/components/ui/textarea.tsx
+++ b/crm_dashboard/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/crm_dashboard/src/lib/activities.ts
+++ b/crm_dashboard/src/lib/activities.ts
@@ -1,0 +1,52 @@
+// Typed wrapper for /v1/leads/{id}/activities — shape verified against
+// crm_be/internal/activity/handler_http.go's activityJSON.
+//
+// Append-only on the backend (no PATCH/DELETE route exists at all — see
+// that file's own comment) — this module mirrors that by never exposing
+// an update or delete function, not just by convention.
+import { apiFetch } from "./api-client";
+
+// The 7 types crm_be writes automatically (ck_activities_type,
+// migrations/0003_crm_core.sql) plus the 3 a human can create via
+// createActivity below.
+export type ActivityType =
+  | "lead_created"
+  | "lead_assigned"
+  | "lead_unassigned"
+  | "status_changed"
+  | "lead_converted"
+  | "note_added"
+  | "call_logged"
+  | "whatsapp_opened"
+  | "task_created"
+  | "task_completed";
+
+export interface Activity {
+  id: string;
+  lead_id: string;
+  type: ActivityType;
+  actor_membership_id: string | null;
+  body: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export function listActivities(leadId: string, signal?: AbortSignal): Promise<Activity[]> {
+  return apiFetch<Activity[]>(`/v1/leads/${leadId}/activities`, { signal });
+}
+
+// Only these three — POST .../activities rejects any other type with
+// 422 invalid_activity_type (the system-generated types are written
+// internally by their own usecases, never through this endpoint).
+export type UserActivityType = "note_added" | "call_logged" | "whatsapp_opened";
+
+export function createActivity(
+  leadId: string,
+  type: UserActivityType,
+  body: string
+): Promise<Activity> {
+  return apiFetch<Activity>(`/v1/leads/${leadId}/activities`, {
+    method: "POST",
+    body: { type, body },
+  });
+}

--- a/crm_dashboard/src/lib/activity-text.test.ts
+++ b/crm_dashboard/src/lib/activity-text.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { activityToTimelineEntry } from "./activity-text";
+import type { Activity } from "./activities";
+
+const NAMES = new Map([
+  ["m-budi", "Budi Santoso"],
+  ["m-sari", "Sari Wulandari"],
+]);
+
+function activity(overrides: Partial<Activity>): Activity {
+  return {
+    id: "a-1",
+    lead_id: "l-1",
+    type: "note_added",
+    actor_membership_id: null,
+    body: null,
+    metadata: null,
+    created_at: "2026-08-17T09:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("activityToTimelineEntry", () => {
+  // lead_created: internal/lead/usecase.go's Create passes metadata=nil.
+  it("lead_created — no metadata, static text", () => {
+    const entry = activityToTimelineEntry(activity({ type: "lead_created", metadata: null }), NAMES);
+    expect(entry).toEqual({ isHuman: false, text: "Lead dibuat" });
+  });
+
+  // status_changed: {"from": "...", "to": "..."} — internal/lead/usecase.go UpdateStatus.
+  it("status_changed — renders from -> to using status labels, not raw enum values", () => {
+    const entry = activityToTimelineEntry(
+      activity({ type: "status_changed", metadata: { from: "new", to: "contacted" } }),
+      NAMES
+    );
+    expect(entry.text).toBe("Status: Baru → Dihubungi");
+  });
+
+  // lead_assigned: {"from": <id|null>, "to": <id>} — internal/lead/usecase.go UpdateAssignment.
+  it("lead_assigned — first-time assignment (no `from`) reads as \"ditugaskan ke\"", () => {
+    const entry = activityToTimelineEntry(
+      activity({ type: "lead_assigned", metadata: { to: "m-budi" } }),
+      NAMES
+    );
+    expect(entry.text).toBe("Ditugaskan ke Budi Santoso");
+  });
+
+  it("lead_assigned — reassignment (both from and to present) reads as a transfer", () => {
+    const entry = activityToTimelineEntry(
+      activity({ type: "lead_assigned", metadata: { from: "m-budi", to: "m-sari" } }),
+      NAMES
+    );
+    expect(entry.text).toBe("Dipindahkan dari Budi Santoso ke Sari Wulandari");
+  });
+
+  // lead_unassigned: {"from": <id>} — internal/lead/usecase.go UpdateAssignment.
+  it("lead_unassigned", () => {
+    const entry = activityToTimelineEntry(
+      activity({ type: "lead_unassigned", metadata: { from: "m-budi" } }),
+      NAMES
+    );
+    expect(entry.text).toBe("Dilepas dari Budi Santoso");
+  });
+
+  it("resolves a membership id no longer in the map as a deactivated member, not a crash", () => {
+    const entry = activityToTimelineEntry(
+      activity({ type: "lead_assigned", metadata: { to: "m-gone" } }),
+      NAMES
+    );
+    expect(entry.text).toBe("Ditugaskan ke Anggota yang sudah tidak aktif");
+  });
+
+  // lead_converted: {"customer_id": "..."} — internal/customer/usecase.go Convert.
+  it("lead_converted", () => {
+    const entry = activityToTimelineEntry(
+      activity({ type: "lead_converted", metadata: { customer_id: "c-1" } }),
+      NAMES
+    );
+    expect(entry.text).toBe("Dikonversi menjadi customer");
+  });
+
+  // task_created: {"task_id": "...", "title": "..."} — internal/task/usecase.go Create.
+  it("task_created — includes the title", () => {
+    const entry = activityToTimelineEntry(
+      activity({ type: "task_created", metadata: { task_id: "t-1", title: "Telepon lagi besok" } }),
+      NAMES
+    );
+    expect(entry.text).toBe("Task dibuat: Telepon lagi besok");
+  });
+
+  // task_completed: {"task_id": "..."} ONLY — no title in this metadata,
+  // unlike task_created. A naive implementation might assume it's there.
+  it("task_completed — has no title in its metadata, must not crash or show \"undefined\"", () => {
+    const entry = activityToTimelineEntry(
+      activity({ type: "task_completed", metadata: { task_id: "t-1" } }),
+      NAMES
+    );
+    expect(entry.text).toBe("Task diselesaikan");
+  });
+
+  it.each(["note_added", "call_logged", "whatsapp_opened"] as const)(
+    "%s — human-authored, body is the text, author resolved from actor_membership_id",
+    (type) => {
+      const entry = activityToTimelineEntry(
+        activity({ type, body: "Sudah dihubungi, tertarik.", actor_membership_id: "m-sari" }),
+        NAMES
+      );
+      expect(entry.isHuman).toBe(true);
+      expect(entry.text).toBe("Sudah dihubungi, tertarik.");
+      expect(entry.authorName).toBe("Sari Wulandari");
+    }
+  );
+});

--- a/crm_dashboard/src/lib/activity-text.ts
+++ b/crm_dashboard/src/lib/activity-text.ts
@@ -1,0 +1,99 @@
+// Turns one Activity into what the timeline actually shows. Split out as
+// a pure function (no React) so every metadata shape crm_be's usecases
+// write — verified against internal/{lead,task,customer}/usecase.go's
+// Activity.Record calls, not guessed — has a locked, tested rendering.
+import type { Activity } from "./activities";
+import { LOST_REASON_LABELS, STATUS_META, type LeadStatus, type LostReason } from "./labels";
+
+export interface TimelineEntry {
+  /** true for the 3 user-authored types (note_added/call_logged/whatsapp_opened). */
+  isHuman: boolean;
+  text: string;
+  /** Only set for isHuman entries — resolved from actor_membership_id. */
+  authorName?: string;
+}
+
+function memberName(id: string | null, namesById: Map<string, string>): string {
+  if (!id) return "Seseorang";
+  return namesById.get(id) ?? "Anggota yang sudah tidak aktif";
+}
+
+// namesById maps membership_id -> full_name (built from GET
+// /v1/memberships, same map @/app/(protected)/leads's list screen
+// already builds — see notes.md "## #33" for why a membership missing
+// from that map isn't an error: it can be a deactivated member whose
+// name the org still needs to see in old history).
+export function activityToTimelineEntry(
+  activity: Activity,
+  namesById: Map<string, string>
+): TimelineEntry {
+  const meta = (activity.metadata ?? {}) as Record<string, unknown>;
+  const str = (key: string): string | null =>
+    typeof meta[key] === "string" && meta[key] !== "" ? (meta[key] as string) : null;
+
+  switch (activity.type) {
+    case "lead_created":
+      // metadata is nil for this type (internal/lead/usecase.go's
+      // Create) — the source is already shown in the header, so this
+      // stays a plain, static line rather than plumbing lead.source
+      // through just for this one sentence.
+      return { isHuman: false, text: "Lead dibuat" };
+
+    case "status_changed": {
+      const from = str("from") as LeadStatus | null;
+      const to = str("to") as LeadStatus | null;
+      const fromLabel = from ? STATUS_META[from].label : "?";
+      const toLabel = to ? STATUS_META[to].label : "?";
+      return { isHuman: false, text: `Status: ${fromLabel} → ${toLabel}` };
+    }
+
+    case "lead_assigned": {
+      const from = str("from");
+      const to = str("to");
+      const toName = memberName(to, namesById);
+      return {
+        isHuman: false,
+        text: from
+          ? `Dipindahkan dari ${memberName(from, namesById)} ke ${toName}`
+          : `Ditugaskan ke ${toName}`,
+      };
+    }
+
+    case "lead_unassigned":
+      return { isHuman: false, text: `Dilepas dari ${memberName(str("from"), namesById)}` };
+
+    case "lead_converted":
+      return { isHuman: false, text: "Dikonversi menjadi customer" };
+
+    case "task_created": {
+      const title = str("title");
+      return { isHuman: false, text: title ? `Task dibuat: ${title}` : "Task dibuat" };
+    }
+
+    case "task_completed":
+      return { isHuman: false, text: "Task diselesaikan" };
+
+    case "note_added":
+      return {
+        isHuman: true,
+        text: activity.body ?? "",
+        authorName: memberName(activity.actor_membership_id, namesById),
+      };
+    case "call_logged":
+      return {
+        isHuman: true,
+        text: activity.body ?? "",
+        authorName: memberName(activity.actor_membership_id, namesById),
+      };
+    case "whatsapp_opened":
+      return {
+        isHuman: true,
+        text: activity.body ?? "",
+        authorName: memberName(activity.actor_membership_id, namesById),
+      };
+  }
+}
+
+export function lostReasonDisplayLabel(reason: LostReason | null): string | null {
+  return reason ? LOST_REASON_LABELS[reason] : null;
+}

--- a/crm_dashboard/src/lib/auth-errors.ts
+++ b/crm_dashboard/src/lib/auth-errors.ts
@@ -51,3 +51,19 @@ export function globalMessage(err: unknown): string {
   if (err instanceof ApiError) return err.message;
   return "Terjadi kesalahan. Coba lagi.";
 }
+
+// version_conflict (409, Aturan #35) — crm_be sends the row's CURRENT
+// state in error.current so the screen can reload it without a second
+// request. This is the ONE place in the product a save must never
+// silently overwrite: the caller is required to show the conflict and
+// let the user choose, never retry with the old version automatically.
+export function versionConflictCurrent<T>(err: unknown): T | null {
+  if (err instanceof ApiError && err.code === "version_conflict") {
+    return (err.body.current as T) ?? null;
+  }
+  return null;
+}
+
+export function isLeadAlreadyConverted(err: unknown): boolean {
+  return err instanceof ApiError && err.code === "lead_already_converted";
+}

--- a/crm_dashboard/src/lib/lead-status.test.ts
+++ b/crm_dashboard/src/lib/lead-status.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { LEAD_STATUSES, type LeadStatus } from "./labels";
+import { isValidStatusTransition, statusTransitionOptions } from "./lead-status";
+
+// This is the literal transition matrix from
+// crm_be/internal/lead/usecase.go's validateStatusTransition, worked out
+// by hand from the Go source (docs/phases/02-crm-core/td.md §5 + the
+// documented "leaving lost" deviation) — not derived from
+// isValidStatusTransition itself, so a bug that breaks BOTH the same way
+// can't hide.
+const EXPECTED_VALID: Record<LeadStatus, LeadStatus[]> = {
+  new: ["contacted", "lost", "unqualified", "spam"],
+  contacted: ["new", "qualified", "lost", "unqualified", "spam"],
+  qualified: ["contacted", "proposal", "lost", "unqualified", "spam"],
+  proposal: ["qualified", "won", "lost", "unqualified", "spam"],
+  won: ["proposal", "lost", "unqualified", "spam"],
+  // "leaving lost" is a documented backend simplification: ANY main-path
+  // status is valid, not just the one the lead was in before — there's
+  // no cheap way to know "before" without activity history (crm_be #20
+  // notes). unqualified/spam are also reachable directly from lost.
+  lost: ["new", "contacted", "qualified", "proposal", "won", "unqualified", "spam"],
+  unqualified: [],
+  spam: [],
+};
+
+describe("isValidStatusTransition", () => {
+  it("matches the full matrix for every (from, to) pair — including same-status", () => {
+    for (const from of LEAD_STATUSES) {
+      for (const to of LEAD_STATUSES) {
+        const expected = to === from ? to === "lost" : EXPECTED_VALID[from].includes(to);
+        expect(
+          isValidStatusTransition(from, to),
+          `${from} -> ${to} expected ${expected}`
+        ).toBe(expected);
+      }
+    }
+  });
+
+  it("unqualified and spam are final — no outgoing transition at all, not even to themselves", () => {
+    for (const to of LEAD_STATUSES) {
+      expect(isValidStatusTransition("unqualified", to)).toBe(false);
+      expect(isValidStatusTransition("spam", to)).toBe(false);
+    }
+  });
+
+  it("main path movement is exactly one step in either direction", () => {
+    expect(isValidStatusTransition("qualified", "contacted")).toBe(true); // back
+    expect(isValidStatusTransition("qualified", "proposal")).toBe(true); // forward
+    expect(isValidStatusTransition("proposal", "new")).toBe(false); // two steps back
+    expect(isValidStatusTransition("new", "won")).toBe(false); // skips ahead
+  });
+});
+
+describe("statusTransitionOptions", () => {
+  it("offers nothing for the two final statuses", () => {
+    expect(statusTransitionOptions("unqualified")).toEqual([]);
+    expect(statusTransitionOptions("spam")).toEqual([]);
+  });
+
+  it("offers only both main-path neighbors plus the three side exits for a middle status", () => {
+    const options = statusTransitionOptions("qualified");
+    expect(options.map((o) => o.status).sort()).toEqual(
+      ["contacted", "proposal", "lost", "unqualified", "spam"].sort()
+    );
+  });
+
+  it("offers only forward, no backward, for the first main-path status", () => {
+    const options = statusTransitionOptions("new");
+    const steps = options.filter((o) => o.kind === "step");
+    expect(steps.map((o) => o.status)).toEqual(["contacted"]);
+  });
+
+  it("offers only backward, no forward, for the last main-path status", () => {
+    const options = statusTransitionOptions("won");
+    const steps = options.filter((o) => o.kind === "step");
+    expect(steps.map((o) => o.status)).toEqual(["proposal"]);
+  });
+
+  it('restricts "lost" to a single reopen-to-"new" option, not all 5 valid main-path targets', () => {
+    // isValidStatusTransition allows lost -> any main-path status; the UI
+    // deliberately narrows this to avoid a wall of buttons for a rare
+    // case. This test locks that narrowing as intentional.
+    const options = statusTransitionOptions("lost");
+    expect(options).toHaveLength(1);
+    expect(options[0].status).toBe("new");
+  });
+
+  it("every option returned is actually valid per isValidStatusTransition", () => {
+    for (const from of LEAD_STATUSES) {
+      for (const option of statusTransitionOptions(from)) {
+        expect(isValidStatusTransition(from, option.status)).toBe(true);
+      }
+    }
+  });
+});

--- a/crm_dashboard/src/lib/lead-status.ts
+++ b/crm_dashboard/src/lib/lead-status.ts
@@ -1,0 +1,85 @@
+// Which status transitions the UI offers. Mirrors
+// crm_be/internal/lead/usecase.go's validateStatusTransition EXACTLY —
+// this is NOT the Claude Design mockup's simplified TRANSITIONS map
+// (which, e.g., only lets "lost" reopen to "new"). Issue #33's
+// acceptance criterion is "transisi yang tidak sah tidak ditawarkan di
+// UI"; a button that the backend then rejects is a worse failure than
+// one the UI never shows.
+import { STATUS_META, type LeadStatus } from "./labels";
+
+const MAIN_PATH: LeadStatus[] = ["new", "contacted", "qualified", "proposal", "won"];
+const SIDE_EXITS: LeadStatus[] = ["lost", "unqualified", "spam"];
+
+function mainPathIndex(status: LeadStatus): number {
+  return MAIN_PATH.indexOf(status);
+}
+
+// Line-for-line port of the Go function of the same name.
+export function isValidStatusTransition(from: LeadStatus, to: LeadStatus): boolean {
+  if (from === "unqualified" || from === "spam") return false;
+  if (to === from) return to === "lost";
+  if (to === "unqualified" || to === "spam" || to === "lost") return true;
+
+  const toIdx = mainPathIndex(to);
+  if (toIdx === -1) return false;
+  if (from === "lost") return true;
+
+  const fromIdx = mainPathIndex(from);
+  if (fromIdx === -1) return false;
+  const diff = toIdx - fromIdx;
+  return diff === 1 || diff === -1;
+}
+
+export interface StatusTransitionOption {
+  status: LeadStatus;
+  label: string;
+  /** "step" = adjacent on the main path (accent-styled); "exit" = a side terminal (neutral-styled). */
+  kind: "step" | "exit";
+}
+
+// The backend allows "lost" to reopen to ANY main-path status (a
+// documented simplification from TD phase 2 §5's ideal "one step back
+// to whatever it was before" — crm_be issue #20's notes: not
+// implementable without activity history). Offering all five as buttons
+// would be a wall of options for a case that's actually rare; the
+// design's own choice — reopen to "Baru" only — is the sensible default
+// and is unconditionally valid per the rule above, so it's kept here
+// rather than re-litigated.
+export function statusTransitionOptions(from: LeadStatus): StatusTransitionOption[] {
+  if (from === "lost") {
+    return [
+      {
+        status: "new",
+        label: `→ Buka kembali ke ${STATUS_META.new.label}`,
+        kind: "step",
+      },
+    ];
+  }
+
+  const options: StatusTransitionOption[] = [];
+  const idx = mainPathIndex(from);
+  if (idx !== -1) {
+    if (idx - 1 >= 0) {
+      const prev = MAIN_PATH[idx - 1];
+      options.push({ status: prev, label: `→ ${STATUS_META[prev].label}`, kind: "step" });
+    }
+    if (idx + 1 < MAIN_PATH.length) {
+      const next = MAIN_PATH[idx + 1];
+      options.push({ status: next, label: `→ ${STATUS_META[next].label}`, kind: "step" });
+    }
+  }
+
+  for (const exit of SIDE_EXITS) {
+    if (isValidStatusTransition(from, exit)) {
+      options.push({ status: exit, label: STATUS_META[exit].label, kind: "exit" });
+    }
+  }
+  return options;
+}
+
+// TD phase 3 §5 / issue #33: konversi hanya ditawarkan saat status
+// "won" — checked here once so the button and any future call site
+// agree, rather than each re-typing the string literal.
+export function canConvertLead(status: LeadStatus): boolean {
+  return status === "won";
+}

--- a/crm_dashboard/src/lib/leads.ts
+++ b/crm_dashboard/src/lib/leads.ts
@@ -80,3 +80,72 @@ export function createLead(input: CreateLeadInput): Promise<Lead> {
     },
   });
 }
+
+export function getLead(id: string, signal?: AbortSignal): Promise<Lead> {
+  return apiFetch<Lead>(`/v1/leads/${id}`, { signal });
+}
+
+// Every write below requires `version` — the value read from the Lead
+// currently on screen, sent back unchanged (TD §6). A form that forgets
+// it works exactly once, then fails 409 on every subsequent save.
+
+export interface UpdateLeadInput {
+  version: number;
+  name?: string;
+  email?: string | null;
+  phone?: string | null;
+  company?: string | null;
+  notes?: string | null;
+}
+
+export function updateLead(id: string, input: UpdateLeadInput): Promise<Lead> {
+  return apiFetch<Lead>(`/v1/leads/${id}`, { method: "PATCH", body: input });
+}
+
+export function updateLeadStatus(
+  id: string,
+  input: { version: number; status: LeadStatus; lostReason?: LostReason }
+): Promise<Lead> {
+  return apiFetch<Lead>(`/v1/leads/${id}/status`, {
+    method: "PATCH",
+    body: { version: input.version, status: input.status, lost_reason: input.lostReason },
+  });
+}
+
+// assignedToMembershipId: null explicitly unassigns — "melepas" per the
+// checklist — undefined would simply omit the field, which the backend
+// would treat as "don't touch" instead.
+export function updateLeadAssignment(
+  id: string,
+  input: { version: number; assignedToMembershipId: string | null }
+): Promise<Lead> {
+  return apiFetch<Lead>(`/v1/leads/${id}/assignment`, {
+    method: "PATCH",
+    body: { version: input.version, assigned_to_membership_id: input.assignedToMembershipId },
+  });
+}
+
+export function deleteLead(id: string): Promise<void> {
+  return apiFetch<void>(`/v1/leads/${id}`, { method: "DELETE" });
+}
+
+export interface Customer {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  phone_e164: string | null;
+  company: string | null;
+  notes: string | null;
+  converted_from_lead_id: string;
+  converted_by_membership_id: string | null;
+  converted_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// Only offered when status === "won" (TD §12, checked by the caller via
+// canConvertLead in @/lib/lead-status — not duplicated here).
+export function convertLead(id: string): Promise<Customer> {
+  return apiFetch<Customer>(`/v1/leads/${id}/convert`, { method: "POST" });
+}

--- a/crm_dashboard/src/lib/tasks.ts
+++ b/crm_dashboard/src/lib/tasks.ts
@@ -1,0 +1,76 @@
+// Typed wrapper for /v1/leads/{id}/tasks and /v1/tasks/{id} — shape
+// verified against crm_be/internal/task/handler_http.go's taskJSON.
+import { apiFetch } from "./api-client";
+
+export type TaskStatus = "open" | "done";
+
+export interface Task {
+  id: string;
+  lead_id: string;
+  title: string;
+  description: string | null;
+  due_at: string | null;
+  status: TaskStatus;
+  assigned_to_membership_id: string | null;
+  completed_at: string | null;
+  completed_by_membership_id: string | null;
+  version: number;
+  created_by_membership_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export function listTasksByLead(leadId: string, signal?: AbortSignal): Promise<Task[]> {
+  return apiFetch<Task[]>(`/v1/leads/${leadId}/tasks`, { signal });
+}
+
+export interface CreateTaskInput {
+  title: string;
+  description?: string;
+  dueAt?: string;
+  assignedToMembershipId?: string;
+}
+
+export function createTask(leadId: string, input: CreateTaskInput): Promise<Task> {
+  return apiFetch<Task>(`/v1/leads/${leadId}/tasks`, {
+    method: "POST",
+    body: {
+      title: input.title,
+      description: input.description || undefined,
+      due_at: input.dueAt || undefined,
+      assigned_to_membership_id: input.assignedToMembershipId || undefined,
+    },
+  });
+}
+
+export interface UpdateTaskInput {
+  version: number;
+  title?: string;
+  description?: string;
+  dueAt?: string;
+  assignedToMembershipId?: string | null;
+}
+
+export function updateTask(id: string, input: UpdateTaskInput): Promise<Task> {
+  return apiFetch<Task>(`/v1/tasks/${id}`, {
+    method: "PATCH",
+    body: {
+      version: input.version,
+      title: input.title,
+      description: input.description,
+      due_at: input.dueAt,
+      assigned_to_membership_id: input.assignedToMembershipId,
+    },
+  });
+}
+
+export function completeTask(id: string, version: number): Promise<Task> {
+  return apiFetch<Task>(`/v1/tasks/${id}/complete`, {
+    method: "POST",
+    body: { version },
+  });
+}
+
+export function deleteTask(id: string): Promise<void> {
+  return apiFetch<void>(`/v1/tasks/${id}`, { method: "DELETE" });
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 26 Agustus 2026 — Issue #32 selesai (daftar lead: filter, pencarian, pagination)
-**Phase sekarang:** Phase 3 — Owner Dashboard (4/7 issue selesai — #40 ditambahkan setelah hasil desain masuk)
+**Last updated:** 26 Agustus 2026 — Issue #33 selesai (detail lead: timeline, activity, task, status, assignment, konversi)
+**Phase sekarang:** Phase 3 — Owner Dashboard (5/7 issue selesai — #40 ditambahkan setelah hasil desain masuk)
 
 ---
 
@@ -38,6 +38,7 @@
 | **Issue #31 — Setup Next.js, klien API, sesi, auth UI** | — | 3 | `crm_dashboard/` dari `README.md` saja menjadi aplikasi utuh — Next.js App Router + TypeScript + Tailwind v4 + shadcn/ui (`components.json` dengan `registries: {}` kosong, tanpa registry privat). `src/lib/api-client.ts`: `credentials:'include'`, `X-CSRF-Token` di setiap non-GET, dan **refresh single-flight** — satu `refreshPromise` modul-level yang ditetapkan sinkron sebelum `await` apa pun, sehingga request paralel yang 401 bersamaan memakai ulang Promise yang sama, bukan masing-masing memanggil refresh sendiri. Route group `(auth)` vs `(protected)` — layar protected memanggil `GET /v1/me` di layout-nya (`SessionGate`), **tanpa** `middleware.ts` (tidak bisa baca token `HttpOnly`). 5 layar auth (login, register, verifikasi email, lupa/reset password) + pilih organization (`409 organization_selection_required`, ADR-007) ditangani inline di form login, bukan route terpisah. Test runner **Vitest** (dikonfirmasi pemilik produk) — 6 test di `api-client.test.ts`, termasuk **test konkurensi genuine** (refresh sengaja ditahan lewat `deferred()` sampai 6 panggilan paralel semuanya mencapai titik single-flight) yang membuktikan tepat 1 panggilan `/v1/auth/refresh`, diulang 5× tanpa flaky. Kontrak backend (`src/lib/auth.ts`) dibangun dari pembacaan literal `crm_be/internal/auth/*.go`, **diverifikasi end-to-end lewat `curl`** terhadap `crm_be` sungguhan (register → verify → login → cookie flags persis benar → CSRF terbukti aktif → logout) — bukan diasumsikan dari baca kode saja. `.github/workflows/ci-dashboard.yml` baru (`paths: crm_dashboard/**`). **Phase 3 sekarang punya UI** — #32 (daftar lead) bisa mulai. |
 | **Issue #40 — Fondasi desain: token warna, label Indonesia, app shell** | — | 3 | **Issue di luar rencana awal**, dibuka setelah hasil Claude Design masuk: desainnya mencakup ~15 layar (seluruh #32–#35) sementara token, label, dan kerangka aplikasi dipakai bersama dan tidak dimiliki satu pun dari mereka (design brief §7.6 sudah menandainya "belum ada dan dibutuhkan"). Hasil desain dibaca lewat `DesignSync` dari project `5ac090ad`. **Aksen desain gagal WCAG AA dan diperbaiki, bukan disalin apa adanya**: `oklch(0.58 0.19 41)` dipakai sebagai latar tombol dengan teks putih 14px = **4.45:1**, di bawah ambang 4.5:1 — diturunkan ke `oklch(0.56 0.19 41)` (**4.83:1**, `#D14400`→`#CA3C00`, tak terlihat mata). **Lima dari delapan badge status juga gagal**, terburuk `proposal` **3.14:1** → 4.55:1; diperbaiki dengan menurunkan *lightness* saja sehingga hue/chroma desain dan tampilan badge tetap sebagaimana digambar. Dua token aksen dipisah karena tugasnya berlawanan: `--primary` (0.56) untuk putih-di-atas-warna, `--accent-strong` (0.48, 7.04:1) untuk warna-di-atas-putih. `src/lib/labels.ts` baru — 8 status + 6 alasan kalah + 4 sumber + 4 role, satu tempat supaya tidak ada layar yang menuliskan ulang peta yang sama. Label nav desain ("Home"/"Task"/"Settings") **diterjemahkan** jadi Beranda/Tugas/Pengaturan (acceptance criterion #12); "Lead"/"Customer" tetap karena keduanya istilah `glossary.md` — dikunci test. Logika nav (`isActive`/`pageTitle`) dipisah ke `lib/nav.ts` agar bisa diuji tanpa merender React — jebakannya nyata (prefix-match naif membuat `/` aktif di setiap halaman). **Bug font sejak #31 diperbaiki**: `--font-sans` menunjuk dirinya sendiri sehingga Geist tidak pernah diterapkan; dibuktikan dari CSS hasil build. 9 test baru (15 total). Lima halaman placeholder bertanggal, masing-masing menyebut issue penggantinya. |
 | **Issue #32 — Daftar lead: filter, pencarian, pagination** | — | 3 | Layar traffic tertinggi di seluruh produk (freeze 3.2). URL adalah sumber kebenaran filter (`useSearchParams` + `router.replace`); setiap perubahan filter mereset `page` ke 1. Kata kunci di-debounce 300ms; `AbortController` di setiap fetch (leads, memberships, metrics) mencegah respons lambat untuk filter yang ditinggalkan menimpa yang baru. **Bug nyata ditemukan saat verifikasi terhadap `crm_be` sungguhan**: `GET /v1/metrics/summary`'s `by_status` adalah Go map — status dengan nol lead **dihilangkan dari JSON**, bukan dikirim `0`; kode naif (`summary?.by_status[status] ?? "…"`) akan menampilkan "…" **selamanya** untuk status yang belum pernah dipakai, tak bisa dibedakan dari sedang memuat. Diperbaiki dengan fungsi murni `statusCount()` di `lib/metrics.ts` yang memisahkan "summary belum dimuat" dari "key tidak ada di summary yang sudah dimuat" — dikunci test yang membangun ulang response asli sebagai fixture. `loading` adalah *derived state* (`loadedKey !== requestKey`), bukan `setState` sinkron di effect — ESLint rule `react-hooks/set-state-in-effect` (baru di toolchain React 19) menolaknya. Hitungan chip status/tanpa-pemilik dari `GET /v1/metrics/summary`, di-scope periode saja (bukan dipersempit sumber/pemilik/kata kunci — satu request untuk delapan angka, didokumentasikan sebagai simplifikasi sadar). Kolom Pemilik diselesaikan di klien: `leadJSON` backend hanya kirim `assigned_to_membership_id`, di-lookup lewat `GET /v1/memberships` yang diambil sekali. Baris tabel **sengaja tidak bisa diklik** — issue eksplisit "detail lead belum ada di sini" (#33). `source` selalu `"manual"` saat buat lead dari layar ini. Badge nav "Lead" (kosong sejak #40) tersambung ke jumlah lead tanpa pemilik aktif. Logika murni dipisah & diuji mengikuti pola `lib/nav.ts`: `lib/lead-filters.ts`, `lib/date.ts`, `buildQuery` di `lib/leads.ts`. 18 test baru (33 total). Diverifikasi lewat `curl` terhadap `crm_be` sungguhan dengan 5 lead nyata (status/assignment/pencarian semua menghasilkan `meta.total` yang benar) — bukan hanya lewat mock. |
+| **Issue #33 — Detail lead: timeline, activity, task, status, assignment, konversi** | — | 3 | Layar dengan hampir seluruh aksi tulis produk. **Logika transisi status desain adalah simplifikasi prototipe yang TIDAK diikuti** — `lib/lead-status.ts`'s `isValidStatusTransition` ditulis ulang sebagai port baris-demi-baris dari `validateStatusTransition` Go (backend membolehkan keluar dari `lost` ke seluruh 5 status jalur utama, bukan cuma "Baru" seperti mockup), diuji terhadap matriks lengkap 8×8 yang ditulis tangan dari TD, terpisah dari implementasinya. Satu penyempitan dipertahankan sadar: UI tetap hanya menawarkan "→ Buka kembali ke Baru" untuk `lost` (bukan kelima opsi yang backend benarkan) — sah karena acceptance criterion melarang menawarkan yang *tidak sah*, bukan mewajibkan menawarkan *semua* yang sah; dikunci test. Bentuk metadata activity untuk 10 tipe diverifikasi terhadap `crm_be` sungguhan lewat siklus hidup lead penuh — `lead_created` metadata ternyata `null` (bukan berisi source seperti dugaan), `task_completed` tidak membawa `title` (beda dari `task_created`) — keduanya dikunci test di `activity-text.test.ts` supaya asumsi salah tidak lolos diam-diam. **Dua bagian tidak ada di mockup sama sekali**, ditambahkan karena checklist mewajibkan: form edit field umum (`edit-lead-dialog.tsx`) dan form buat task (`new-task-dialog.tsx` — kode sumber desain sendiri membuat task hardcode tanpa form, ditandai "visual only"). `ConflictDialog` satu tempat untuk status/assignment/edit — tombol "Muat ulang" memicu refetch penuh, tidak pernah menerapkan `error.current` otomatis (Aturan #35). `EditLeadDialog` di-*remount* lewat `key={lead.id}-${lead.version}`, bukan `useEffect`+`setState` (pola yang sama seperti `loading` di #32 untuk lolos `react-hooks/set-state-in-effect`). Tombol Konversi hilang berdasar `activities.some(type==='lead_converted')`, bukan cuma `status==='won'` (Lead tidak punya flag "sudah dikonversi"). Hapus lead & Konversi disembunyikan untuk Manager (RBAC Owner/Admin saja). Dropdown penugasan **tidak** memfilter Employee (beda dari mockup) — Employee justru target assignment paling wajar. 18 test baru (54 total). Diverifikasi lewat `curl` terhadap `crm_be` sungguhan — status lengkap `new→...→won`, `lost` tanpa alasan ditolak `400`, convert dua kali → `409 lead_already_converted`, dan **`version` basi memicu `409 version_conflict` dengan `error.current` berbentuk persis `Lead`** — dibuktikan langsung, bukan diasumsikan. |
 
 ---
 
@@ -49,25 +50,26 @@ _(kosong)_
 
 ## Berikutnya
 
-**Issue #33 — Detail lead: timeline, activity, task, status, assignment, konversi** (`crm_dashboard`)
+**Issue #34 — Tim: anggota, undangan, penonaktifan, notifikasi** (`crm_dashboard`)
 
-- Cakupan & acceptance: [issue #33](https://github.com/Pravasta/jualin-crm/issues/33)
-- TD: `docs/phases/03-owner-dashboard/td.md` §5, §6, §8
-- Layar traffic tertinggi kedua, dan tempat **hampir seluruh aksi tulis** produk berada. Seluruh
-  endpoint sudah ada sejak #20–#23 — issue ini membangun layarnya, tidak menambah endpoint.
-- Baris tabel di `/leads` **belum navigasi kemana pun** (sengaja, per batas #32) — sambungkan ke
-  `/leads/{id}` saat halaman ini ada, dan hapus komentar terkait di `leads-list.tsx`.
-- **`version` wajib ikut terkirim di setiap form edit** (lead dan task), TD §6 — lupa membawanya bekerja
-  tepat sekali lalu gagal `409` di setiap penyimpanan berikutnya.
-- **`409 version_conflict` → tampilkan konflik, muat ulang dari `error.current`, JANGAN PERNAH menimpa
-  otomatis** (Aturan #35) — satu-satunya tempat pengguna harus memilih secara sadar.
-- `auth-errors.ts` belum menangani `version_conflict` — tambahkan handler-nya di issue ini, saat
-  layar yang pertama benar-benar membutuhkannya.
-- `STATUS_META`/`LOST_REASON_LABELS` di `lib/labels.ts` (dari #40) sudah siap untuk pilihan transisi
-  status dan alasan `lost`.
-- Desain layar ini ada di project `5ac090ad` (`DesignSync` → `get_file`), bagian
-  `<!-- ===== LEAD DETAIL ===== -->`.
-- Berurutan: #30 ✅ → #31 ✅ → #40 ✅ → #32 ✅ → #33 → #34 → #35. Rincian di
+- Cakupan & acceptance: [issue #34](https://github.com/Pravasta/jualin-crm/issues/34)
+- TD: `docs/phases/03-owner-dashboard/td.md` §5, §8
+- Area admin, tetapi **satu-satunya layar dengan percabangan keputusan sungguhan** di Phase 3: alur
+  penonaktifan anggota tiga cabang (`membership_has_open_leads`, `?on_open_leads=unassign|reassign`).
+- **Jangan sederhanakan penonaktifan jadi dialog "Yakin? [Ya]/[Batal]"** — lead yang tetap ter-assign
+  ke anggota yang tidak bisa login lagi tidak muncul di daftar siapa pun **dan tidak tertangkap filter
+  "belum ter-assign"** (freeze 2.3). Design brief §8.1 dan issue body membahasnya panjang lebar.
+- `ConflictDialog` (dari #33) generik — dapat dipakai ulang bila layar ini butuh (kecil kemungkinan,
+  memberships tidak punya optimistic locking).
+- Pola dialog multi-tahap (pilih opsi → tampilkan sub-form kondisional) sudah ada presedennya di
+  `LostReasonDialog` (#33) — bentuk serupa untuk memilih `unassign`/`reassign`.
+- Halaman terima undangan (`GET /v1/invitations/token/{token}` → `POST /v1/invitations/accept`) adalah
+  route **publik** (`OptionalMiddleware`, bukan `SessionGate`) — dua cabang: user baru vs sudah login.
+  Ini satu-satunya layar Phase 3 di luar `(protected)`/`(auth)` yang sudah ada.
+- Desain layar ini ada di project `5ac090ad` (`DesignSync` → `get_file`), bagian yang relevan sudah
+  sempat terlihat sekilas saat #33 (dialog undang anggota & penonaktifan) — baca ulang penuh sebelum
+  implementasi, jangan andalkan potongan lama.
+- Berurutan: #30 ✅ → #31 ✅ → #40 ✅ → #32 ✅ → #33 ✅ → #34 → #35. Rincian di
   `docs/phases/03-owner-dashboard/issues.md`.
 
 ---

--- a/docs/phases/03-owner-dashboard/notes.md
+++ b/docs/phases/03-owner-dashboard/notes.md
@@ -416,3 +416,158 @@ Terhadap crm_be sungguhan (docker compose + migrate, organization baru "Toko Lea
   refactor teknis.
 - `apiFetchList`/`buildQuery` di `lib/leads.ts` adalah pola yang akan dipakai ulang oleh `/customers`
   dan `/tasks` (#35) — keduanya endpoint list berpaginasi dengan bentuk yang sama.
+
+---
+
+## #33 — Detail lead: timeline, activity, task, status, assignment, konversi
+
+Layar dengan **hampir seluruh aksi tulis produk**. Dibangun dari `<!-- ===== LEAD DETAIL ===== -->`
+project `5ac090ad` (dibaca ulang dari awal, bukan cache — ukurannya tetap 111022 byte, tidak ada
+perubahan sejak #32).
+
+### Logika transisi status di mockup adalah simplifikasi prototipe — TIDAK diikuti apa adanya
+
+Ini temuan paling penting di issue ini. Kode sumber desain punya `TRANSITIONS`/`FINAL_EXITS` sendiri
+yang **berbeda** dari backend sungguhan pada satu kasus: keluar dari status `lost`. Backend
+(`validateStatusTransition` di `internal/lead/usecase.go`) membolehkan `lost` pindah ke **kelima**
+status jalur utama (penyimpangan terdokumentasi dari TD Phase 2 §5 — lihat notes issue #20: "satu
+langkah tepat" tidak bisa ditegakkan tanpa riwayat activity), sementara mockup hanya menawarkan satu
+tombol "→ Buka kembali ke Baru".
+
+Karena acceptance criterion issue ini eksplisit — *"transisi status yang tidak sah tidak ditawarkan di
+UI"* — logikanya **ditulis ulang sebagai port baris-demi-baris dari fungsi Go**, bukan disalin dari
+mockup: `lib/lead-status.ts`'s `isValidStatusTransition(from, to)`. Diuji terhadap **matriks lengkap**
+(`lead-status.test.ts`, seluruh 8×8 pasangan status), ditulis tangan dari TD, bukan diturunkan dari
+fungsi yang sama yang diuji — supaya bug yang merusak keduanya dengan cara yang sama tidak bisa
+bersembunyi.
+
+**Satu penyempitan disengaja dipertahankan dari mockup**: untuk `lost`, hanya satu tombol "→ Buka
+kembali ke Baru" yang ditawarkan, bukan kelima status yang backend benarkan. Backend membolehkan lebih
+banyak; UI menawarkan lebih sedikit — itu sah (acceptance criterion melarang menawarkan yang **tidak
+sah**, tidak mewajibkan menawarkan **semua** yang sah), dan menghindari lima tombol untuk kasus yang
+jarang terjadi. Dikunci test (`statusTransitionOptions("lost")` harus tepat satu opsi) supaya
+penyempitan ini terlihat sebagai keputusan, bukan bug yang kebetulan cocok.
+
+### Bentuk metadata activity diverifikasi langsung dari `crm_be` sungguhan, bukan ditebak dari desain
+
+Mockup punya akses langsung ke object `lead`/`task` JavaScript-nya sendiri untuk menyusun teks timeline
+(`a.text` sudah jadi). API sungguhan tidak mengirim teks jadi — hanya `type` + `metadata` mentah. Setiap
+bentuk metadata dibaca dari `internal/{lead,task,customer}/usecase.go`'s pemanggilan `Activity.Record`,
+lalu **dibuktikan lagi** lewat lead sungguhan yang dijalankan melalui seluruh siklus hidupnya (buat →
+ubah status → assign → catat 3 tipe catatan → buat task → selesaikan task → convert):
+
+```
+lead_created      metadata: null                          — TIDAK seperti dugaan awal, tidak ada source
+status_changed    {"from":"new","to":"contacted"}          — cocok
+lead_assigned     {"to":"<id>","from":null}                — from eksplisit null saat pertama kali, bukan absen
+lead_unassigned   {"from":"<id>"}                          — (tidak diuji ulang di sesi ini, sudah diverifikasi #22)
+lead_converted    {"customer_id":"<id>"}                   — cocok
+task_created      metadata via endpoint task, bukan activity langsung — {"task_id","title"}
+task_completed    {"task_id":"<id>"}                       — TANPA title, beda dari task_created
+```
+
+`lead_created` metadata **null** berarti teks timeline-nya statis ("Lead dibuat") — sumber lead sudah
+terlihat di header, jadi tidak perlu di-plumbing ulang hanya untuk satu baris timeline. `task_completed`
+**tidak** membawa title (beda dari `task_created`) — kalau kode mengasumsikan keduanya simetris, hasilnya
+"undefined" di layar. Dikunci test eksplisit di `activity-text.test.ts`.
+
+Fungsi murni `activityToTimelineEntry(activity, namesById)` di `lib/activity-text.ts` — menerima
+`Map<membership_id, full_name>` yang sama dibangun dari `GET /v1/memberships` (dipakai lagi, sama seperti
+kolom Pemilik di #32). Membership yang sudah dinonaktifkan (tidak ada di map) → "Anggota yang sudah
+tidak aktif", bukan crash atau `undefined` — riwayat lama tetap harus terbaca meski pelakunya sudah
+tidak aktif.
+
+### Dua bagian layar yang **tidak ada di mockup sama sekali**, ditambahkan karena checklist mewajibkannya
+
+- **Form edit field umum** (nama/email/telepon/perusahaan/catatan). Section LEAD DETAIL desain hanya
+  punya header read-only + tombol aksi — tidak ada form edit di manapun. Checklist eksplisit: *"Ubah
+  field umum (`PATCH /v1/leads/{id}`) — membawa `version`"*. Ditambahkan sebagai dialog terpisah
+  (`edit-lead-dialog.tsx`), mengikuti pola modal yang sudah ada.
+- **Form buat task**. `onAddLeadTask` di kode sumber desain literal membuat task dengan judul hardcode
+  `"Task baru"` tanpa form apa pun (`// visual only` menurut komentar mockup sendiri). Dunia nyata butuh
+  minimal judul. `new-task-dialog.tsx` ditambahkan mengikuti pola `new-lead-dialog.tsx` dari #32.
+
+### Keputusan implementasi
+
+- **Konflik penyimpanan (`ConflictDialog`) satu tempat untuk semua aksi pada lead** — status, assignment,
+  edit field umum. Ketiganya memicu dialog yang sama; tombol "Muat ulang data terkini" memicu refetch
+  penuh (lead+activities+tasks+members), **bukan** langsung menerapkan `error.current` — pengguna harus
+  mengklik dulu, sesuai Aturan #35 ("tidak pernah menimpa otomatis" berarti juga tidak pernah *menerima*
+  keadaan baru tanpa aksi sadar, bukan hanya soal tidak mengirim ulang data lama).
+- **Konflik pada task diberi perlakuan lebih ringan** — pesan inline + refetch otomatis, bukan modal
+  terpisah. Task adalah objek turunan dengan taruhan lebih rendah daripada lead itu sendiri; menambah
+  modal kedua untuk kasus yang sama akan menggandakan pola tanpa menambah kejelasan.
+- **`EditLeadDialog` di-*remount* lewat `key`, bukan `useEffect` + `setState`.** ESLint
+  `react-hooks/set-state-in-effect` (sama seperti #32) menolak sinkronisasi form dari prop via effect.
+  Diselesaikan dengan memisahkan form ke komponen `EditLeadForm` yang di-`key`-kan
+  `${lead.id}-${lead.version}` — setiap kali dialog dibuka dengan `lead` yang mungkin sudah berbeda
+  (mis. setelah reload dari konflik), React me-remount komponennya dan `useState(lead.name)` dkk.
+  otomatis mendapat nilai segar. Cara yang direkomendasikan React sendiri untuk "reset state saat prop
+  berubah", bukan sekadar menghindari lint.
+- **Tombol "Konversi menjadi customer" hilang setelah konversi sungguhan terjadi**, bukan hanya
+  berdasarkan `status==='won'`. Entity `Lead` tidak punya flag "sudah dikonversi" (itu ada di
+  `Customer.converted_from_lead_id`, TD §12 — lead sendiri tidak pernah berubah oleh konversi). Sinyalnya
+  diambil dari timeline: `activities.some(a => a.type === 'lead_converted')`.
+- **Dropdown penugasan menyertakan SEMUA anggota**, tidak memfilter role `employee` seperti mockup
+  (`MEMBERS.filter(m => m.role !== 'employee')`). Backend tidak membatasi assignee berdasarkan role
+  (`fk_leads_assignee` tidak punya constraint role), dan Employee justru target assignment paling wajar
+  di produk sungguhan — mereka yang menindaklanjuti lead lewat mobile (Phase 5). Memfilter mereka keluar
+  akan salah, bukan sekadar beda gaya dari mockup.
+- **Hapus lead & Konversi disembunyikan untuk role Manager** di UI (`ActionLeadDelete`/`ActionLeadConvert`
+  = Owner/Admin saja, `docs/architecture/authorization.md`). UI tidak menawarkan aksi yang pasti ditolak
+  backend — otorisasi sungguhan tetap di backend, tidak diduplikasi di klien.
+- **Checkbox task hanya satu arah** (buka → selesai). Tidak ada endpoint "buka kembali task" di backend;
+  checkbox yang sudah tercentang di-`disabled`, bukan berpura-pura bisa diklik ulang.
+- **`onShowConflictPattern` dari mockup tidak diimplementasikan** — itu tombol demo prototipe murni
+  ("Pola desain: konflik penyimpanan →") untuk memamerkan `ConflictDialog` tanpa aksi nyata di baliknya.
+  Produk sungguhan memicu dialog yang sama itu dari kegagalan `409` asli, bukan dari tombol demo.
+
+### Verifikasi
+
+```
+npm run typecheck · lint · test · build   → bersih; exit code diperiksa (bukan hanya `tail`)
+npm run test                                → 54/54 PASS (18 baru: lead-status × 2 file, activity-text)
+
+Terhadap crm_be sungguhan (docker compose + migrate, organization baru "Toko Lead33"), SETIAP endpoint
+yang disentuh layar ini, dengan bentuk request PERSIS yang dikirim lib/*.ts:
+  PATCH .../status new→contacted                          200
+  PATCH .../assignment ke diri sendiri                     200
+  POST .../activities × 3 (note_added, call_logged, whatsapp_opened)   201 × 3
+  POST .../tasks (title+description+due_at+assignee)       201, bentuk cocok persis tipe Task
+  POST /v1/tasks/{id}/complete                             200
+  PATCH /v1/leads/{id} (name/email/phone/company/notes)    200, seluruh field tersimpan benar
+  PATCH .../status TANPA lost_reason saat status=lost       400 (divalidasi backend, bukan cuma UI)
+  PATCH .../status DENGAN lost_reason=price                200
+  PATCH .../status lost→new (reopen)                       200
+  new→contacted→qualified→proposal→won (jalur penuh)        200 × 4
+  POST /v1/leads/{id}/convert                               201
+  POST /v1/leads/{id}/convert LAGI                          409 lead_already_converted, message jelas
+  DELETE /v1/tasks/{id}                                     204
+  DELETE /v1/leads/{id}                                     204, GET setelahnya → 404 (soft delete)
+  PATCH /v1/leads/{id} dengan version BASI                  409 version_conflict, error.current
+                                                             berbentuk PERSIS tipe Lead — dibuktikan
+                                                             langsung, bukan diasumsikan dari baca kode
+  GET /leads/{id}, /leads/{id-tidak-valid}, /leads          200 semua (Next.js dev server, tanpa error render)
+```
+
+**Batas verifikasi, dicatat apa adanya:** seluruh interaksi dibuktikan lewat kontrak API (`curl` dengan
+bentuk request persis yang dikirim kode) dan lewat unit test logika murni (transisi status, format
+timeline) — **bukan** lewat klik sungguhan di browser. Tidak ada tool otomasi browser di sesi ini.
+Konsekuensinya: **tata letak visual dan interaksi dialog (buka/tutup, styling hover) belum diverifikasi
+otomatis** — hanya bahwa route-nya hidup tanpa error render dan setiap panggilan API menghasilkan data
+yang benar.
+
+### Utang teknis
+
+- Tidak ada item baru dari issue ini.
+
+### Catatan untuk session berikutnya
+
+- **#34 (tim) dan #35 (customer/task/settings/home) bisa mulai.** Pola `ConflictDialog` dan
+  `versionConflictCurrent<T>` di `auth-errors.ts` generik — dipakai ulang langsung untuk task (#35)
+  tanpa perubahan.
+- `activity-text.ts` sudah menangani seluruh 10 tipe activity yang backend tulis sampai Phase 3. Tidak
+  ada tipe baru yang direncanakan sampai Deal ada (pasca-Phase 5).
+- `EditLeadDialog`'s pola remount-lewat-`key` adalah jawaban standar untuk "reset form saat prop
+  berubah" di bawah `react-hooks/set-state-in-effect` — pakai ulang pola yang sama, bukan
+  `useEffect`+`setState`, kalau butuh form serupa di #34/#35.


### PR DESCRIPTION
## Summary

Where **almost every write action** in the product lives (issue body). Every endpoint already existed since #20–#23; this issue builds the screen, adds no endpoint.

## The most important finding: the design's status-transition logic is a prototype simplification, not the real contract

The mockup's own `TRANSITIONS`/`FINAL_EXITS` diverge from the actual backend on one case — leaving `lost`. `validateStatusTransition` (`internal/lead/usecase.go`) allows `lost` to move to **all 5** main-path statuses — a documented deviation from TD phase 2 §5's ideal rule (crm_be issue #20's notes: *"satu langkah tepat"* isn't enforceable without activity history) — while the mockup only offers reopening to "Baru".

Since the acceptance criterion is explicit (*"transisi status yang tidak sah tidak ditawarkan di UI"*), the logic is a **line-for-line port of the Go function** — `lib/lead-status.ts`'s `isValidStatusTransition` — tested against the **full 8×8 matrix**, hand-written from the TD independently of the implementation, so a bug breaking both the same way can't hide.

One narrowing *is* kept from the mockup: `lost` still offers only the single "→ Buka kembali ke Baru" button, not all 5 valid targets. That's legitimate — the criterion forbids offering *invalid* transitions, it doesn't require offering *every* valid one — and avoids a wall of buttons for a rare case. Locked by a test (`statusTransitionOptions("lost")` must return exactly one option) so the narrowing reads as a decision, not an accidental match.

## Activity metadata verified against a real crm_be, not assumed

The mockup has direct access to its own in-memory `lead`/`task` objects to build timeline text. The real API sends only `type` + raw `metadata`. Each shape was read from `internal/{lead,task,customer}/usecase.go`'s `Activity.Record` calls, then **proven again** by running one real lead through its full lifecycle (create → status changes → assign → 3 note types → task create → complete → convert):

```
lead_created      metadata: null            — no source, contrary to a first guess
status_changed    {"from":"new","to":"contacted"}
lead_assigned     {"to":"<id>","from":null}  — from is explicit null the first time, not absent
lead_converted     {"customer_id":"<id>"}
task_completed    {"task_id":"<id>"}         — NO title, unlike task_created
```

`lead_created`'s null metadata means its timeline text is static ("Lead dibuat") — the source is already in the header. `task_completed` carrying no title (unlike `task_created`) is exactly the kind of asymmetry a naive implementation assumes away — both locked in `activity-text.test.ts`.

## Two things missing from the design entirely, added because the checklist requires them

- **General field editing** (name/email/phone/company/notes). The mockup's header is read-only; there's no edit form anywhere in it. Checklist: *"Ubah field umum (PATCH /v1/leads/{id}) — membawa version"* → `edit-lead-dialog.tsx`.
- **Task creation form.** The mockup's own `onAddLeadTask` hardcodes a task titled "Task baru" with zero form — its own source comment says `// visual only`. `new-task-dialog.tsx` follows the same pattern as `new-lead-dialog.tsx` from #32.

## Other decisions

- **`ConflictDialog` is one shared place** for status/assignment/edit conflicts. Its only button triggers a full refetch — `error.current` is never applied automatically. Aturan #35 means the user must consciously act before stale state is replaced, not just that the client mustn't resend the old version.
- **Task conflicts get lighter treatment** (inline message + auto-refetch, not a second modal) — lower stakes than a lead conflict; a second dialog for the same underlying case would duplicate the pattern without adding clarity.
- **`EditLeadDialog` remounts via a `key`** (`${lead.id}-${lead.version}`), not `useEffect`+`setState` — `react-hooks/set-state-in-effect` (same rule hit in #32) forbids syncing form state from a prop inside an effect. Splitting the form into its own keyed component is React's own recommended fix for "reset state when a prop changes."
- **The Convert button disappears once a conversion has genuinely happened**, not just when `status === "won"` — `Lead` carries no "already converted" flag (that's `Customer.converted_from_lead_id`; TD §12 says the lead itself is never mutated). The signal comes from the timeline containing a `lead_converted` entry.
- **Assignment dropdown includes all members**, unlike the mockup (which filters out `role=employee`) — nothing in the schema restricts assignee by role, and Employee is the most natural real-world assignee (they follow up via mobile in Phase 5).
- **Delete and Convert hidden in the UI for Manager** (`ActionLeadDelete`/`ActionLeadConvert` = Owner/Admin only) — the UI doesn't offer an action the backend is certain to reject.
- **The mockup's `onShowConflictPattern` demo button isn't implemented** — a prototype-only trigger with no real action behind it. The real product reaches `ConflictDialog` from an actual `409`, not a demo button.

## Test plan

- [x] `typecheck` · `lint` · `test` · `build` — clean, exit codes checked
- [x] **18 new tests** (54 total): `lead-status` (full transition matrix + option-narrowing), `activity-text` (all 10 activity types including the two metadata gotchas above)
- [x] Verified against a real `crm_be`, exact request shapes every `lib/*.ts` function sends:
  - `PATCH .../status` new→contacted, `.../assignment` to self, 3× `POST .../activities` (note/call/wa) → all correct
  - `POST .../tasks` → `complete` → matches `Task` type exactly
  - `PATCH /v1/leads/{id}` (name/email/phone/company/notes) → all fields persisted correctly
  - `lost` without `lost_reason` → `400`; with reason → `200`; reopen `lost`→`new` → `200`
  - Full path `new→contacted→qualified→proposal→won` → `200` × 4
  - `POST .../convert` → `201`; convert again → `409 lead_already_converted`, clear message
  - `DELETE` task → `204`; `DELETE` lead → `204`, `GET` after → `404` (soft delete)
  - **Stale `version` → `409 version_conflict`, `error.current` shaped exactly like `Lead`** — proven directly
  - `/leads/{id}`, `/leads/{invalid-id}`, `/leads` on the Next.js dev server → `200`, no render error

**Verification limit, stated plainly:** every interaction is proven via the API contract (`curl` with the exact request shapes the code sends) and via unit tests of the pure logic (status transitions, timeline formatting) — not via clicking through a real browser. No browser automation tool was available in this session; visual layout and dialog open/close interaction are unverified beyond "the route renders without error."

Refs #33