### PR TITLE
docs(phase-4): open Public API with PRD, TD, and issue breakdown

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 26 Agustus 2026 — Issue #35 selesai. **Phase 3 — Owner Dashboard selesai.**
-**Phase sekarang:** Phase 3 selesai — phase berikutnya (4 atau 5) belum diputuskan, lihat *Berikutnya*.
+**Last updated:** 27 Agustus 2026 — Phase 4 dibuka (PRD + TD + issue #46–#49)
+**Phase sekarang:** Phase 4 — Public API (0/4 issue selesai)
 
 ---
 
@@ -52,17 +52,31 @@ _(kosong)_
 
 ## Berikutnya
 
-**Phase 3 — Owner Dashboard selesai** (#30–#35, #40). Dua hal menunggu keputusan manusia sebelum sesi
-coding berikutnya dimulai — bukan sesuatu yang bisa diputuskan sepihak dalam sesi agent:
+**Issue #46 — Migration `0005`, domain `api_key`, CRUD kredensial** (backend, pembuka Phase 4)
 
-1. **Demo ke calon pengguna** (freeze bagian 4) — tujuan phase-nya, belum dilakukan.
-2. **Pilih phase berikutnya**: Phase 4 (Public API — api_keys, `POST /v1/leads` publik, rate limit per
-   key, dokumentasi integrasi) atau Phase 5 (Employee Mobile — Flutter, `crm_employee/`). Freeze
-   menempatkan keduanya **tidak saling bergantung**, jadi urutannya murni keputusan produk (mana yang
-   lebih mendesak: capture layer eksternal, atau alat kerja harian Employee di lapangan).
+- Cakupan & acceptance: [issue #46](https://github.com/Pravasta/jualin-crm/issues/46)
+- TD: `docs/phases/04-public-api/td.md` §1, §2, §9, §11, §15
+- **Baca ADR-004 sebelum menyentuh hashing.** SHA-256 (bukan argon2id) untuk API key akan terlihat
+  seperti kesalahan keamanan bagi yang membaca sekilas — ADR itu ditulis persis untuk mencegah
+  "perbaikan" yang membuat lookup mustahil.
+- Urutan: #46 → #47 → #49, dengan **#48 boleh paralel** (layar dashboard hanya bergantung pada #46).
+  Rincian di `docs/phases/04-public-api/issues.md`.
+- **Risiko terbesar phase ini ada di #47**, bukan di sini: satu peta otorisasi salah dan API key bisa
+  mengelola tim (Aturan #24). Bentuk penegakannya sudah diputuskan di TD §4 — di `authz`, bukan per
+  handler.
 
-Setelah salah satu dipilih: PRD + TD phase itu dulu (pola yang sama seperti Phase 2→3), baru issue
-per-issue. Rincian riwayat #30–#35 di `docs/phases/03-owner-dashboard/issues.md` dan `notes.md`.
+### Dua hal yang tetap menunggu keputusan manusia
+
+Keduanya tercatat sejak Phase 3 tutup dan **tidak** memblokir Phase 4:
+
+1. **Demo ke calon pengguna** (freeze bagian 4) — tujuan Phase 3, belum dilakukan.
+2. **Apple Developer Program & Firebase** — belum dimulai, lihat bagian *Punya Lead Time* di bawah.
+   Keduanya menunggu pihak ketiga dan bisa menghentikan Phase 5 tepat di bagian build iOS dan push
+   notification. **Ini alasan Phase 4 dikerjakan lebih dulu**, bukan karena ia lebih penting — freeze
+   menempatkan keduanya tidak saling bergantung. Mengurusnya selama Phase 4 berjalan adalah cara
+   termurah menghindari Phase 5 berhenti sebelum dimulai.
+
+Riwayat #30–#35 di `docs/phases/03-owner-dashboard/issues.md` dan `notes.md`.
 
 ---
 
@@ -73,8 +87,8 @@ per-issue. Rincian riwayat #30–#35 di `docs/phases/03-owner-dashboard/issues.m
 | Tidak ada test end-to-end otomatis untuk graceful shutdown | Issue #1 | Diverifikasi manual (build binary + SIGINT). Otomatisasi butuh test yang menjalankan binary sungguhan dan mengirim sinyal OS — `go run` tidak meneruskan sinyal ke child process, jadi tidak bisa diuji lewat itu. Belum ada issue yang mencakup ini; angkat saat menyentuh area shutdown lagi. |
 | Tidak ada auto-migrate saat container `api` start | Issue #2 | `make migrate-up` dijalankan manual. Sengaja dipisah dari entrypoint `api` — migration dan serving punya kelas kegagalan berbeda. |
 | `ratelimit.FixedWindow` tidak pernah membersihkan key lama | Issue #9 | Map tumbuh tanpa batas seiring IP/email baru muncul. Tidak masalah di volume MVP; perlu eviction sebelum traffic produksi nyata. |
-| Angka rate limit (register 5/jam, resend 3/jam+10/jam) belum final | Issue #9 | Cukup untuk membuktikan mekanisme aktif, bukan hasil tuning. Freeze mencatat "strategi rate limit final" sebagai keputusan terbuka hingga Phase 4. |
-| `leads.idempotency_key` tidak punya retensi | Issue #20, TD §7 | Disimpan selamanya — key yang dipakai ulang setahun kemudian mengembalikan lead lama. Tidak berbahaya (tidak pernah membuat duplikat), tetapi salah. Baru relevan saat Phase 4 (API publik) membuat integrator sungguhan mulai mengirim key. |
+| Angka rate limit (register 5/jam, resend 3/jam+10/jam) belum final | Issue #9 | Cukup untuk membuktikan mekanisme aktif, bukan hasil tuning. **Sebagian ditutup di Phase 4**: batas API publik ditetapkan (D4 — 60/menit per kunci, `PUBLIC_API_RATE_LIMIT`). Angka endpoint email masih default konservatif. |
+| `leads.idempotency_key` tidak punya retensi | Issue #20, TD §7 | Disimpan selamanya — key yang dipakai ulang setahun kemudian mengembalikan lead lama. Tidak berbahaya (tidak pernah membuat duplikat), tetapi salah. **Dijadwalkan ditutup di [#47](https://github.com/Pravasta/jualin-crm/issues/47)** (retensi 48 jam, penghapusan malas tanpa scheduler — keputusan D3). |
 | `notifications` tidak punya retensi | Issue #22, TD §2 | Sama seperti `idempotency_key` — tidak ada scheduler di Phase 2 untuk membersihkan notifikasi lama. Tidak mendesak di volume MVP. |
 
 > ~~Test otomatis `db.InTx` dan migration round-trip~~ — selesai di issue #3.
@@ -100,6 +114,8 @@ Tidak ada yang memblokir. Semuanya diputuskan saat fitur terkait dikerjakan.
 Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 dan `docs/brainstorming/architecture_product_review.md` bagian 12.
 
 > **B6–B9 ditutup** saat PRD Phase 2 dibuka (21 Agustus 2026), seluruhnya mengikuti rekomendasi freeze: `lost_reason` 6 nilai · mundur satu langkah · `tasks.lead_id NOT NULL` · konversi ke Customer adalah aksi eksplisit. Alasan tiap keputusan ada di `docs/phases/02-crm-core/prd.md` bagian *Keputusan yang ditutup di phase ini*.
+
+> **D1–D5 ditutup** saat PRD Phase 4 dibuka (27 Agustus 2026): otorisasi principal tanpa role lewat `Scopes` + cabang di `authz.Require` (D1) · `POST /v1/leads` **satu path** untuk dua bentuk kredensial, dipilah dari prefix `jln_live_` (D2) · retensi `idempotency_key` 48 jam dengan penghapusan malas, tanpa scheduler (D3) · rate limit API publik 60/menit **per kunci**, bukan per IP (D4) · API publik **tidak** bisa dipanggil dari browser — sudah terjaga allowlist CORS #30, yang ditambahkan hanya test dan peringatan di dokumentasi (D5). Tidak satu pun dari kelimanya tercatat di tabel ini sebelumnya; semuanya ditutup di muka, bukan di tengah implementasi. Alasan tiap keputusan ada di `docs/phases/04-public-api/prd.md`.
 
 > **C1–C3 ditutup** saat PRD Phase 3 dibuka (24 Agustus 2026): **Bahasa UI Indonesia saja, tanpa i18n** (C1 — satu-satunya dari ketiganya yang memang tercatat di tabel ini) · **browser → Go langsung dengan CORS**, bukan BFF (C2) · **shadcn/ui + Tailwind** (C3). C2 dan C3 ternyata belum pernah diputuskan di dokumen manapun; keduanya ditutup di muka, bukan di tengah implementasi. Alasan tiap keputusan ada di `docs/phases/03-owner-dashboard/prd.md`.
 
@@ -141,7 +157,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 1 | Auth & Organization | ✅ | ✅ | ✅ #8–#11, #15 | ✅ |
 | 2 | CRM Core | ✅ | ✅ | ✅ #19–#23 | ✅ |
 | 3 | Owner Dashboard | ✅ | ✅ | ✅ #30–#35, #40 | ✅ |
-| 4 | Public API | ⬜ | ⬜ | ⬜ | ⬜ |
+| 4 | Public API | ✅ | ✅ | ✅ #46–#49 | ⬜ |
 | 5 | Employee Mobile | ⬜ | ⬜ | ⬜ | ⬜ |
 
 Pekerjaan yang sedang berjalan: `gh issue list --state open`

--- a/docs/phases/04-public-api/issues.md
+++ b/docs/phases/04-public-api/issues.md
@@ -1,0 +1,95 @@
+# Phase 4 — Public API · Issues
+
+> Indeks pekerjaan. **Tanpa kolom status** — status hidup di GitHub ([ADR-008](../../decisions/ADR-008-delivery-workflow.md)).
+>
+> Status terkini: `gh issue list --milestone "Phase 4 — Public API"`
+
+**Milestone:** [Phase 4 — Public API](https://github.com/Pravasta/jualin-crm/milestone/5)
+
+---
+
+## Daftar
+
+| # | Judul | Aplikasi | Cakupan | TD |
+|---|---|---|---|---|
+| [46](https://github.com/Pravasta/jualin-crm/issues/46) | Migration `0005`, domain `api_key`, CRUD kredensial | `crm_be` | `0005_api_keys` + `leads.source_api_key_id`, `internal/apikey`, format `jln_live_` (ADR-004), 3 endpoint pengelolaan, audit log | §1, §2, §9, §11, §15 |
+| [47](https://github.com/Pravasta/jualin-crm/issues/47) | Autentikasi API key, `POST /v1/leads` publik, rate limit, idempotency | `crm_be` | Pemilahan kredensial, otorisasi berbasis scope, jalur API pada `POST /v1/leads`, header `X-RateLimit-*`, retensi `idempotency_key`. **Risiko keamanan tertinggi phase ini** | §3–§8, §10, §14 |
+| [48](https://github.com/Pravasta/jualin-crm/issues/48) | Dashboard: manajemen API key | `crm_dashboard` | Layar buat/daftar/cabut, raw secret sekali dengan tombol salin, Owner/Admin saja | §9, §12 |
+| [49](https://github.com/Pravasta/jualin-crm/issues/49) | Halaman dokumentasi integrasi | `crm_dashboard` | Halaman menghadap pelanggan + bab **API Publik** di `api.md`. **Penutup phase** | §13, §14, §18 |
+
+---
+
+## Urutan
+
+```
+#46 kredensial ──┬──► #47 autentikasi + endpoint publik ──► #49 dokumentasi (penutup)
+                 │
+                 └──► #48 layar dashboard   (paralel, bukan prasyarat #47)
+```
+
+| Dependensi | Sifat |
+|---|---|
+| #47 → #46 | **Keras.** Tidak ada yang bisa diautentikasi sebelum kredensialnya ada. |
+| #48 → #46 | **Keras** ke #46 saja. Layar hanya memakai tiga endpoint pengelolaan; ia tidak peduli apakah kunci sudah bisa dipakai. |
+| #48 → #47 | **Bukan prasyarat.** Boleh dikerjakan paralel. |
+| #49 → #47 | **Keras.** Halaman ini mendokumentasikan perilaku nyata endpoint publik. Ditulis sebelum #47 selesai, ia hanya mendokumentasikan rencana. |
+
+**#47 dan #48 boleh ditukar atau dikerjakan paralel.** Sisanya berurutan.
+
+---
+
+## Batas per issue
+
+| Issue | Berhenti di |
+|---|---|
+| #46 | Kunci bisa dibuat, dilihat, dan dicabut lewat `curl` **sebagai user**. Kunci itu **belum bisa dipakai untuk apa pun** — tidak ada jalur autentikasi yang menerimanya. |
+| #47 | `curl` dari mesin luar membuat lead. **Belum ada satu baris UI**; seluruh verifikasi lewat test dan `curl`. |
+| #48 | Owner mengelola kunci tanpa terminal. **Belum ada halaman dokumentasi.** |
+| #49 | Phase 4 tutup. Mobile (Phase 5), embedded form (Phase 6), dan webhook (Phase 7) **tidak** disentuh. |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Dua issue yang perlu perhatian ekstra saat review
+
+**#47 — satu peta otorisasi salah, dan kredensial yang bocor menjadi pengambilalihan organization.**
+Ini bukan hiperbola: bila `authz` mengizinkan lebih dari `lead.create` untuk `PrincipalAPIKey`, sebuah
+kunci yang tertempel di repositori publik pelanggan bisa mengundang anggota, mengubah role, dan membuat
+kunci baru. Freeze menamai kelas kegagalan ini secara eksplisit (bagian 5.1, Aturan #24) — itu sebabnya
+ia punya ADR sendiri.
+
+Yang layak direview di PR itu **bukan** jumlah test yang lolos, melainkan **bentuk** dua hal:
+
+1. Apakah penolakan datang dari *"action ini tidak ada di peta"* (gagal aman — endpoint baru yang lupa
+   memikirkan API key otomatis tertutup) atau dari *"handler ini mengecek"* (gagal terbuka — endpoint
+   yang lupa otomatis terbuka).
+2. Apakah test-nya berupa **tabel atas seluruh `authz.Action`**, atau daftar action yang ditulis tangan.
+   Yang kedua hijau hari ini dan bocor di phase berikutnya, saat seseorang menambah action baru dan
+   tidak ada yang mengingatkannya.
+
+**#49 — dokumentasi adalah fitur, dan kriterianya bukan "halaman ada".** Kriterianya *"integrasi bekerja
+tanpa bertanya kepada siapa pun"*, dan satu-satunya cara memverifikasinya adalah **mengikuti halaman itu
+dari nol**, bukan membacanya ulang. Membaca ulang dokumen yang kita tulis sendiri selalu terasa jelas —
+justru karena kita sudah tahu bagian yang tidak tertulis di sana.
+
+Di produk berharga murah, setiap pertanyaan yang halaman ini gagal jawab akan datang sebagai tiket
+support, dan margin per pelanggan tidak menyediakan ruang untuk itu.
+
+---
+
+## Setelah keempatnya selesai
+
+Phase 4 tutup bila **13 acceptance criteria** di [`prd.md`](./prd.md) terpenuhi — terutama #1 (`curl`
+dari mesin luar → lead di dashboard) dan #5 (API key tidak bisa memanggil satu pun endpoint aplikasi
+pengguna). Lalu:
+
+1. `api.md` (bab API Publik), `authentication.md`, `authorization.md`, `multi-tenancy.md` diperbarui (TD §18)
+2. `docs/STATUS.md` — Phase 4 ✅, dan utang retensi `idempotency_key` **ditutup**
+3. Buka **Phase 5 — Employee Mobile** — satu-satunya phase MVP yang tersisa
+
+> **Sebelum membuka Phase 5, periksa `STATUS.md` bagian *Punya Lead Time*.** Pendaftaran Apple Developer
+> Program dan pembuatan Firebase project belum dimulai, dan keduanya menunggu pihak ketiga —
+> enrollment bisa berhari-hari sampai berminggu. Phase 5 bisa dimulai tanpa keduanya, tetapi akan
+> berhenti tepat di bagian build iOS dan push notification. Mengurusnya **selama** Phase 4 berjalan
+> adalah cara termurah menghindari itu.

--- a/docs/phases/04-public-api/prd.md
+++ b/docs/phases/04-public-api/prd.md
@@ -1,0 +1,175 @@
+# Phase 4 — Public API · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md).
+> Sumber: [`architecture/freeze.md`](../../architecture/freeze.md) bagian 4 (Phase 4), 3.1 (API Key & Public Lead API), 5.1 (Aturan #24 — User App ≠ API Key), 8.4 (migration `0005`), Aturan #21, #23, #26 · [ADR-004](../../decisions/ADR-004-api-key-format.md) (format & hashing API key) · [ADR-005](../../decisions/ADR-005-public-form-key.md) (kenapa public form key **bukan** API key) · [`api.md`](../../architecture/api.md) bagian *Idempotency*, *Rate limiting*, *Yang menyusul di Phase 4*
+
+---
+
+## Tujuan
+
+**Tesis produk terbukti.** Capture layer bekerja dari luar.
+
+Sampai sekarang setiap lead di sistem ini lahir dari seseorang yang mengetiknya — lewat `curl` di Phase 2,
+lewat form dashboard di Phase 3. Keduanya membuktikan lead bisa **dikelola**. Tidak satu pun membuktikan
+lead bisa **masuk sendiri**.
+
+Kalimat inti MVP (freeze 3, Decisions §23) menyebutnya secara eksplisit:
+
+> Owner mendaftar → verifikasi email → login → undang employee → employee login →
+> **owner membuat API key → website mengirim lead** → owner meng-assign →
+> employee menerima notifikasi → follow-up dari HP → update → konversi ke Customer
+
+Dua langkah yang ditebalkan adalah satu-satunya bagian dari kalimat itu yang belum pernah dijalankan
+siapa pun. Phase 4 menutupnya.
+
+> Ini juga phase pertama yang menghadapi **klien yang bukan kita**. Dashboard salah bisa diperbaiki dan
+> di-deploy ulang tanpa memberi tahu siapa pun; bentuk request yang sudah dipakai integrator tidak bisa.
+> Itulah kenapa `api.md` sengaja ditulis sejak bootstrap, dan kenapa halaman dokumentasi di phase ini
+> bukan pelengkap.
+
+---
+
+## Kebutuhan
+
+| # | Sebagai… | Saya butuh… | Supaya… |
+|---|---|---|---|
+| 1 | Owner | Membuat kredensial untuk website saya, tanpa meminta bantuan developer Jualin | Bisa mulai mengirim lead di hari yang sama saat saya berlangganan |
+| 2 | Owner | Melihat kredensial mana yang pernah dipakai, dan kapan terakhir | Bisa tahu integrasi mana yang hidup dan mana yang tinggal nama |
+| 3 | Owner | Mencabut satu kredensial seketika, tanpa mengganggu yang lain | Kebocoran satu kunci tidak berarti mematikan seluruh integrasi |
+| 4 | Owner | Melihat lead yang masuk lewat API tercampur dengan lead manual, dengan penanda dari mana ia datang | Tidak perlu membuka dua tempat berbeda untuk pekerjaan yang sama |
+| 5 | Developer pelanggan | Satu halaman yang cukup untuk membuat integrasi bekerja | Tidak perlu menghubungi support — dan saya tidak perlu membayar orang yang menjawabnya |
+| 6 | Developer pelanggan | Mengulang request yang timeout tanpa membuat lead ganda | Retry saat jaringan buruk adalah kejadian normal, bukan insiden data |
+| 7 | Developer pelanggan | Tahu berapa sisa kuota saya **sebelum** ditolak | Bisa mengatur laju kirim sendiri, bukan menabrak `429` lalu menebak |
+| 8 | Developer pelanggan | Pesan kesalahan yang menyebut field mana yang salah | Bisa memperbaikinya tanpa menebak-nebak |
+| 9 | Pemilik sistem | Kredensial yang bocor **tidak bisa** dipakai mengelola tim, mengubah subscription, atau membuat kredensial baru | Radius ledakan kebocoran API key terbatas pada "lead palsu masuk", bukan pengambilalihan organization |
+
+---
+
+## Acceptance Criteria
+
+Phase 4 selesai bila **semuanya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | `curl` dari mesin di luar jaringan kita → lead muncul di dashboard, dengan `source = api` dan penanda kredensial mana yang mengirimnya |
+| 2 | Raw secret ditampilkan **tepat sekali** saat dibuat. Tidak ada endpoint, layar, atau query yang bisa menampilkannya lagi (Aturan #21) |
+| 3 | Kredensial yang direvoke ditolak **seketika** — tanpa jeda cache, tanpa masa tenggang |
+| 4 | Request berulang dengan `Idempotency-Key` sama mengembalikan **lead yang sama**, bukan duplikat dan bukan error |
+| 5 | API key **tidak bisa** memanggil satu pun endpoint aplikasi pengguna — bukan karena setiap handler mengeceknya, melainkan karena otorisasi memang tidak punya jalan untuk mengizinkannya (Aturan #24) |
+| 6 | Setiap response API publik membawa `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`; `429` membawa `Retry-After` |
+| 7 | Lookup kredensial **tidak** memindai tabel — `key_id` di-index, secret dibandingkan `subtle.ConstantTimeCompare` (ADR-004) |
+| 8 | Payload yang dikirim integrator tersimpan apa adanya di `raw_payload`, termasuk field yang tidak dikenal |
+| 9 | Owner bisa membuat, melihat, dan mencabut kredensial **dari dashboard**, tanpa `curl` |
+| 10 | Halaman dokumentasi integrasi cukup untuk membuat integrasi bekerja **tanpa bertanya kepada siapa pun** — diverifikasi dengan mengikutinya dari nol, bukan dengan membacanya |
+| 11 | Raw API key **tidak pernah** muncul di log, termasuk saat request-nya gagal (Aturan #26) |
+| 12 | Harness isolasi tenant bertambah kasus untuk jalur kredensial baru, dan **tetap terbukti bisa gagal** |
+| 13 | `idempotency_key` punya retensi — key kedaluwarsa tidak lagi tersimpan selamanya (utang yang diwarisi Phase 2) |
+
+---
+
+## Keputusan yang ditutup di phase ini
+
+Lima keputusan yang jatuh tempo di sini, ditutup di muka daripada di tengah implementasi. Alasan
+teknis lengkap ada di [`td.md`](./td.md); yang di bawah adalah **apa** dan **kenapa** dalam kalimat produk.
+
+| # | Pertanyaan | Keputusan | Alasan |
+|---|---|---|---|
+| **D1** | Bagaimana otorisasi bekerja untuk principal yang **tidak punya role**? | `tenant.Context` bertambah `Scopes`; `authz.Require` bercabang pada `PrincipalType`. Untuk API key ada **satu** peta `Action → scope`, berisi tepat satu baris: `lead.create → leads:write`. | Aturan #24 menuntut "ditegakkan di middleware, bukan per handler". Peta yang hanya berisi satu baris membuat setiap action lain ditolak **karena tidak ada di daftar** — bukan karena seseorang ingat menuliskan pengecualiannya. Menambah kemampuan API key di masa depan berarti menambah baris ke satu tempat yang terlihat, bukan mengaudit ulang seluruh handler. |
+| **D2** | `POST /v1/leads` satu path untuk dua jalur kredensial, atau path terpisah? | **Satu path.** Middleware memilah dari prefix `jln_live_`/`jln_test_` pada `Authorization: Bearer`. | Freeze 3.1 dan `api.md` sama-sama menyebut endpoint publiknya `POST /v1/leads`. `api.md` melarang endpoint menerima dua principal *tanpa alasan tertulis* — ini alasan tertulisnya, dan bentuk kredensialnya bisa dibedakan tanpa menebak. Path terpisah (`/v1/public/leads`) berarti dua handler yang harus tetap sama selamanya. |
+| **D3** | Retensi `idempotency_key` (utang Phase 2) | **48 jam**, dihapus malas saat `POST /v1/leads` berjalan — tanpa scheduler, tanpa tabel `jobs`. | `api.md` menyebut 24–48 jam; freeze melarang worker sampai ada kebutuhan async nyata (Phase 5/7). Penghapusan malas menumpang pada satu-satunya jalur yang pasti berjalan bila keynya dipakai sama sekali. Bila tidak ada traffic, tidak ada yang perlu dibersihkan. |
+| **D4** | Angka rate limit final (terbuka sejak Phase 1) | **60 request/menit per API key** untuk `POST /v1/leads`, jendela tetap. Bisa diubah lewat konfigurasi tanpa deploy ulang kode. | Website SMB yang normal mengirim beberapa lead per jam, bukan per detik. 60/menit memberi ruang dua orde besaran di atas pemakaian nyata sambil tetap membuat penyalahgunaan mahal. Angkanya **bukan** hasil pengukuran — ia baru bisa di-tuning setelah ada integrator sungguhan, dan headernya (kriteria #6) memang ada supaya perubahan itu tidak mengejutkan siapa pun. |
+| **D5** | Apakah API publik boleh dipanggil dari browser? | **Tidak.** Origin website pelanggan tidak pernah masuk `CORS_ALLOWED_ORIGINS`, jadi request browser dari sana tidak pernah mendapat header CORS. | Aturan #23: API key tidak pernah hadir di sisi klien. Bila browser bisa memanggilnya, seseorang **akan** menempelkan key di JavaScript website-nya, dan itu berarti kredensial organization tersebar ke setiap pengunjung. Ternyata ini **sudah** terjaga oleh allowlist yang dibuat di #30 — yang belum ada hanyalah pernyataan tertulisnya, test yang menguncinya, dan peringatan di halaman dokumentasi (TD §8). Kebutuhan "form di website mengirim lead langsung dari browser" adalah **Phase 6** dan punya kredensialnya sendiri (ADR-005). |
+
+---
+
+## Di luar cakupan
+
+| Tidak dikerjakan | Ke |
+|---|---|
+| Embedded form, `forms`, `public_key`, `source_form_id` | Phase 6 — kredensial berbeda dengan aturan berbeda (ADR-005) |
+| Mobile app | Phase 5 — memakai user session, **tidak menyentuh API key sama sekali** (Aturan #24) |
+| Webhook keluar (Jualin memberi tahu sistem pelanggan) | Phase 7 |
+| Endpoint publik selain `POST /v1/leads` — membaca lead, mengubah status, mengelola tim lewat API | Belum dijadwalkan — lihat catatan di bawah |
+| Scope selain `leads:write` | Kolomnya ada sejak awal (ADR-004 aturan #4), nilainya menyusul saat ada endpoint keduanya |
+| Penegakan kuota per plan (limit lead per bulan) | Phase 8 — rate limit ≠ quota, lihat catatan di bawah |
+| SDK / library klien resmi | Belum dijadwalkan — `curl` dan contoh dalam bahasa umum lebih dulu |
+| Rotasi otomatis & masa berlaku key (`expires_at` terisi) | Kolomnya dibuat, pengisiannya belum — lihat catatan di bawah |
+| Dashboard analytics pemakaian API (grafik request per hari) | Phase 8 bersama usage counter |
+
+### Tiga hal yang sengaja tertahan
+
+**API publik hanya menulis, belum membaca.** Freeze 3.1 menyebut cakupannya `POST /v1/leads` — satu
+endpoint, bukan "API publik" dalam arti seluruh CRUD. Alasannya bukan kemalasan: endpoint baca publik
+mengharuskan kita membekukan bentuk respons lead untuk pihak luar, dan bentuk itu masih berubah setiap
+phase (`source_form_id` datang di Phase 6, Deal mengubah daftar status pasca-Phase 5). Menulis lebih
+aman dibekukan lebih dulu karena payload masuk memang sudah stabil sejak Phase 2.
+
+**Rate limit bukan quota.** Rate limit menjawab *"seberapa cepat"* dan melindungi sistem; quota menjawab
+*"seberapa banyak per bulan"* dan menegakkan harga. Keduanya sering dikira satu hal. Phase 4 hanya
+mengerjakan yang pertama. Yang kedua butuh `usage_counters` dan definisi plan yang memang dijadwalkan
+Phase 8 — dan menebaknya sekarang berarti membangun penegakan untuk harga yang belum ditetapkan.
+
+**`expires_at` dibuat kosong.** Kolomnya ada di ADR-004 dan dibuat di `0005`, tetapi tidak ada UI dan
+tidak ada perilaku yang mengisinya. Menambahkan kolom nullable belakangan ke tabel yang sudah beredar
+bersifat instan; yang tidak instan adalah menjelaskan kepada integrator kenapa kunci mereka tiba-tiba
+mati. Masa berlaku diaktifkan saat ada yang memintanya, bukan karena tabelnya terlihat kurang lengkap.
+
+---
+
+## Dependensi
+
+Phase 1, 2, dan 3 selesai. Yang dipakai phase ini sudah ada seluruhnya:
+
+| Yang dipakai | Dari | Catatan |
+|---|---|---|
+| `tenant.Context` dengan `PrincipalAPIKey` dan `APIKeyID` | Phase 1 | **Sudah ada, belum pernah dipakai.** Field `APIKeyID` ditulis di Phase 1 dengan komentar eksplisit: *"exists now so this struct's shape doesn't change when Phase 4 introduces API keys"*. Phase 4 adalah momen itu. |
+| `internal/shared/token` (SHA-256 + hex) | Phase 1 | Doc comment-nya sudah menyebut ADR-004 sebagai prinsip yang sama |
+| `internal/shared/ratelimit` | Phase 1 | **Perlu diperluas** — `Allow(key) bool` tidak cukup untuk header `X-RateLimit-Remaining`/`Reset` (TD §6) |
+| `leads.source` menerima `api`, `raw_payload jsonb`, `idempotency_key` + `uq_leads_org_idempotency` | Phase 2 | Ketiganya dibuat di `0003` **sebelum** ada yang memakainya, persis untuk phase ini |
+| `lead.Usecase.Create` dengan jalur idempotent replay | Phase 2 | Sudah mengembalikan `isNew=false` + 200 pada replay; jalur API memakai ulang, tidak menulis ulang |
+| `auditlog` dengan `actor_type = 'api_key'` | Phase 1 | Nilai `api_key` sudah ada di `ck_audit_logs_actor_type` sejak `0002` |
+| `crm_dashboard` — sesi, klien API, app shell, komponen | Phase 3 | Dua layar baru menempel pada kerangka yang sudah ada |
+
+**Satu kewajiban diwarisi Phase 2** ([`02-crm-core/td.md`](../02-crm-core/td.md) §19): retensi
+`idempotency_key`. Phase 2 mencatatnya sebagai utang dengan kalimat *"baru benar-benar relevan di Phase 4,
+saat integrator sungguhan mulai mengirim key"*. Itu terjadi sekarang — ia masuk sebagai acceptance
+criterion #13, bukan sebagai catatan.
+
+**Tidak ada keputusan yang memblokir.** D1–D5 ditutup di atas.
+
+### Yang **tidak** dibutuhkan phase ini
+
+Demo ke calon pengguna (tujuan Phase 3) dan pemilihan Phase 4-vs-5 sudah dicatat di `STATUS.md` sebagai
+keputusan manusia. Phase 4 dipilih lebih dulu **bukan** karena lebih penting dari Phase 5, melainkan
+karena Phase 5 menunggu pihak ketiga: pendaftaran Apple Developer Program dan Firebase belum dimulai
+(`STATUS.md` bagian *Punya Lead Time*), sementara Phase 4 tidak menunggu siapa pun. Freeze menempatkan
+keduanya tidak saling bergantung, jadi urutan ini tidak melanggar apa pun.
+
+---
+
+## Pembagian issue
+
+Freeze memetakan Phase 4 sebagai **dua** session (13: API Key · 14: Public Lead API + rate limit +
+dokumentasi). Saya pecah menjadi **empat**, dengan memisahkan aplikasi:
+
+| Urut | Issue | Kenapa dipisah |
+|---|---|---|
+| 1 | Migration `0005` + domain `api_key` + CRUD kredensial | Kredensialnya harus ada sebelum ada yang bisa mengautentikasi dengannya. Seluruhnya `crm_be`, dan seluruhnya bisa diuji tanpa menyentuh jalur lead. |
+| 2 | Autentikasi API key + `POST /v1/leads` publik + rate limit + idempotency | Bagian dengan risiko keamanan tertinggi di seluruh phase: satu peta otorisasi salah dan API key bisa mengelola tim. Layak direview sendiri, bukan tertimbun di antara layar. |
+| 3 | Dashboard — manajemen API key | Aplikasi berbeda, CI berbeda (ADR-009). Bergantung pada #1, **tidak** pada #2. |
+| 4 | Halaman dokumentasi integrasi — penutup phase | Freeze: *"Halaman dokumentasi integrasi bukan pelengkap."* Ia hanya bisa ditulis jujur setelah #2 selesai, karena isinya adalah perilaku nyata endpoint itu — bukan rencana perilakunya. |
+
+Ini **penyimpangan dari peta session di freeze**, dicatat di sini agar terlihat — pola yang sama dipakai
+Phase 1 (3 → 4) dan Phase 2 (4 → 5). Yang menambah dua bukan kerumitan backend, melainkan bahwa Phase 4
+menyentuh **dua aplikasi**, dan freeze memetakan session sebelum ADR-009 memisahkan repo-nya.
+
+Rincian: [`issues.md`](./issues.md)
+
+---
+
+## Bukan tujuan phase ini
+
+- **Bukan** membangun "API publik" yang lengkap — satu endpoint tulis, sesuai freeze 3.1
+- **Bukan** menetapkan harga atau limit plan — rate limit melindungi sistem, bukan menegakkan tagihan
+- **Bukan** membuat kredensial kedua untuk browser — itu Phase 6, dan ADR-005 sudah menjelaskan kenapa ia tidak boleh dijadikan satu dengan API key
+- **Bukan** menyiapkan struktur untuk webhook yang "sudah pasti datang" (Aturan #27, #28)

--- a/docs/phases/04-public-api/td.md
+++ b/docs/phases/04-public-api/td.md
@@ -1,0 +1,640 @@
+# Phase 4 — Public API · Technical Design
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+> Hanya **delta** untuk phase ini — aturan yang sudah ada di [`freeze.md`](../../architecture/freeze.md) dirujuk, tidak diulang.
+> Sumber: freeze 3.1, 5.1 (Aturan #24), 8.4 (`0005`), Aturan #21, #23, #26, #32, #33 · [ADR-004](../../decisions/ADR-004-api-key-format.md) · [ADR-011](../../decisions/ADR-011-layered-packages-and-unit-of-work.md) · [`api.md`](../../architecture/api.md)
+
+---
+
+## 1. Schema — migration `0005_api_keys`
+
+### 1.1 `api_keys`
+
+Tenant-scoped. Aturan #1, #2, #12, #13, #16 berlaku penuh.
+
+| Kolom | Tipe | Ketentuan |
+|---|---|---|
+| `id` | uuid | PK, UUIDv7 dari aplikasi, **tanpa** `DEFAULT` (Aturan #12) |
+| `organization_id` | uuid | NOT NULL, FK → `organizations` |
+| `key_id` | text | NOT NULL, **`UNIQUE` global, ter-index** — ini yang dicari (ADR-004) |
+| `secret_hash` | text | NOT NULL — SHA-256 hex dari bagian secret |
+| `key_prefix` | text | NOT NULL — untuk ditampilkan (`jln_live_a3f9…`) |
+| `name` | text | NOT NULL — diisi Owner (*"Website utama"*) |
+| `scopes` | text[] | NOT NULL, `CHECK` isi ⊆ `{leads:write}` |
+| `created_by_membership_id` | uuid | NULL — composite FK, hanya untuk audit (ADR-004 aturan #2) |
+| `created_at` | timestamptz | NOT NULL |
+| `last_used_at` | timestamptz | NULL |
+| `revoked_at` | timestamptz | NULL |
+| `expires_at` | timestamptz | NULL — **selalu NULL di Phase 4** (prd *Di luar cakupan*) |
+
+```sql
+CONSTRAINT uq_api_keys_id_org UNIQUE (id, organization_id)      -- Aturan #2
+CONSTRAINT uq_api_keys_key_id UNIQUE (key_id)                   -- pencari, lintas organization
+CONSTRAINT ck_api_keys_scopes CHECK (scopes <@ ARRAY['leads:write']::text[])
+CONSTRAINT fk_api_keys_created_by FOREIGN KEY (created_by_membership_id, organization_id)
+    REFERENCES memberships (id, organization_id)                -- Aturan #3
+CREATE INDEX ix_api_keys_org_created ON api_keys (organization_id, created_at DESC);
+```
+
+**`key_id` unik lintas organization, bukan per organization.** Ini pengecualian sadar terhadap kebiasaan
+"unik per tenant": lookup terjadi **sebelum** organization diketahui — organization justru hasil dari
+lookup itu (Aturan #5: `organization_id` tidak pernah dari client). Bentuknya sama persis dengan
+`refresh_tokens.token_hash` dan `RefreshTokenRepository.FindByHashForUpdate` di Phase 1, dan dicatat di
+sini karena alasan yang sama: ia terlihat seperti pelanggaran tenancy bila dibaca sekilas.
+
+**Tidak ada `deleted_at`.** Revoke ≠ hapus. Kredensial yang direvoke harus tetap terbaca — Owner perlu
+tahu bahwa kunci itu pernah ada, siapa membuatnya, dan kapan terakhir dipakai. Aturan #18 mewajibkan
+soft delete untuk entity bisnis; `api_keys` memakai `revoked_at` yang lebih kuat: ia tidak pernah hilang
+dari daftar.
+
+**`scopes` sebagai `text[]`, bukan tabel dan bukan JSONB.** Nilainya satu enum kecil dan tertutup
+(ADR-004 aturan #4), tidak pernah di-query isinya kecuali sebagai keanggotaan. Aturan #17 mensyaratkan
+alasan tertulis untuk JSONB — tidak ada alasan itu di sini, dan tabel `api_key_scopes` adalah tabel
+untuk kebutuhan yang belum ada (Aturan #29).
+
+### 1.2 `ALTER leads ADD source_api_key_id`
+
+```sql
+ALTER TABLE leads ADD COLUMN source_api_key_id uuid;
+ALTER TABLE leads ADD CONSTRAINT fk_leads_source_api_key
+    FOREIGN KEY (source_api_key_id, organization_id)
+    REFERENCES api_keys (id, organization_id);                  -- Aturan #3, composite
+```
+
+Nullable, instan (Aturan 8.4 freeze). `leads.source` sudah menerima `'api'` sejak `0003` — nilai enum
+mendahului FK-nya, sengaja.
+
+**Tidak ada `CHECK` yang memaksa `source='api' ⟺ source_api_key_id IS NOT NULL`.** Lead `source='api'`
+bisa lahir dari import lama atau dari kunci yang sudah dihapus di masa depan; memaksakan biconditional
+di database berarti migration berikutnya yang menyentuhnya harus membongkarnya lebih dulu. Yang
+ditegakkan usecase: jalur API key **selalu** mengisi keduanya.
+
+### Larangan yang berlaku pada migration ini
+
+- Tanpa `DEFAULT gen_random_uuid()` — UUIDv7 dari aplikasi (Aturan #12)
+- Tanpa tipe `ENUM` PostgreSQL — `CHECK` (Aturan #15)
+- Tanpa index yang tidak berawalan `organization_id`, **kecuali** `uq_api_keys_key_id` yang alasannya di §1.1 (Aturan #16)
+- `down` harus bersih: `DROP CONSTRAINT` + `DROP COLUMN` pada `leads` sebelum `DROP TABLE api_keys`
+
+---
+
+## 2. Format & siklus hidup kredensial
+
+Mengikuti [ADR-004](../../decisions/ADR-004-api-key-format.md). Yang di bawah adalah bagian yang ADR
+biarkan terbuka.
+
+```
+jln_live_a3f9K2mQxL7p_<secret>
+└──┬───┘ └─────┬─────┘ └──┬───┘
+   │           │          └─ 32 byte crypto/rand, base64url → 43 karakter
+   │           └─ key_id: 9 byte crypto/rand, base64url → 12 karakter, plaintext & ter-index
+   └─ environment
+```
+
+### Dua angka di ADR-004 yang tidak konsisten satu sama lain
+
+ADR-004 menulis *"secret: 32char"* dan *"entropi 256-bit"* pada baris yang sama. Keduanya tidak bisa
+benar bersamaan: 32 karakter base64url ≈ 192 bit; 256 bit = 32 **byte** = 43 karakter base64url.
+
+**Diambil: 256 bit.** Seluruh argumen keamanan ADR itu bersandar pada angka tersebut — *"Pada rahasia
+256-bit dari `crypto/rand`, brute-force mustahil terlepas dari kecepatan hash"* — dan itulah yang membuat
+SHA-256 (bukan argon2id) sah di sini. "32char" terbaca sebagai penyebutan longgar dari "32 byte".
+Dicatat, bukan diperbaiki diam-diam (Aturan #30); bila pembacaan ini keliru, yang berubah hanyalah satu
+konstanta.
+
+`key_id` 12 karakter tepat = 9 byte base64url tanpa padding. Ia **bukan rahasia** — hanya pencari.
+
+`key_prefix` = `jln_live_` + 4 karakter pertama `key_id` → `jln_live_a3f9`, persis contoh di ADR-004.
+(Baris *"8 karakter pertama"* di ADR itu, dibaca harfiah, menghasilkan `jln_live` yang tidak
+membedakan kunci mana pun — contoh di kolom sebelahnya adalah maksud yang sebenarnya.)
+
+### `jln_test_` diterima bentuknya, tidak pernah diterbitkan
+
+Parser mengenali `jln_live_` dan `jln_test_`; Phase 4 hanya menerbitkan `live`. Kunci `test` tidak akan
+ditemukan di database → `401`. Membangun mode sandbox berarti membangun tempat lead palsu hidup tanpa
+mengotori data pelanggan — itu fitur tersendiri, bukan awalan string (Aturan #29).
+
+### Siklus hidup
+
+```
+create   → raw ditampilkan SEKALI di response 201, tidak pernah lagi (Aturan #21)
+list     → key_prefix, name, scopes, created_at, last_used_at, revoked_at — TIDAK PERNAH secret_hash
+revoke   → revoked_at = now(). Idempoten: revoke kedua tetap 204.
+```
+
+Tidak ada endpoint "lihat lagi", "regenerate", atau "ubah scope". Regenerate = buat baru + revoke lama,
+dua aksi yang memang berbeda dan terlihat berbeda di audit log.
+
+---
+
+## 3. Autentikasi — pemilahan kredensial (keputusan D2)
+
+Satu path, dua bentuk kredensial:
+
+```
+Authorization: Bearer eyJhbGciOi...        → JWT       → PrincipalUser
+Authorization: Bearer jln_live_a3f9...      → API key   → PrincipalAPIKey
+Cookie: access_token=...                    → JWT       → PrincipalUser (+ CSRF)
+```
+
+Pemilahannya **bukan** tebakan: `jln_live_`/`jln_test_` adalah prefix yang tidak mungkin muncul di JWT
+(yang selalu diawali `eyJ` — base64url dari `{"`). Bila prefix cocok tapi kuncinya tidak valid, hasilnya
+`401 invalid_api_key`, **bukan** jatuh kembali ke jalur JWT — kredensial yang menyatakan dirinya API key
+diperlakukan sebagai API key sampai selesai.
+
+### Letak kode
+
+`authn` mendapat satu fungsi baru, bukan paket baru:
+
+```go
+// internal/shared/authn/authn.go
+type APIKeyResolver interface {
+    ResolveAPIKey(ctx context.Context, raw string) (tenant.Context, error)
+}
+
+func MiddlewareWithAPIKey(parser ClaimsParser, keys APIKeyResolver) gin.HandlerFunc
+```
+
+`APIKeyResolver` dideklarasikan **konsumennya** (Aturan ADR-011: interface milik consumer), dipenuhi
+secara struktural oleh `*apikey.Usecase`. `authn` tidak pernah mengimpor `internal/apikey` — pola yang
+sama persis dengan `ClaimsParser` yang membuat `authn` tidak mengimpor `internal/auth` sejak #11.
+
+`MiddlewareWithAPIKey` dipasang **hanya** pada `POST /v1/leads`. Seluruh route lain tetap memakai
+`authn.Middleware` yang tidak mengenal API key sama sekali — pertahanan pertama Aturan #24 adalah routing,
+bukan pengecekan.
+
+### CSRF
+
+Tidak berlaku pada jalur API key: kredensialnya tidak pernah dikirim otomatis oleh browser, sama seperti
+`Authorization: Bearer` pada jalur mobile (`authentication.md`). `MiddlewareWithAPIKey` mempertahankan
+cabang CSRF yang sudah ada untuk kredensial yang datang **dari cookie**.
+
+---
+
+## 4. Otorisasi principal API key (keputusan D1)
+
+### Masalahnya
+
+`authz.Require(t, action)` membaca `permissions[t.Role][action]`. API key tidak punya role — `t.Role`
+kosong, `permissions[""]` nil, **semuanya ditolak**. Itu jawaban yang benar untuk 23 action yang ada, dan
+salah untuk satu-satunya yang harus diizinkan.
+
+### Bentuknya
+
+```go
+// internal/shared/tenant/tenant.go
+type Context struct {
+    // …
+    APIKeyID *uuid.UUID   // sudah ada sejak Phase 1
+    Scopes   []string     // baru — hanya terisi saat PrincipalType == PrincipalAPIKey
+}
+```
+
+```go
+// internal/shared/authz/authz.go
+// Satu-satunya action yang bisa dilakukan principal API key. Setiap
+// action lain ditolak karena TIDAK ADA DI PETA INI — bukan karena
+// seseorang ingat menuliskan pengecualiannya.
+var apiKeyScopeFor = map[Action]string{
+    ActionLeadCreate: "leads:write",
+}
+
+func Require(t tenant.Context, action Action) error {
+    if t.PrincipalType == tenant.PrincipalAPIKey {
+        scope, ok := apiKeyScopeFor[action]
+        if !ok || !slices.Contains(t.Scopes, scope) {
+            return forbidden()      // 403 insufficient_scope
+        }
+        return nil
+    }
+    return roleGate(t, action)      // perilaku Phase 1–3, tak berubah
+}
+```
+
+**Kenapa di `authz`, bukan di handler publik.** Freeze 5.1 mensyaratkan penegakan Aturan #24 di lapisan
+yang dilewati semua orang, bukan per handler. Menaruhnya di sini berarti endpoint baru mana pun yang
+lupa memikirkan API key **otomatis menolaknya** — kegagalan yang aman. Menaruhnya di handler berarti
+endpoint yang lupa **otomatis mengizinkannya**.
+
+**Kenapa peta terpisah, bukan baris di `permissions`.** Menambahkan `tenant.Role("api_key")` akan
+membuat API key tampak sebagai role kelima di seluruh matriks — dan `authorization.md` sudah menyatakan
+role adalah enum tertutup berisi empat. Peta terpisah membuat pertanyaan *"apa yang bisa dilakukan API
+key?"* dijawab dengan membaca sepuluh baris, bukan menyaring empat kolom.
+
+### Test yang mengunci ini
+
+Test tabel yang mengulang **seluruh** `Action` yang terdaftar di `authz`: setiap action selain
+`ActionLeadCreate` harus ditolak untuk `PrincipalAPIKey`. Action baru yang ditambahkan phase berikutnya
+otomatis ikut diuji tanpa ada yang perlu ingat menambahkannya.
+
+---
+
+## 5. `POST /v1/leads` — jalur API key
+
+Endpoint yang sama, handler yang sama, usecase yang sama. Yang berbeda hanya isi `tenant.Context`.
+
+| Aspek | Jalur user (Phase 2–3) | Jalur API key (baru) |
+|---|---|---|
+| `source` | dari body, default `manual` | **dipaksa** `api` — body diabaikan bila mengirim `source` |
+| `source_api_key_id` | NULL | `t.APIKeyID` |
+| `created_by_membership_id` | `t.MembershipID` | NULL |
+| `assigned_to_membership_id` | boleh dari body | **ditolak** — `403 insufficient_scope`, bukan diabaikan diam-diam |
+| `raw_payload` | NULL | seluruh body seperti diterima |
+| Rate limit | tidak ada | §6 |
+| Activity `lead_created` | `actor_membership_id` = membership | `actor_membership_id` = **NULL** |
+
+**`assigned_to_membership_id` ditolak, bukan diabaikan.** Sistem eksternal tidak punya cara mengetahui
+membership id siapa pun, jadi field itu hanya bisa muncul karena salah paham. Mengabaikannya diam-diam
+berarti integrator mengira assignment-nya bekerja.
+
+**`raw_payload`.** Body disimpan apa adanya termasuk field tak dikenal — alasannya sudah tertulis di
+`0003` (Aturan #17): *"field itu tetap tersimpan supaya lead bisa direkonstruksi saat integrator melapor
+'data saya hilang'"*. Batas ukuran body **64 KB** (`http.MaxBytesReader`); di atas itu `413
+payload_too_large` sebelum apa pun di-parse. Tanpa batas, `raw_payload` adalah jalur menulis megabyte ke
+database dengan satu request.
+
+**`lead_created` tanpa aktor.** `activities.actor_membership_id` memang nullable untuk kasus ini (freeze
+2.5). **Konsekuensi ke dashboard yang sudah jadi:** `#33` merender nama aktor di timeline; lead pertama
+yang masuk lewat API akan menjadi yang pertama menabraknya. Diverifikasi di #2, diperbaiki di #3 bila
+tampil kosong (lihat §16).
+
+### Perubahan pada `internal/lead`
+
+```
+CreateLeadInput  + RawPayload []byte, + SourceAPIKeyID *uuid.UUID
+CreateInput      + RawPayload []byte, + SourceAPIKeyID *uuid.UUID
+```
+
+Usecase `Create` menetapkan `source='api'` dan menolak `assigned_to_membership_id` **saat
+`t.PrincipalType == PrincipalAPIKey`** — di usecase, bukan di handler (Aturan: otorisasi & aturan bisnis
+di usecase). Jalur idempotent replay yang sudah ada (`ErrIdempotencyKeyExists` → 200) **tidak disentuh**.
+
+---
+
+## 6. Rate limit & header (keputusan D4)
+
+### Yang kurang dari `ratelimit` hari ini
+
+`Limiter.Allow(key) bool` menjawab boleh/tidak, tapi `X-RateLimit-Remaining` dan `X-RateLimit-Reset`
+butuh angka. Yang ditambahkan:
+
+```go
+// internal/shared/ratelimit/limiter.go
+type Result struct {
+    Allowed   bool
+    Limit     int
+    Remaining int
+    ResetAt   time.Time
+}
+
+func (f *FixedWindow) Take(key string) Result   // metode baru pada tipe yang sudah ada
+```
+
+**Bukan interface baru** — `Limiter` tetap apa adanya dan seluruh call site Phase 1 tidak berubah.
+Handler publik mendeklarasikan interface konsumennya sendiri berisi satu metode `Take`. Abstraksi baru
+menunggu implementasi kedua yang nyata (Aturan #28).
+
+### Angka & kunci
+
+| Aspek | Nilai |
+|---|---|
+| Batas | 60 request / menit **per `api_keys.id`** (`PUBLIC_API_RATE_LIMIT`, default 60) |
+| Jendela | tetap, 1 menit |
+| Kunci limiter | `publiclead:key:<api_key_id>` — bukan per IP: satu website di belakang CDN muncul sebagai banyak IP, dan kredensial adalah identitas yang sebenarnya kita batasi |
+
+Header dikirim pada **setiap** response jalur API key, termasuk `201`, `200` (replay), dan `4xx` —
+`api.md`: *"Dikirim sejak versi pertama"*. Pada `429` ditambah `Retry-After` (detik sampai `ResetAt`).
+
+```go
+// internal/shared/httpx
+func SetRateLimitHeaders(c *gin.Context, r ratelimit.Result)
+```
+
+Rate limit dievaluasi **setelah** kredensial diverifikasi — kunci limiternya adalah `api_key_id`, yang
+baru diketahui setelah lookup. Konsekuensi yang diterima: request dengan kredensial sampah tidak
+dibatasi oleh limiter ini. Yang membatasinya adalah biaya lookup itu sendiri (satu index hit) dan
+`invalid_api_key` yang tidak membedakan penyebab, sehingga penebakan tidak memberi sinyal apa pun.
+
+---
+
+## 7. Idempotency & retensi (keputusan D3)
+
+Mekanismenya **tidak berubah** dari Phase 2 §7: unique violation pada `uq_leads_org_idempotency`, replay
+mengembalikan lead asli dengan `200`. Yang ditambahkan hanya retensi.
+
+`idempotency_key` adalah **kolom pada `leads`**, bukan tabel tersendiri (freeze: *"resource-nya adalah
+response-nya"*). Jadi "menghapus key yang kedaluwarsa" berarti mengosongkan kolomnya, **bukan** menghapus
+lead:
+
+```sql
+-- di jalur POST /v1/leads, sebelum insert, DI LUAR transaksi lead
+UPDATE leads
+   SET idempotency_key = NULL
+ WHERE organization_id = $1
+   AND idempotency_key IS NOT NULL
+   AND created_at < now() - interval '48 hours';
+```
+
+Lead-nya tetap utuh; yang kedaluwarsa hanyalah jaminan *"kirim ulang mengembalikan yang ini"*.
+
+| Aspek | Ketentuan |
+|---|---|
+| Umur | 48 jam (`api.md`: 24–48) |
+| Kapan dijalankan | Pada `POST /v1/leads` jalur API key, **paling sering sekali per organization per jam** (throttle in-memory, sama bentuknya seperti `last_used_at` §10) |
+| Di dalam transaksi lead? | **Tidak.** Pembersihan yang gagal tidak boleh menggagalkan lead yang sedang masuk. |
+| Bila tidak ada traffic | Tidak ada yang dibersihkan — dan tidak ada yang perlu dibersihkan |
+
+**Kenapa penghapusan malas, bukan cron.** Freeze bagian 6 aturan #4: tabel `jobs` + worker
+diperkenalkan saat ada kebutuhan async **nyata** — push notification (Phase 5) atau webhook (Phase 7).
+Membangun scheduler untuk satu `UPDATE` adalah infrastruktur yang lebih besar dari masalahnya.
+
+**Konsekuensi yang diterima:** organization yang berhenti mengirim lead selamanya akan menyimpan key
+lamanya selamanya. Tidak berbahaya (tidak pernah membuat duplikat) dan volumenya terbatas oleh jumlah
+lead yang pernah mereka kirim.
+
+---
+
+## 8. CORS & Aturan #23 (keputusan D5)
+
+**Tidak ada kode baru.** `CORS_ALLOWED_ORIGINS` (#30) berisi origin dashboard kita, tidak pernah domain
+pelanggan. Konsekuensinya sudah berlaku hari ini: `fetch('…/v1/leads', {headers:{Authorization:'Bearer
+jln_live_…'}})` dari website pelanggan diblokir browser sebelum response terbaca.
+
+Yang ditambahkan Phase 4:
+
+1. **Test yang menguncinya** — request dengan `Origin: https://toko-pelanggan.example` tidak menerima
+   satu pun header `Access-Control-Allow-*` (§16). Tanpa test ini, seseorang yang kelak menambahkan
+   wildcard "supaya lebih mudah" tidak akan tertahan apa pun.
+2. **Peringatan eksplisit di halaman dokumentasi** (§13) — *"kirim dari server Anda, jangan dari
+   browser"*, dengan alasannya, bukan hanya larangannya.
+
+> Kalimat *"kenapa tidak bisa dari JavaScript website saya?"* adalah pertanyaan support yang **akan**
+> datang. Menjawabnya di halaman dokumentasi lebih murah daripada menjawabnya satu per satu — dan
+> jawabannya bukan "tidak didukung" melainkan "kunci Anda akan terbaca setiap pengunjung". Kebutuhan itu
+> punya jawaban sendiri di Phase 6 (ADR-005).
+
+---
+
+## 9. Endpoint
+
+### Manajemen kredensial — principal **user**, di belakang `authn.Middleware`
+
+| Method | Path | Isi | Role |
+|---|---|---|---|
+| `POST` | `/v1/api-keys` | `{name, scopes?}` → `201 {id, name, key_prefix, scopes, created_at, secret}` | Owner, Admin |
+| `GET` | `/v1/api-keys` | Daftar, terbaru dulu — **tanpa** `secret` | Owner, Admin |
+| `DELETE` | `/v1/api-keys/{id}` | Revoke → `204`, idempoten | Owner, Admin |
+
+`secret` **hanya** ada di response `POST`, sekali (Aturan #21). Tidak ada `GET /v1/api-keys/{id}` —
+daftar sudah memuat seluruh field yang boleh dilihat, dan endpoint detail hanya menambah permukaan.
+
+Manager dan Employee **tidak punya akses sama sekali** — bukan read-only. API key adalah kredensial yang
+bisa memasukkan data ke organization; daftarnya sendiri adalah informasi tentang integrasi apa yang
+hidup. Ini sejajar dengan `invitation.*` yang juga Owner/Admin saja.
+
+### API publik — principal **api_key**
+
+| Method | Path | Isi |
+|---|---|---|
+| `POST` | `/v1/leads` | `{name, email?, phone?, company?, notes?, …}` + `Idempotency-Key?` → `201` / `200` (replay) |
+
+Endpoint yang **sama** dengan jalur dashboard (D2). Ini satu-satunya endpoint di API ini yang menerima
+dua principal, dan §3 adalah alasan tertulisnya yang `api.md` syaratkan.
+
+### Action `authz` baru
+
+```
+ActionAPIKeyCreate  api_key.create   Owner, Admin
+ActionAPIKeyList    api_key.list     Owner, Admin
+ActionAPIKeyRevoke  api_key.revoke   Owner, Admin
+```
+
+Ketiganya **tidak** ada di `apiKeyScopeFor` (§4) — API key tidak bisa membuat API key. Ini kasus yang
+freeze 5.1 sebut namanya secara eksplisit.
+
+---
+
+## 10. `last_used_at` — di-throttle
+
+ADR-004 aturan #3: *"di-update async atau throttled, bukan setiap request — kalau tidak, tabel ini
+menjadi write hotspot."*
+
+| Aspek | Ketentuan |
+|---|---|
+| Frekuensi | Paling sering **sekali per 5 menit per kunci** — peta in-memory `map[uuid.UUID]time.Time` di `apikey.Usecase` |
+| Kapan | Setelah response terkirim, tidak memblokir request |
+| Bila proses restart | Peta kosong → paling banyak satu penulisan ekstra per kunci. Tidak ada koreksi yang perlu dilakukan. |
+| Akurasi yang dijanjikan | *"terakhir dipakai sekitar…"*, dan dashboard menuliskannya begitu — bukan timestamp presisi |
+
+Peta ini tumbuh sebesar jumlah kunci aktif per proses; tidak ada eviction, sama seperti
+`ratelimit.FixedWindow` (utang yang sudah tercatat sejak #9).
+
+---
+
+## 11. Audit log & logging (Aturan #26)
+
+| Aksi | `action` | `actor_type` |
+|---|---|---|
+| Buat kredensial | `api_key.created` | `user` |
+| Revoke kredensial | `api_key.revoked` | `user` |
+
+Lead yang masuk lewat API **tidak** menulis audit log — ia menulis `activity`, seperti setiap lead lain.
+Audit log untuk aksi sensitif; membuat lead bukan salah satunya, dan satu baris audit per lead masuk
+akan membuat tabel itu tumbuh secepat `leads`.
+
+### Yang tidak boleh masuk log
+
+Aturan #26 sudah menyebut *raw API key* dan *payload lead lengkap*. Dua jalur baru yang berisiko:
+
+1. **Request yang gagal.** `401 invalid_api_key` menggoda untuk mencatat kredensial yang ditolak "supaya
+   bisa di-debug". Yang boleh dicatat: `key_id` (bukan rahasia). Yang tidak: apa pun setelahnya.
+2. **`raw_payload`.** Disimpan ke database, **tidak pernah** ke log — termasuk saat validasi gagal.
+   Pesan errornya menyebut nama field, bukan isinya.
+
+Redaksi di logger, bukan di call site (Aturan #26).
+
+---
+
+## 12. Dashboard — manajemen API key
+
+`crm_dashboard`, mengikuti seluruh konvensi Phase 3 (skill `jualin-dashboard`).
+
+| Layar | Isi |
+|---|---|
+| `/settings/api-keys` | Daftar: `key_prefix`, nama, scopes, dibuat oleh, terakhir dipakai, status. Tombol *Buat kunci baru* dan *Cabut*. |
+| Dialog buat | Satu field nama → response memuat `secret` |
+| Dialog "kunci Anda" | **Satu-satunya kali secret terlihat.** Tombol salin, peringatan bahwa ia tidak bisa dilihat lagi, tombol tutup yang mengharuskan konfirmasi telah menyimpan |
+| Dialog cabut | Konfirmasi tunggal, menyebut nama kunci — pencabutan tidak bisa dibatalkan |
+
+Digerbang `role === 'owner' || role === 'admin'`, sejajar dengan area tim di #34. Manager/Employee tidak
+melihat menunya sama sekali.
+
+**Yang harus dihindari:** menaruh `secret` ke state yang bertahan (context, `localStorage`, URL). Ia hidup
+di state dialog dan mati bersamanya. Aturan #25 melarang token di `localStorage`; raw API key lebih
+sensitif dari itu — ia tidak kedaluwarsa.
+
+---
+
+## 13. Halaman dokumentasi integrasi
+
+Halaman **menghadap pelanggan** di dashboard (`/settings/api-keys/docs` atau tab di layar yang sama),
+bukan file Markdown di repo. Alasannya: pembacanya adalah developer milik pelanggan yang sedang membuka
+dashboard untuk menyalin kunci — jarak antara kunci dan cara memakainya harus nol.
+
+Isi minimum:
+
+1. **Satu contoh `curl` yang bisa disalin dan langsung bekerja**, dengan `key_prefix` kunci yang sedang
+   dilihat sudah terisi di dalamnya
+2. Autentikasi: header, format, dan **peringatan browser** (§8)
+3. Field yang diterima, mana yang wajib, apa yang terjadi pada field tak dikenal (`raw_payload`)
+4. Katalog error yang mungkin diterima integrator, dengan arti dan tindakan yang disarankan
+5. `Idempotency-Key`: kapan dipakai, apa yang terjadi saat diulang, retensi 48 jam
+6. Header rate limit dan arti `429`
+
+**Kriteria selesai bukan "halaman ada", melainkan "integrasi bekerja tanpa bertanya"** (acceptance
+criterion #10) — diverifikasi dengan mengikuti halaman itu dari nol untuk membuat lead pertama,
+bukan dengan membacanya ulang.
+
+---
+
+## 14. Error code baru
+
+Ditambahkan ke katalog di [`api.md`](../../architecture/api.md):
+
+| HTTP | `code` | Kapan |
+|---|---|---|
+| 401 | `invalid_api_key` | Kredensial `jln_*` tidak dikenal, sudah direvoke, atau kedaluwarsa — **ketiganya pesan yang sama** |
+| 403 | `insufficient_scope` | Kredensial sah tapi scope-nya tidak mencakup aksi ini, termasuk setiap endpoint aplikasi pengguna (Aturan #24) |
+| 413 | `payload_too_large` | Body `POST /v1/leads` di atas 64 KB |
+
+**Ketiga penyebab `invalid_api_key` sengaja tidak dibedakan.** Membedakan "tidak ada" dari "sudah
+direvoke" memberi tahu penebak bahwa kunci itu pernah ada — bentuk kebocoran yang sama dengan 403-vs-404
+di Aturan #6.
+
+Dipakai ulang tanpa perubahan: `validation_failed` (400), `rate_limited` (429), `internal_error` (500).
+
+---
+
+## 15. Paket baru
+
+```
+internal/apikey/          entity · port · usecase · repository_postgres · handler_http
+```
+
+Satu paket, bentuk lima berkas penuh (ADR-011), dengan `Store`/`Repos` sendiri dan composition root
+`cmd/api/apikey_store.go`.
+
+Yang **bertambah** pada paket yang sudah ada:
+
+| Paket | Perubahan |
+|---|---|
+| `internal/shared/tenant` | `Context.Scopes []string` |
+| `internal/shared/authz` | 3 `Action` baru + cabang `PrincipalAPIKey` + peta `apiKeyScopeFor` |
+| `internal/shared/authn` | `APIKeyResolver` + `MiddlewareWithAPIKey` |
+| `internal/shared/ratelimit` | `Result` + `(*FixedWindow).Take` |
+| `internal/shared/httpx` | `SetRateLimitHeaders` |
+| `internal/shared/config` | `PUBLIC_API_RATE_LIMIT` |
+| `internal/lead` | `RawPayload`, `SourceAPIKeyID`, cabang `PrincipalAPIKey` di `Create` |
+
+Tidak ada paket `internal/publicapi`. Endpoint publiknya **adalah** `POST /v1/leads` milik
+`internal/lead`; memindahkannya ke paket lain berarti dua handler untuk satu route.
+
+---
+
+## 16. Rencana test
+
+### Test keamanan wajib
+
+| Skenario | Harapan |
+|---|---|
+| API key memanggil `GET /v1/leads` | **403** `insufficient_scope` |
+| API key memanggil `GET /v1/memberships`, `POST /v1/invitations`, `POST /v1/api-keys` | **403** — dan ketiganya diuji, bukan diwakili satu |
+| **Tabel atas seluruh `authz.Action`**: setiap action ≠ `lead.create` ditolak untuk `PrincipalAPIKey` | Action baru phase berikutnya ikut terjaga otomatis |
+| Kunci direvoke, lalu dipakai | **401** `invalid_api_key` seketika, tanpa jeda |
+| Kunci organization A membuat lead, dibaca dari organization B | **404** |
+| `secret` kunci A + `key_id` kunci B | **401** — perbandingan constant-time tidak bocor |
+| `key_id` ada, secret salah satu karakter | **401**, pesan **identik** dengan `key_id` yang tidak ada |
+| API key mengirim `assigned_to_membership_id` | **403**, lead **tidak** dibuat |
+| Body 65 KB | **413**, tidak ada baris tertulis |
+| `Origin: https://toko-pelanggan.example` pada `POST /v1/leads` | Tidak ada satu pun header `Access-Control-Allow-*` |
+| Response `401` mana pun | Raw kredensial tidak muncul di log (diperiksa terhadap buffer log, bukan dengan membaca kode) |
+
+### Wajib di bawah konkurensi
+
+| Test | Membuktikan |
+|---|---|
+| N request bersamaan dengan `Idempotency-Key` sama lewat API key | Tepat **satu** lead — jalur Phase 2 tetap utuh melalui kredensial baru |
+| N request bersamaan melewati batas rate limit | Jumlah `201` **tepat** sama dengan batas, sisanya `429` — bukan "kira-kira" |
+
+### Harness isolasi tenant
+
+`cmd/api/tenant_isolation_test.go` bertambah entri `api_key` ke `[]isolationCase` yang sudah ada sejak
+#11 — **menambah entri, bukan menulis harness baru**.
+
+**Kriteria kualitas tetap berlaku: harness harus terbukti bisa gagal.** Prosedurnya sudah dijalankan di
+#11, #23, dan #30; ulangi untuk `api_key` — hapus predikat `organization_id` dari
+`FindByID` secara sengaja, pastikan merah, kembalikan.
+
+### Test lain
+
+- Format: `Generate()` menghasilkan `key_id` 12 karakter, secret 43 karakter, prefix cocok; `Parse()` menolak bentuk cacat (tanpa underscore, environment tak dikenal, secret kosong)
+- `Take()` pada `FixedWindow`: `Remaining` menurun, `ResetAt` maju satu jendela, `Allowed` berubah tepat di batas
+- Retensi idempotency: key berumur 49 jam menjadi NULL, key berumur 47 jam tetap
+- `last_used_at`: dua request berturut-turut menghasilkan **satu** `UPDATE`
+- Setiap usecase punya test unit tanpa Docker (`TestUnit_*`, fake `Store`) — ADR-011
+- **Dashboard**: `secret` tidak pernah keluar dari state dialog (test unit atas fungsi murni yang membentuk baris daftar, mengikuti pola `lib/nav.ts`, `lib/team-permissions.ts`)
+
+### Verifikasi manual yang tidak bisa digantikan test
+
+`curl` dari mesin **di luar jaringan pengembangan** → lead muncul di dashboard dengan penanda `api`
+(acceptance criterion #1). Test integrasi berjalan di dalam proses yang sama; ia tidak bisa membuktikan
+bahwa endpoint ini benar-benar terjangkau dari luar.
+
+---
+
+## 17. Risiko teknis
+
+| Risiko | Mitigasi |
+|---|---|
+| **API key bisa memanggil endpoint aplikasi pengguna** — kegagalan terparah phase ini: kredensial yang bocor dari website statis berubah menjadi pengambilalihan organization | Otorisasi di `authz`, bukan per handler (§4); routing yang hanya memasang `MiddlewareWithAPIKey` pada satu route (§3); test tabel atas **seluruh** `Action` (§16) |
+| **Raw secret bocor lewat log atau response** | Tidak pernah disimpan (hanya hash); hanya ada di satu response; test yang memeriksa buffer log; dashboard menahannya di state dialog saja |
+| **Rate limit di-bypass** karena kuncinya IP, bukan kredensial | Kunci limiter adalah `api_key_id` (§6) |
+| **`last_used_at` menjadi write hotspot** | Throttle 5 menit (§10), diuji |
+| **Perbandingan secret bocor lewat waktu** | `subtle.ConstantTimeCompare` (ADR-004), dan pesan `401` yang identik untuk ketiga penyebab (§14) |
+| **Bentuk request terlanjur dipakai integrator lalu perlu berubah** | Satu-satunya endpoint publik adalah yang bentuknya sudah dipakai internal sejak Phase 2 — ia tidak dirancang di phase ini, hanya dibuka |
+| **Timeline dashboard menampilkan aktor kosong** untuk lead dari API | Diverifikasi di issue #2, diperbaiki di #3 bila perlu (§5) |
+| **Halaman dokumentasi ditulis dari rencana, bukan dari perilaku** | Ditempatkan sebagai issue terakhir, setelah endpointnya berjalan; diverifikasi dengan mengikutinya dari nol |
+
+---
+
+## 18. Yang berubah pada dokumentasi
+
+| Berkas | Perubahan |
+|---|---|
+| [`api.md`](../../architecture/api.md) | **Bab baru "API Publik"** — autentikasi API key, format `jln_live_`, scope, contoh `curl`, header rate limit, idempotency. Ini yang bagian *"Yang menyusul di Phase 4"* janjikan; bagian itu diganti oleh babnya. Plus 3 error code baru (§14). |
+| [`authentication.md`](../../architecture/authentication.md) | Jalur kedua dari tiga (*"API key → Phase 4"*) berubah dari rencana menjadi kenyataan: lookup, verifikasi, revoke, dan **kenapa tidak ada CSRF di jalur ini** |
+| [`authorization.md`](../../architecture/authorization.md) | Baris `api_key.*` di matriks role; bagian baru untuk otorisasi berbasis scope (§4) — matriks role saja tidak lagi menggambarkan seluruh sistem |
+| [`multi-tenancy.md`](../../architecture/multi-tenancy.md) | Lapis 1: `PrincipalAPIKey` akhirnya terpakai; catatan bahwa `key_id` unik lintas organization dan kenapa itu bukan pelanggaran (§1.1) |
+| `STATUS.md` | Phase 4 selesai; utang retensi `idempotency_key` **ditutup**; utang eviction map bertambah satu pemakai |
+| `phases/04-public-api/notes.md` | Satu bagian per issue |
+
+---
+
+## 19. Kewajiban yang diteruskan ke phase berikutnya
+
+Ditulis di sini agar tidak bergantung pada ingatan:
+
+> **Phase 5 (Mobile)** tidak menyentuh API key sama sekali (Aturan #24). Yang ia warisi dari phase ini
+> hanya satu: `tenant.Context.Scopes` sekarang ada, dan jalur user **tidak boleh** mulai memakainya —
+> scope adalah mekanisme untuk principal tanpa role.
+>
+> **Phase 6 (Embedded Form)** menambahkan `forms` + `leads.source_form_id` di `0007`, dengan kredensial
+> ketiga (`public_key`, ADR-005) yang **tidak** boleh disatukan dengan API key. Cabang `PrincipalAPIKey`
+> di `authz` (§4) adalah tempat `PrincipalPublicForm` akan menempel — bentuknya sudah ada, isinya belum.
+> Ia juga yang menjawab *"kirim lead dari browser"* yang Phase 4 tolak (§8).
+>
+> **Phase 8 (Billing)** memerlukan quota per plan, yang **bukan** rate limit (§6, prd *Di luar cakupan*).
+> `usage_counters` menghitung; `ratelimit` melindungi. Keduanya tidak saling menggantikan.
+>
+> **Kapan pun `expires_at` diisi**: kolomnya sudah ada dan `invalid_api_key` sudah mencakup kedaluwarsa
+> sebagai penyebab (§14) — yang belum ada hanya UI dan pengisiannya.


### PR DESCRIPTION
Membuka **Phase 4 — Public API**. PRD + TD + pemecahan issue, sesuai `docs/workflow.md` Bagian 1. **Tidak ada kode** di PR ini.

## Kenapa Phase 4 dulu, bukan Phase 5

Bukan soal mana yang lebih penting — freeze menempatkan keduanya tidak saling bergantung. Alasannya **lead time**: pendaftaran Apple Developer Program dan Firebase belum dimulai (`STATUS.md` bagian *Punya Lead Time*, seluruh checkbox masih kosong), dan keduanya menunggu pihak ketiga. Phase 5 yang dimulai sekarang akan berhenti tepat di bagian build iOS dan push notification. Phase 4 tidak menunggu siapa pun.

## Lima keputusan yang ditutup di muka (D1–D5)

| # | Keputusan |
|---|---|
| **D1** | Otorisasi principal tanpa role: `tenant.Context.Scopes` + cabang `PrincipalType` di `authz.Require`, dengan peta berisi **tepat satu** baris (`lead.create → leads:write`). Endpoint baru yang lupa memikirkan API key **gagal aman**. |
| **D2** | `POST /v1/leads` tetap **satu path**, dipilah dari prefix `jln_live_`. `api.md` melarang endpoint menerima dua principal tanpa alasan tertulis — TD §3 adalah alasan itu. |
| **D3** | Retensi `idempotency_key` **48 jam**, penghapusan malas tanpa scheduler. Menutup utang yang diwarisi Phase 2. |
| **D4** | Rate limit 60/menit **per kunci**, bukan per IP. |
| **D5** | API publik tidak bisa dipanggil dari browser — ternyata **sudah** terjaga allowlist CORS #30; yang ditambahkan hanya test dan peringatan di halaman dokumentasi. |

## Satu ketidakkonsistenan di ADR-004 yang ditemukan saat menulis TD

ADR-004 menulis *"secret: 32char"* dan *"entropi 256-bit"* di baris yang sama. Keduanya tidak bisa benar bersamaan (32 karakter base64url ≈ 192 bit). **Diambil 256 bit**, karena seluruh argumen keamanan ADR itu — kenapa SHA-256 sah menggantikan argon2id — bersandar pada angka tersebut. Dicatat di TD §2, bukan diperbaiki diam-diam (Aturan #30).

## Empat issue, bukan dua session

Freeze memetakan Phase 4 sebagai dua session. Yang menambah dua bukan kerumitan backend, melainkan bahwa Phase 4 menyentuh **dua aplikasi**, dan freeze memetakan session sebelum ADR-009 memisahkan repo-nya. Penyimpangan yang sama sudah dilakukan Phase 1 (3→4), Phase 2 (4→5), dan Phase 3 (4→6).

- #46 — Migration `0005`, domain `api_key`, CRUD kredensial (`crm_be`)
- #47 — Autentikasi API key, `POST /v1/leads` publik, rate limit, idempotency (`crm_be`) — **risiko keamanan tertinggi phase ini**
- #48 — Dashboard: manajemen API key (`crm_dashboard`, boleh paralel dengan #47)
- #49 — Halaman dokumentasi integrasi (penutup phase)

## Yang layak diperiksa saat review

1. **Bentuk penegakan Aturan #24 di TD §4** — apakah penolakan datang dari *"action ini tidak ada di peta"* (gagal aman) atau dari *"handler ini mengecek"* (gagal terbuka). Ini bagian yang, bila salah, membuat kunci bocor dari website statis pelanggan menjadi pengambilalihan organization.
2. **D3** — apakah penghapusan malas cukup, atau Anda lebih memilih membiarkan utangnya terbuka sampai ada scheduler nyata di Phase 5/7.
3. **Resolusi ketidakkonsistenan ADR-004** — bila pembacaan saya keliru, yang berubah hanya satu konstanta.

Refs #46, #47, #48, #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)