### PR TITLE
docs: per-issue phase-closure checklists for #46 and #47

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -62,7 +62,10 @@ dokumentasi integrasi**, meski #49 secara praktis lebih mudah ditulis jujur sete
   `docs/phases/04-public-api/td.md` §9, §12
 - Cakupan & acceptance #49: [issue #49](https://github.com/Pravasta/jualin-crm/issues/49) — TD §13,
   §14, §18 — **penutup Phase 4**, mencakup update `api.md`/`authentication.md`/`authorization.md`/
-  `multi-tenancy.md` dan pengecekan seluruh 13 acceptance criteria PRD Phase 4
+  `multi-tenancy.md` dan pengecekan seluruh 13 acceptance criteria PRD Phase 4. Sebelum menutup, cek
+  `docs/issues/046-api-key-crud.md` dan `docs/issues/047-public-lead-api.md` — checklist ringkas hal
+  yang perlu ditinjau ulang dari kedua issue itu (ADR-004 yang belum diperbaiki, angka rate limit yang
+  belum diukur, dll.), bukan pengganti 13 acceptance criteria di atas.
 - Endpoint yang dikonsumsi #48 sudah stabil sejak #46 (`POST/GET/DELETE /v1/api-keys`); #47 tidak
   mengubah bentuknya sama sekali, hanya menambahkan jalur autentikasi terpisah (`POST /v1/leads`).
 - Setelah #48 dan #49 selesai: **Phase 4 tutup**, lanjut ke **Phase 5 — Employee Mobile** (satu-satunya

--- a/docs/issues/046-api-key-crud.md
+++ b/docs/issues/046-api-key-crud.md
@@ -1,0 +1,33 @@
+# Issue #46 — checklist penutupan phase
+
+> Checklist ringkas, **bukan** catatan status. Status pekerjaan tetap hidup di GitHub Issues
+> (ADR-008) — berkas ini hanya mengumpulkan poin yang perlu **dicek ulang saat #49** (penutup Phase 4)
+> menutup phase-nya, supaya tidak ada yang terlewat di antara PR-PR yang sudah lama merge. Detail lengkap
+> tiap poin ada di `docs/phases/04-public-api/notes.md` bagian `## #46` dan PR
+> [#51](https://github.com/Pravasta/jualin-crm/pull/51).
+
+## Deviasi dari TD / ADR
+
+- [ ] **ADR-004 masih menampilkan angka yang salah di dokumennya sendiri.** "secret: 32char" vs "entropi
+      256-bit" tidak bisa benar bersamaan (32 karakter base64url ≈ 192 bit). Kode mengambil 256-bit (`entity.go`,
+      `keyIDRawBytes`/`secretRawBytes`) dan mendokumentasikan alasannya di komentar — tapi **ADR-004
+      sendiri belum diperbaiki**. Perlu diputuskan saat #49: revisi ADR-004 langsung, atau tambahkan
+      catatan errata yang menunjuk ke kode sebagai sumber kebenaran.
+- [ ] **ADR-004 "key_prefix 8 karakter pertama" tidak cocok dengan contohnya sendiri.** Contoh di ADR
+      (`jln_live_a3f9…`) menunjukkan 4 karakter pertama `key_id`, bukan 8. Kode mengikuti contohnya
+      (benar), teksnya belum diperbaiki. Sama seperti poin di atas — revisi atau errata.
+
+## Keputusan yang perlu dicek ulang
+
+- [ ] **Manager & Employee tidak punya akses sama sekali** ke `api_key.*` (bukan read-only seperti
+      `membership.list`). Ini keputusan sadar (TD §9), bukan bug — pastikan masih relevan saat #49
+      mengecek matriks RBAC final terhadap `authorization.md`.
+- [ ] `expires_at` tetap `NULL` selamanya di seluruh Phase 4 — kolomnya ada, isinya tidak pernah diisi.
+      Pastikan halaman dokumentasi integrasi (#49) tidak menyiratkan fitur masa berlaku yang belum ada.
+
+## Bug ditemukan & sudah diperbaiki (tidak perlu tindakan lanjut, dicatat untuk arsip)
+
+- [x] Fixture test dengan `membership_id` acak menabrak `fk_api_keys_created_by` (composite FK
+      sungguhan) → `500`. Diperbaiki dengan men-seed membership asli sebelum PR #51 dibuka.
+- [x] Test tabel per-role (`authz_test.go`) tidak pernah mendapat 3 baris `api_key.create/list/revoke`
+      saat aksinya ditambahkan — ketahuan & dibackfill di #47 (PR #52), bukan di sini.

--- a/docs/issues/047-public-lead-api.md
+++ b/docs/issues/047-public-lead-api.md
@@ -1,0 +1,43 @@
+# Issue #47 — checklist penutupan phase
+
+> Checklist ringkas, **bukan** catatan status. Status pekerjaan tetap hidup di GitHub Issues
+> (ADR-008) — berkas ini hanya mengumpulkan poin yang perlu **dicek ulang saat #49** (penutup Phase 4)
+> menutup phase-nya. Detail lengkap tiap poin ada di `docs/phases/04-public-api/notes.md` bagian `## #47`
+> dan PR [#52](https://github.com/Pravasta/jualin-crm/pull/52).
+
+## Deviasi dari teks issue / TD — sudah diverifikasi benar, catat alasannya di dokumentasi #49
+
+- [ ] **Empat endpoint non-`POST /v1/leads` menghasilkan `401`, bukan `403` seperti tertulis literal di
+      checklist acceptance criteria issue #47.** Sudah diverifikasi **tidak** bertentangan dengan PRD
+      Phase 4 — acceptance criterion PRD #5 hanya mensyaratkan *"API key tidak bisa memanggil satu pun
+      endpoint aplikasi pengguna... karena otorisasi memang tidak punya jalan untuk mengizinkannya"*,
+      tanpa menyebut kode status tertentu; `401` (ditolak di autentikasi, sebelum authz sama sekali
+      dikonsultasi) justru bentuk yang **lebih kuat** dari "tidak punya jalan" dibanding `403`. Yang
+      perlu dilakukan #49: pastikan halaman dokumentasi integrasi menyebut `401` sebagai perilaku
+      sesungguhnya untuk permintaan di luar `POST /v1/leads`, bukan `403` yang tidak pernah terjadi.
+- [ ] **`CreateLeadInput` tidak mendapat field `SourceAPIKeyID` seperti tertulis di TD §5.**
+      `source_api_key_id` diturunkan langsung dari `t.APIKeyID` di usecase — dicatat sebagai penyimpangan
+      sadar (analog Aturan #5), bukan celah. Tidak perlu tindakan, hanya perlu diingat bila TD §5 dibaca
+      ulang secara harfiah di masa depan (mis. Phase 6 saat `source_form_id` ditambahkan dengan pola
+      serupa).
+
+## Keputusan yang perlu dicek ulang / ditinjau saat traffic nyata ada
+
+- [ ] **`PUBLIC_API_RATE_LIMIT=60`/menit bukan hasil pengukuran** (TD §6, keputusan D4) — dua orde
+      besaran di atas dugaan traffic SMB normal. Perlu ditinjau ulang begitu integrator sungguhan
+      (bukan simulasi) mulai mengirim lead — bisa jadi terlalu longgar atau terlalu ketat.
+- [ ] **Retensi `idempotency_key` 48 jam, penghapusan malas tanpa scheduler** — throttle 1×/organization/
+      jam. Untuk organization dengan traffic API sangat tinggi (>1 request/jam terus-menerus), sweep ini
+      akan berjalan sesering itu; belum pernah diuji di bawah volume produksi nyata.
+- [ ] **`last_used_at` di-throttle 5 menit/kunci, peta in-memory tanpa eviction** — sama seperti
+      `ratelimit.FixedWindow`'s bucket map (utang sejak #9). Volume MVP aman; catat kembali bila jumlah
+      API key aktif per proses mulai besar.
+
+## Bug ditemukan & sudah diperbaiki (tidak perlu tindakan lanjut, dicatat untuk arsip)
+
+- [x] `leadJSON` tidak pernah menyertakan `source_api_key_id` di response — acceptance criterion PRD #1
+      eksplisit menyebut field ini harus terisi. Ketahuan dari test HTTP pertama, diperbaiki sebelum PR
+      #52 dibuka.
+- [x] Fixture test (`internal/lead`, `cmd/api`) dengan `APIKeyID` acak menabrak `fk_leads_source_api_key`
+      (composite FK sungguhan) → `500`. Kelas bug yang sama seperti #46's `fk_api_keys_created_by`.
+      Diperbaiki dengan men-seed baris `api_keys` sungguhan sebelum PR #52 dibuka.

--- a/docs/phases/04-public-api/issues.md
+++ b/docs/phases/04-public-api/issues.md
@@ -84,6 +84,10 @@ Phase 4 tutup bila **13 acceptance criteria** di [`prd.md`](./prd.md) terpenuhi 
 dari mesin luar → lead di dashboard) dan #5 (API key tidak bisa memanggil satu pun endpoint aplikasi
 pengguna). Lalu:
 
+0. **Cek `docs/issues/046-api-key-crud.md` dan `docs/issues/047-public-lead-api.md`** — checklist ringkas
+   deviasi/keputusan dari kedua issue itu yang perlu ditinjau ulang sebelum phase benar-benar ditutup
+   (mis. ADR-004 yang belum diperbaiki, angka rate limit yang belum diukur). Bukan pengganti langkah
+   1–3 di bawah, hanya supaya tidak ada yang terlewat di antara PR yang sudah lama merge.
 1. `api.md` (bab API Publik), `authentication.md`, `authorization.md`, `multi-tenancy.md` diperbarui (TD §18)
 2. `docs/STATUS.md` — Phase 4 ✅, dan utang retensi `idempotency_key` **ditutup**
 3. Buka **Phase 5 — Employee Mobile** — satu-satunya phase MVP yang tersisa


### PR DESCRIPTION
Permintaan Anda: catatan hasil #46/#47 ditulis di `docs/issues/`, urut sequential, supaya bisa di-*resolve* saat penutupan Phase 4 (#49).

## Isi

- `docs/issues/046-api-key-crud.md`, `docs/issues/047-public-lead-api.md` — checklist ringkas (bukan naratif, itu sudah tugas `notes.md`) berisi tiga kategori: deviasi TD/ADR yang masih perlu ditinjau, keputusan yang perlu dicek ulang, dan bug yang sudah diperbaiki (arsip).
- Dikaitkan eksplisit ke GitHub Issues, **bukan** pengganti status di sana (ADR-008) — setiap berkas menyatakan ini di baris pertama.
- Dihubungkan dari `docs/phases/04-public-api/issues.md`'s "Setelah keempatnya selesai" dan `docs/STATUS.md`'s "Berikutnya" — sebagai langkah **sebelum** 13 acceptance criteria PRD, bukan pengganti.

## Temuan saat menulis ini

Poin "endpoint lain → 401 bukan 403" (deviasi dari teks checklist issue #47) saya cek ulang terhadap **PRD Phase 4** (bukan hanya TD): acceptance criterion PRD #5 hanya mensyaratkan *"otorisasi memang tidak punya jalan untuk mengizinkannya"* tanpa menyebut kode status — jadi tidak ada konflik di level PRD, hanya di teks checklist issue yang saya tulis sendiri sesi lalu. Dicatat di checklist supaya #49 tidak salah menulis "403" di halaman dokumentasi integrasi.

Refs #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)