### PR TITLE
docs: open Phase 4.5 — Hardening (PRD, TD, issues)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 28 Agustus 2026 — Issue #49 selesai. **Phase 4 — Public API selesai.**
-**Phase sekarang:** Phase 4 selesai — phase berikutnya (5) belum dibuka, lihat *Berikutnya*.
+**Last updated:** 29 Agustus 2026 — **Phase 4.5 — Hardening dibuka** (#57, #58) setelah pemeriksaan `docs/issues/` menemukan Aturan #34 tidak pernah ditegakkan.
+**Phase sekarang:** Phase 4.5 — Hardening. Phase 4 selesai; Phase 5 menunggu, lihat *Berikutnya*.
 
 ---
 
@@ -56,9 +56,39 @@ _(kosong)_
 
 ## Berikutnya
 
-**Phase 4 — Public API selesai** (#46–#49). Dua hal menunggu keputusan manusia sebelum sesi coding
-berikutnya dimulai — bukan sesuatu yang bisa diputuskan sepihak dalam sesi agent, pola yang sama seperti
-saat Phase 3 tutup:
+### Phase 4.5 — Hardening (#57, #58) — dikerjakan lebih dulu
+
+**Tidak direncanakan.** Lahir dari pemeriksaan ulang `docs/issues/046` & `047` sebelum Phase 5 dibuka —
+pemeriksaan yang memang gunanya untuk itu. Dokumen: `docs/phases/04.5-hardening/`.
+
+Penutupan Phase 4 mencatat tiga poin "butuh traffic produksi nyata". Dua di antaranya memang begitu.
+Yang ketiga (peta tanpa eviction) **salah dikategorikan** — empat map digabung jadi satu baris utang
+padahal dua ber-key entity bisnis (terbatas, penundaannya benar) dan dua ber-key input penyerang
+(tidak butuh data apa pun untuk diketahui salah). Menarik benang itu menemukan bahwa **Aturan #34
+secara faktual tidak pernah ditegakkan sejak Phase 1**:
+
+- `cmd/api/main.go:85` memakai `gin.New()` tanpa `SetTrustedProxies`; default Gin 1.12 mempercayai
+  setiap peer sebagai proxy, sehingga `c.ClientIP()` mengembalikan isi `X-Forwarded-For` — **dibuktikan
+  langsung**. Seluruh limit per-IP bisa dilewati satu header; sisi per-email dilewati dengan mengganti
+  alamat tiap request. Konsekuensinya: email verifikasi & reset password tak terbatas ke alamat mana
+  pun, membakar reputasi domain pengirim yang justru item lead-time di bawah.
+- `auth.LoginLimiter` diukur menahan **64,7 MB untuk 500.000 email karangan, tidak pernah dibebaskan**.
+- Test-nya memberi lampu hijau palsu: `internal/auth/handler_test.go:125` justru **bersandar** pada
+  `RemoteAddr` konstan. Tidak ada satu pun test di `crm_be` yang pernah mengirim `X-Forwarded-For`.
+  Standar "harness terbukti bisa gagal" yang diterapkan ketat untuk isolasi tenant (#8, #11, #23, #30,
+  #46) tidak pernah diterapkan ke rate limit.
+
+**Bukan darurat** — belum ada yang ter-deploy. Tapi tidak boleh dibawa ke produksi, dan lebih murah
+sekarang: `TRUSTED_PROXIES` adalah keputusan deployment, dan hosting belum dipilih — jadi hosting bisa
+dipilih untuk memenuhi kontraknya, bukan kontraknya ditambal untuk memenuhi hosting.
+
+**Tidak memblokir Phase 5.** Dikerjakan lebih dulu karena murah, terbatas, dan menyentuh kode yang akan
+lebih mahal diubah setelah ada klien kedua menempel padanya.
+
+### Setelah itu
+
+Dua hal menunggu keputusan manusia — bukan sesuatu yang bisa diputuskan sepihak dalam sesi agent, pola
+yang sama seperti saat Phase 3 tutup:
 
 1. **Demo ke calon pengguna** (freeze bagian 4) — tujuan Phase 3, **masih belum dilakukan**. Dicatat
    lagi di sini karena penutupan Phase 4 adalah titik alami kedua untuk mengingatkannya — dua phase
@@ -98,7 +128,8 @@ Riwayat #46–#49 di `docs/phases/04-public-api/issues.md` dan `notes.md`. Riway
 |---|---|---|
 | Tidak ada test end-to-end otomatis untuk graceful shutdown | Issue #1 | Diverifikasi manual (build binary + SIGINT). Otomatisasi butuh test yang menjalankan binary sungguhan dan mengirim sinyal OS — `go run` tidak meneruskan sinyal ke child process, jadi tidak bisa diuji lewat itu. Belum ada issue yang mencakup ini; angkat saat menyentuh area shutdown lagi. |
 | Tidak ada auto-migrate saat container `api` start | Issue #2 | `make migrate-up` dijalankan manual. Sengaja dipisah dari entrypoint `api` — migration dan serving punya kelas kegagalan berbeda. |
-| `ratelimit.FixedWindow` tidak pernah membersihkan key lama | Issue #9 | Map tumbuh tanpa batas seiring IP/email baru muncul. Tidak masalah di volume MVP; perlu eviction sebelum traffic produksi nyata. **Pola yang sama sekarang punya dua pemakai lagi sejak Phase 4** (#47): `apikey.Usecase`'s peta throttle `last_used_at` (per kunci, 5 menit) dan `lead.Usecase`'s peta throttle sweep `idempotency_key` (per organization, 1 jam) — keduanya map in-memory tanpa eviction, debt yang sama, belum jadi masalah karena volume MVP masih kecil. |
+| `ratelimit.FixedWindow` & `auth.LoginLimiter` tidak pernah membersihkan key lama | Issue #9, #10 | **Dijadwalkan Phase 4.5 (#58).** Keduanya ber-key email/IP — yaitu **input penyerang yang belum terautentikasi**, bukan entity bisnis. `LoginLimiter` diukur menahan 64,7 MB untuk 500.000 email karangan tanpa pernah membebaskannya (`RecordSuccess` hanya menghapus saat login *berhasil*). Catatan #49 sebelumnya menggabungkan ini dengan dua map Phase 4 di bawah dan menunda semuanya dengan alasan "butuh traffic" — **kategorisasi itu salah**, lihat `docs/phases/04.5-hardening/prd.md`. |
+| `apikey.lastUsedThrottle` & `lead.idempotencyCleanupThrottle` tanpa eviction | Issue #47 | **Sengaja dibiarkan** (keputusan H3 Phase 4.5). Ber-key `api_key_id` dan `organization_id` — terbatas oleh jumlah entity bisnis yang benar-benar ada, dan hanya bertambah lewat jalur terautentikasi. Menambahkan eviction ke sini berarti membangun mekanisme untuk masalah yang belum ada (Aturan #27–#29). |
 | Angka rate limit (register 5/jam, resend 3/jam+10/jam) belum final | Issue #9 | Cukup untuk membuktikan mekanisme aktif, bukan hasil tuning. **Sebagian ditutup di Phase 4**: batas API publik ditetapkan (D4 — 60/menit per kunci, `PUBLIC_API_RATE_LIMIT`) — tapi angka itu sendiri **juga belum hasil pengukuran** (`docs/issues/047-public-lead-api.md`), baru bisa ditinjau ulang begitu integrator produksi nyata mulai mengirim lead. Angka endpoint email masih default konservatif. |
 | `notifications` tidak punya retensi | Issue #22, TD §2 | Sama seperti `idempotency_key` — tidak ada scheduler di Phase 2 untuk membersihkan notifikasi lama. Tidak mendesak di volume MVP. |
 | Retensi `idempotency_key` belum diuji di volume traffic tinggi | Issue #47, TD §7 | Sweep 1×/organization/jam cukup untuk MVP; organization dengan traffic API sangat tinggi (>1 request/jam terus-menerus) belum pernah diukur. Ditinjau ulang begitu ada data nyata (`docs/issues/047-public-lead-api.md`). |
@@ -167,6 +198,13 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 > **Status per issue tidak dicatat di sini** — ia hidup di GitHub Issues (ADR-008).
 > Dokumen ini hanya melacak level phase.
 
+> **Kenapa "4.5" dan bukan phase bernomor baru:** penomoran phase berasal dari `freeze.md`, yang
+> 🔒 FROZEN dan sudah memakai 5–9. Menyisipkan phase baru berarti menggeser Phase 5–9 dan membuat
+> setiap rujukan "Phase 6" di dokumen lain menjadi ambigu. Nomor pecahan menandai phase ini apa
+> adanya: **perbaikan tak terencana yang menyela**, bukan bagian dari rencana produk. Freeze tidak
+> disentuh — Aturan #34 tidak berubah; yang diperbaiki adalah implementasi yang tidak pernah
+> memenuhinya.
+
 | Phase | Nama | PRD | TD | Issues | Selesai |
 |---|---|---|---|---|---|
 | 0 | Foundation | ✅ | ✅ | ✅ #1–#3 | ✅ |
@@ -174,6 +212,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 2 | CRM Core | ✅ | ✅ | ✅ #19–#23 | ✅ |
 | 3 | Owner Dashboard | ✅ | ✅ | ✅ #30–#35, #40 | ✅ |
 | 4 | Public API | ✅ | ✅ | ✅ #46–#49 | ✅ |
+| 4.5 | Hardening | ✅ | ✅ | ✅ #57–#58 | ⬜ |
 | 5 | Employee Mobile | ⬜ | ⬜ | ⬜ | ⬜ |
 
 Pekerjaan yang sedang berjalan: `gh issue list --state open`

--- a/docs/issues/047-public-lead-api.md
+++ b/docs/issues/047-public-lead-api.md
@@ -28,16 +28,29 @@
 Ketiga poin ini **sengaja dibiarkan terbuka** saat Phase 4 ditutup (#49) — bukan terlewat. Tidak ada
 cara jujur menutupnya tanpa data traffic produksi sungguhan, yang belum ada.
 
+> **Ditinjau ulang 29 Agustus 2026, sebelum Phase 5 dibuka.** Dua poin pertama tetap berlaku. Poin
+> ketiga **tidak** — ia salah dikategorikan dan sebenarnya bug, bukan tuning. Koreksinya di poin itu
+> sendiri. Pelajarannya dicatat di sini karena mudah terulang: *"pola kodenya sama"* bukan alasan yang
+> cukup untuk menyimpulkan *"risikonya sama"* — yang menentukan adalah **siapa yang mengendalikan
+> key-nya**.
+
 - [ ] **`PUBLIC_API_RATE_LIMIT=60`/menit bukan hasil pengukuran** (TD §6, keputusan D4) — dua orde
       besaran di atas dugaan traffic SMB normal. Perlu ditinjau ulang begitu integrator sungguhan
       (bukan simulasi) mulai mengirim lead — bisa jadi terlalu longgar atau terlalu ketat.
 - [ ] **Retensi `idempotency_key` 48 jam, penghapusan malas tanpa scheduler** — throttle 1×/organization/
       jam. Untuk organization dengan traffic API sangat tinggi (>1 request/jam terus-menerus), sweep ini
       akan berjalan sesering itu; belum pernah diuji di bawah volume produksi nyata.
-- [ ] **`last_used_at` di-throttle 5 menit/kunci, peta in-memory tanpa eviction** — sama seperti
-      `ratelimit.FixedWindow`'s bucket map (utang sejak #9). Volume MVP aman; catat kembali bila jumlah
-      API key aktif per proses mulai besar. Dicatat lagi di `docs/STATUS.md`'s Utang Teknis (#49) sebagai
-      pemakai kedua dari pola map-tanpa-eviction yang sama.
+- [x] ~~**`last_used_at` di-throttle 5 menit/kunci, peta in-memory tanpa eviction** — sama seperti
+      `ratelimit.FixedWindow`'s bucket map (utang sejak #9).~~ **Dikoreksi 29 Agustus 2026 — poin ini
+      salah dikategorikan.** Menyamakan `lastUsedThrottle` dengan `ratelimit.FixedWindow` menggabungkan
+      dua hal yang berbeda kelas: yang pertama ber-key `api_key_id` (terbatas jumlah kunci, hanya
+      bertambah lewat jalur terautentikasi), yang kedua ber-key email/IP — **input penyerang yang belum
+      terautentikasi, tanpa batas**. Karena disamakan, keduanya ikut ditunda dengan alasan "butuh
+      traffic produksi", padahal hanya yang pertama yang begitu.
+      Menelusuri kesalahan ini menemukan bahwa **Aturan #34 tidak pernah benar-benar ditegakkan**
+      (`ClientIP()` bisa dipalsukan lewat `X-Forwarded-For`). Keduanya sekarang ditangani terpisah di
+      **Phase 4.5 — Hardening** (#57, #58): `FixedWindow` & `LoginLimiter` mendapat eviction;
+      `lastUsedThrottle` **sengaja dibiarkan** (keputusan H3). Lihat `docs/phases/04.5-hardening/prd.md`.
 
 ## Bug ditemukan & sudah diperbaiki (tidak perlu tindakan lanjut, dicatat untuk arsip)
 
@@ -50,6 +63,13 @@ cara jujur menutupnya tanpa data traffic produksi sungguhan, yang belum ada.
 
 ---
 
-**Ditinjau saat penutupan Phase 4 (#49).** Dua bagian pertama selesai. Bagian "keputusan yang dibawa
-maju" **sengaja tetap terbuka** — akan relevan lagi begitu ada integrator produksi nyata, dicatat di
-`docs/STATUS.md` supaya tidak terlupa, bukan diselesaikan sekarang dengan tebakan.
+**Ditinjau saat penutupan Phase 4 (#49).** Dua bagian pertama selesai.
+
+**Ditinjau ulang 29 Agustus 2026 sebelum Phase 5 dibuka** — dan pemeriksaan itu berbuah. Dari tiga poin
+"dibawa maju", **dua tetap terbuka** (angka rate limit, retensi `idempotency_key` di volume tinggi;
+keduanya betul-betul butuh integrator produksi nyata) dan **satu ternyata bug yang menyamar sebagai
+tuning**, yang menelusurinya menemukan Aturan #34 tidak pernah ditegakkan → **Phase 4.5 — Hardening**
+(#57, #58).
+
+> Berkas ini bekerja sebagaimana mestinya. Poin yang ditunda dengan alasan salah tidak akan pernah
+> ketahuan bila tidak ada tempat yang memaksa membacanya lagi.

--- a/docs/phases/04.5-hardening/issues.md
+++ b/docs/phases/04.5-hardening/issues.md
@@ -1,0 +1,55 @@
+# Phase 4.5 — Hardening · Issues
+
+> Indeks pekerjaan. **Tanpa kolom status** — status hidup di GitHub ([ADR-008](../../decisions/ADR-008-delivery-workflow.md)).
+>
+> Status terkini: `gh issue list --milestone "Phase 4.5 — Hardening"`
+
+**Milestone:** [Phase 4.5 — Hardening](https://github.com/Pravasta/jualin-crm/milestone/7)
+
+---
+
+## Daftar
+
+| # | Judul | Aplikasi | Cakupan | TD |
+|---|---|---|---|---|
+| [57](https://github.com/Pravasta/jualin-crm/issues/57) | Trusted proxy: tegakkan Aturan #34 yang selama ini bisa dilewati | `crm_be` | `TRUSTED_PROXIES` + validasi boot, `SetTrustedProxies` di `newRouter`, test anti-spoofing untuk `resend`/`forgot`/`login`. **Akar masalahnya** | §1, §3.1, §3.2 |
+| [58](https://github.com/Pravasta/jualin-crm/issues/58) | Eviction map ber-key penyerang + koreksi kategorisasi utang | `crm_be` | Dua generasi di `FixedWindow` & `LoginLimiter`, koreksi `docs/issues/047`, dokumentasi arsitektur. **Penutup phase** | §2, §3.3, §4 |
+
+---
+
+## Urutan
+
+```
+#57 trusted proxy ──► #58 eviction + penutup
+```
+
+| Dependensi | Sifat |
+|---|---|
+| #58 → #57 | **Lunak, tapi urutannya penting.** Keduanya bisa dikerjakan terpisah, tapi #57 lebih dulu karena ia yang mengubah laju pertumbuhan map dari *tak terbatas* menjadi *terikat pada IP nyata penyerang*. Mengerjakan #58 lebih dulu berarti membangun batas untuk pertumbuhan yang masih tak terbatas — batasnya tetap terlampaui, hanya lebih lambat. |
+
+**Tidak ada pekerjaan paralel.** Phase ini dua issue, berurutan.
+
+---
+
+## Batas per issue
+
+| Issue | Berhenti di |
+|---|---|
+| #57 | `ClientIP()` tidak lagi bisa dipalsukan dan Aturan #34 punya test yang mencoba melewatinya. Map **masih** tumbuh tanpa batas — hanya lebih lambat. |
+| #58 | Phase 4.5 tutup. Angka rate limit, retensi `idempotency_key`, dan utang tak berhubungan (#1, #2, #22) **tidak** disentuh. |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Kenapa hanya dua issue
+
+Phase ini sengaja kecil. Ia bukan phase fitur — ia memperbaiki satu kelas cacat yang ditemukan saat
+memeriksa `docs/issues/046` & `047` sebelum Phase 5 dibuka, dan cakupannya dikunci di dua temuan yang
+**tidak** butuh data traffic untuk diketahui salah.
+
+Dua poin lain di `docs/issues/047` (angka `PUBLIC_API_RATE_LIMIT`, retensi `idempotency_key` di volume
+tinggi) tetap terbuka dan tetap menunggu integrator produksi sungguhan. Menariknya ke sini hanya karena
+"sekalian sedang menyentuh rate limit" akan mengulangi persis kesalahan yang phase ini koreksi:
+menggabungkan hal-hal yang kebetulan bertetangga di kode, lalu memperlakukan mereka sebagai satu
+keputusan.

--- a/docs/phases/04.5-hardening/prd.md
+++ b/docs/phases/04.5-hardening/prd.md
@@ -1,0 +1,196 @@
+# Phase 4.5 — Hardening · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md).
+> Sumber: [`architecture/freeze.md`](../../architecture/freeze.md) Aturan #34 (rate limit per email dan per IP), Aturan #26, bagian 7 (keputusan default — *Rate limit login: Phase 1, bukan Phase 4*) · [ADR-010](../../decisions/ADR-010-fail-fast-startup.md) (fail-fast saat boot) · [`architecture/authentication.md`](../../architecture/authentication.md) bagian *Rate limiting* · temuan penutupan Phase 4 di [`docs/issues/047-public-lead-api.md`](../../issues/047-public-lead-api.md)
+
+---
+
+## Kenapa phase ini ada
+
+**Phase ini tidak direncanakan.** Ia lahir dari pemeriksaan ulang `docs/issues/046` dan `047` sebelum
+Phase 5 dibuka — pemeriksaan yang memang gunanya untuk itu.
+
+Penutupan Phase 4 (#49) mencatat tiga poin sengaja dibiarkan terbuka karena "butuh traffic produksi
+nyata untuk diputuskan jujur". Dua di antaranya memang begitu. Yang ketiga — *"peta `last_used_at` tanpa
+eviction, sama seperti `ratelimit.FixedWindow`'s bucket map"* — **salah dikategorikan**, dan menarik
+benang itu menemukan sesuatu yang lebih besar.
+
+Kesalahannya: empat map in-memory digabung jadi satu baris utang, lalu ditunda seluruhnya dengan alasan
+yang sama. Padahal keempatnya terbelah dua kelas yang berbeda secara fundamental:
+
+| Kelas | Map | Key | Batasnya |
+|---|---|---|---|
+| **Ber-key entity bisnis** | `apikey.lastUsedThrottle` | `api_key_id` | Jumlah kunci yang benar-benar ada |
+| | `lead.idempotencyCleanupThrottle` | `organization_id` | Jumlah tenant |
+| **Ber-key input penyerang** | `ratelimit.FixedWindow.buckets` | email, IP | **Tidak ada** |
+| | `auth.LoginLimiter.state` | email, IP | **Tidak ada** |
+
+Dua yang pertama memang butuh data traffic untuk di-tuning — penundaannya benar dan tetap berlaku.
+Dua yang terakhir tidak butuh data apa pun untuk diketahui salah: map yang key-nya dipilih orang
+asing yang belum terautentikasi tidak boleh tumbuh selamanya, dan itu bisa disimpulkan dari membaca
+kodenya saja.
+
+Menarik benang itu sampai ke akarnya menemukan bahwa **Aturan #34 secara faktual tidak pernah
+ditegakkan**, sejak Phase 1, tanpa satu pun test menyadarinya.
+
+---
+
+## Tiga temuan
+
+### A. `c.ClientIP()` dikendalikan penyerang — akar masalahnya
+
+`cmd/api/main.go:85` membangun engine dengan `gin.New()`. `SetTrustedProxies` tidak dipanggil di mana
+pun. Default Gin 1.12 adalah `trustedProxies: ["0.0.0.0/0", "::/0"]` dengan
+`ForwardedByClientIP: true` dan `RemoteIPHeaders: ["X-Forwarded-For", "X-Real-IP"]` — artinya
+**setiap pengirim request dipercaya sebagai proxy**, dan `ClientIP()` mengembalikan apa pun yang ada
+di header.
+
+Dibuktikan langsung: satu peer asli `203.0.113.9`, tiga nilai `X-Forwarded-For` berbeda, `ClientIP()`
+melaporkan `1.2.3.4`, `5.6.7.8`, `2001:db8::dead`.
+
+Akibatnya seluruh pembatasan per-IP di sistem ini bisa dilewati dengan satu header:
+
+| Endpoint | Key | Nasibnya |
+|---|---|---|
+| `POST /v1/auth/register` | `ip:` | Dilewati |
+| `POST /v1/auth/verify-email/resend` | `email:` + `ip:` | Dilewati **dua-duanya** |
+| `POST /v1/auth/password/forgot` | `forgot:email:` + `forgot:ip:` | Dilewati **dua-duanya** |
+| `POST /v1/auth/login` | `login:ip:` + `login:email:` | Backoff per-IP dilewati |
+| `POST /v1/invitations` | `invite:org:` | **Aman** — ber-key organization |
+| `POST /v1/leads` (API publik) | `publiclead:key:` | **Aman** — ber-key API key |
+
+Sisi per-IP dilewati lewat header; sisi per-email dilewati cukup dengan mengganti alamat email tiap
+request, karena setiap email baru mendapat jatah baru.
+
+**Aturan #34 berbunyi:** *"Setiap endpoint yang memicu pengiriman email wajib dibatasi per alamat email
+dan per IP."* Kedua sisinya bisa dilewati bersamaan. Aturannya ada, kodenya ada, penegakannya tidak ada.
+
+Konsekuensi nyatanya bukan abstrak: **email verifikasi dan reset password bisa dikirim tanpa batas ke
+alamat mana pun.** `STATUS.md` sendiri menyebut deliverability email sebagai pembunuh funnel registrasi
+— *"email verifikasi yang masuk spam akan membunuh funnel registrasi tanpa menghasilkan satu pun
+error"* — dan reputasi domain pengirim adalah item lead-time yang belum diurus. Penyerang, atau
+pesaing, bisa membakarnya tanpa biaya.
+
+### B. Memori tumbuh tanpa batas dan tidak bisa direklamasi
+
+Diukur langsung pada `auth.LoginLimiter` dengan 500.000 email karangan:
+
+```
+entries retained : 500.000
+heap growth      : 64,7 MB  (136 byte/entry)
+```
+
+Tidak ada satu pun yang pernah dibebaskan. `RecordSuccess` hanya menghapus entry saat login **berhasil**
+— yang tidak akan pernah terjadi untuk akun yang tidak ada. `FixedWindow` sedikit lebih baik (bucket
+di-*overwrite* saat jendelanya lewat) tapi tetap tidak pernah **dihapus**.
+
+Digabung dengan temuan A: satu penyerang, satu koneksi, dua entry permanen per request, dan tidak
+pernah menyentuh backoff sama sekali karena setiap key selalu baru.
+
+### C. Test-nya memberi lampu hijau palsu
+
+`internal/auth/handler_test.go:125` justru **bersandar** pada `RemoteAddr` yang konstan, dan
+komentarnya menyebutkan itu terang-terangan:
+
+> `httptest.NewRequest` defaults RemoteAddr to the same value across calls, so every request in this
+> test shares one rate-limit key.
+
+Test itu membuktikan limiter **menyala** saat key-nya sama. Ia tidak pernah membuktikan bahwa key-nya
+**tidak bisa dipilih** penyerang. Kolom enforcement Aturan #34 di freeze berbunyi "Test" — dan test itu
+akan lulus persis sama seandainya IP sepenuhnya bisa dipalsukan.
+
+Tidak ada satu pun test di seluruh `crm_be` yang pernah mengirim `X-Forwarded-For`.
+
+> Ini standar yang project ini terapkan dengan disiplin tinggi di tempat lain. Harness isolasi tenant
+> **dibuktikan bisa gagal** secara adversarial di #8, #11, #23, #30, #46 — predikat tenant sengaja
+> dirusak sementara untuk memastikan test-nya benar-benar merah. Rate limit tidak pernah mendapat
+> perlakuan yang sama. Phase ini memberikannya.
+
+---
+
+## Seberapa mendesak
+
+**Bukan keadaan darurat, tapi tidak boleh dibawa ke produksi.**
+
+Belum ada yang ter-deploy — hosting masih terbuka di *Keputusan Belum Diambil*. Tidak ada pengguna
+nyata yang sedang terpapar hari ini.
+
+Tapi Phase 4 baru saja menambahkan pintu masuk publik **dan** halaman dokumentasi yang mengundang
+developer pelanggan masuk lewat pintu itu. Profil paparan produk ini berubah kelas di Phase 4, dan
+justru itulah momen yang tepat untuk memeriksa ulang asumsi jaringan yang dibuat di Phase 1 — saat
+satu-satunya klien adalah `curl` kita sendiri.
+
+Mengerjakannya sekarang juga lebih murah daripada nanti: `TRUSTED_PROXIES` adalah keputusan
+**deployment**, dan hosting belum dipilih. Menetapkan kontraknya sebelum ada infrastruktur berarti
+hosting dipilih untuk memenuhi kontrak, bukan kontrak ditambal untuk memenuhi hosting.
+
+---
+
+## Kebutuhan
+
+| # | Sebagai… | Saya butuh… | Supaya… |
+|---|---|---|---|
+| 1 | Pemilik sistem | Rate limit per-IP yang benar-benar mengikat, bukan yang bisa dilewati satu header | Aturan #34 berarti sesuatu, bukan sekadar tertulis |
+| 2 | Pemilik sistem | Domain pengirim email saya tidak bisa dibakar reputasinya oleh orang asing | Funnel registrasi tidak mati diam-diam sebelum produk sempat dijual |
+| 3 | Pemilik sistem | Proses yang tidak bisa dihabiskan memorinya oleh orang yang belum login | Satu skrip iseng tidak menjatuhkan seluruh tenant |
+| 4 | Pemilik sistem | Konfigurasi proxy yang **wajib** dinyatakan di produksi, bukan ditebak | Salah pasang di belakang load balancer ketahuan saat boot, bukan saat pengguna pertama diblokir |
+| 5 | Developer berikutnya | Test yang gagal bila proteksinya dilepas | Perbaikan ini tidak diam-diam hilang di refactor tiga phase lagi |
+| 6 | Developer berikutnya | Catatan utang yang membedakan "butuh data" dari "belum dikerjakan" | Poin yang sebenarnya bug tidak ikut tertunda selamanya di balik alasan yang salah |
+
+---
+
+## Acceptance Criteria
+
+Phase 4.5 selesai bila **semuanya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | `X-Forwarded-For` palsu **tidak** lagi mengubah `ClientIP()` saat tidak ada proxy tepercaya dikonfigurasi — dibuktikan test, bukan dibaca dari kode |
+| 2 | `TRUSTED_PROXIES` wajib dinyatakan saat `APP_ENV=production`; boot **gagal** bila tidak (Aturan #36, pola sama seperti `CORS_ALLOWED_ORIGINS` di #30) |
+| 3 | Di belakang proxy tepercaya yang dikonfigurasi, `ClientIP()` mengembalikan IP klien asli — bukan IP proxy, dan bukan header dari peer tak tepercaya |
+| 4 | Aturan #34 punya test yang **mencoba melewatinya** dan gagal melewatinya — untuk `resend` dan `password/forgot`, kedua sisi (email dan IP) |
+| 5 | `ratelimit.FixedWindow` dan `auth.LoginLimiter` tidak lagi tumbuh tanpa batas — dibuktikan dengan pengukuran, bukan dengan pembacaan kode |
+| 6 | Dua map ber-key entity bisnis (`apikey.lastUsedThrottle`, `lead.idempotencyCleanupThrottle`) **tidak disentuh** — dan alasannya tertulis |
+| 7 | Seluruh test yang sudah ada tetap lulus **tanpa perubahan asersi** — perilaku rate limit yang benar tidak berubah, hanya yang salah |
+| 8 | Setiap proteksi baru **terbukti bisa gagal**: dilepas sementara → test merah → dikembalikan (prosedur yang sama seperti harness isolasi tenant) |
+| 9 | `docs/issues/047-public-lead-api.md` dikoreksi — pemisahan dua kelas map tercatat, poin yang memang butuh traffic tetap terbuka |
+| 10 | `authentication.md` menyatakan model kepercayaan jaringan secara eksplisit: apa yang dipercaya, dari siapa, dan kenapa |
+
+---
+
+## Keputusan yang ditutup di phase ini
+
+| # | Pertanyaan | Keputusan | Alasan |
+|---|---|---|---|
+| **H1** | Bagaimana proxy tepercaya dikonfigurasi? | Env `TRUSTED_PROXIES` berisi daftar CIDR. Nilai literal `none` berarti tidak ada proxy di depan. **Wajib** saat `APP_ENV=production` — tidak ada default diam-diam. | Dua kesalahan pasang punya gejala berlawanan dan dua-duanya buruk: percaya semua orang → limit bisa dipalsukan; tidak percaya siapa pun **padahal ada** load balancer → seluruh pengguna terlihat berasal dari satu IP dan berbagi satu jatah, sehingga pengguna keenam diblokir tanpa sebab. Tidak ada nilai default yang benar untuk keduanya, jadi ia harus jadi pilihan sadar. Fail-fast saat boot (ADR-010) mengubah kesalahan konfigurasi dari misteri produksi menjadi pesan error. |
+| **H2** | Bagaimana map dibatasi? | **Dua generasi** (`current` + `previous`, ditukar tiap jendela), bukan sweep berkala dan bukan batas ukuran. | Sweep berkala harus menyapu seluruh map sambil memegang lock — dengan jutaan key hasil serangan, itu justru menjadi pause multi-detik yang menghentikan seluruh proses. Menukar dua map membebaskan seluruh generasi lama sekaligus tanpa memindai satu key pun: O(1) selamanya, tanpa goroutine latar, tanpa `jobs` (freeze bagian 6 aturan 4 melarang worker sampai ada kebutuhan async nyata — ini bukan). |
+| **H3** | Map mana yang diperbaiki? | Hanya dua yang ber-key input penyerang. `apikey.lastUsedThrottle` dan `lead.idempotencyCleanupThrottle` **sengaja tidak disentuh**. | Keduanya ber-key `api_key_id` dan `organization_id` — terbatas oleh jumlah entity bisnis yang benar-benar ada, dan hanya bisa bertambah lewat jalur terautentikasi yang berbayar. Menambahkan eviction ke sana berarti membangun mekanisme untuk masalah yang belum ada (Aturan #27–#29). Penundaannya di `docs/issues/047` **tetap berlaku** — yang dikoreksi hanya alasan yang menggabungkannya dengan dua map lain. |
+| **H4** | Apakah backoff `LoginLimiter` boleh hilang saat generasi ditukar? | Boleh, selama interval tukar ≥ `loginBackoffCap` (5 menit). | Entry yang `nextAllowedAt`-nya sudah lewat memang tidak berguna lagi — melepasnya identik dengan membiarkannya. Selama satu generasi hidup minimal selama backoff terpanjang, tidak ada penyerang yang mendapat jatah lebih cepat daripada tanpa eviction. |
+
+---
+
+## Di luar cakupan
+
+| Tidak dikerjakan | Kenapa |
+|---|---|
+| Angka rate limit final (`PUBLIC_API_RATE_LIMIT=60`, register 5/jam, resend 3+10/jam) | Masih butuh traffic produksi nyata — penundaannya di `docs/issues/047` benar dan tetap berlaku. Phase ini memperbaiki **penegakan**, bukan **angka**. |
+| Retensi `idempotency_key` di volume tinggi | Sama — ber-key `organization_id`, terbatas, butuh data nyata |
+| Eviction untuk `apikey.lastUsedThrottle` & `lead.idempotencyCleanupThrottle` | Keputusan H3 — terbatas oleh entity bisnis |
+| Rate limit terdistribusi (Redis, dsb.) | Freeze melarang infrastruktur di luar PostgreSQL untuk MVP. `ratelimit.Limiter` sudah interface — penggantinya bisa datang tanpa menyentuh satu call site pun |
+| Test e2e graceful shutdown (#1), auto-migrate (#2), retensi `notifications` (#22) | Utang tidak berhubungan. Menggabungkannya ke sini hanya karena "sekalian" melanggar Aturan #27–#29 |
+| Audit ulang seluruh permukaan auth Phase 1–4 | Cakupannya tidak bisa dibatasi di muka. Bila diinginkan, ia phase tersendiri dengan PRD-nya sendiri |
+| CAPTCHA / proof-of-work di endpoint email | Menambah dependensi dan gesekan registrasi untuk masalah yang belum terbukti ada setelah #34 benar-benar ditegakkan |
+
+---
+
+## Dependensi
+
+| Bergantung pada | Sifat |
+|---|---|
+| Phase 1 (#9, #10) | **Keras.** Seluruh kode yang diperbaiki lahir di sana |
+| Phase 4 (#47) | **Lunak.** `publiclead:key:` tidak terdampak, tapi penutupan Phase 4-lah yang menemukan ini |
+| Hosting & load balancer | **Tidak memblokir.** Justru sebaliknya — kontrak `TRUSTED_PROXIES` ditetapkan lebih dulu supaya hosting dipilih untuk memenuhinya |
+
+**Tidak memblokir Phase 5.** Mobile memakai user session dan tidak menyentuh jalur ini. Phase 4.5
+dikerjakan lebih dulu karena murah, terbatas, dan menyentuh kode yang akan lebih mahal diubah setelah
+ada klien kedua yang menempel padanya.

--- a/docs/phases/04.5-hardening/td.md
+++ b/docs/phases/04.5-hardening/td.md
@@ -1,0 +1,318 @@
+# Phase 4.5 — Hardening · Technical Design
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+> Hanya **delta** untuk phase ini — aturan yang sudah ada di [`freeze.md`](../../architecture/freeze.md) dirujuk, tidak diulang.
+> Sumber: freeze Aturan #26, #34, #36 · [ADR-010](../../decisions/ADR-010-fail-fast-startup.md) · [`architecture/authentication.md`](../../architecture/authentication.md) bagian *Rate limiting*
+
+---
+
+## 1. Model kepercayaan jaringan
+
+### 1.1 Keadaan sekarang
+
+`cmd/api/main.go:85` memanggil `gin.New()` dan tidak pernah memanggil `SetTrustedProxies`. Nilai
+bawaan Gin 1.12 (`gin.go:214–226`):
+
+```go
+ForwardedByClientIP: true,
+RemoteIPHeaders:     []string{"X-Forwarded-For", "X-Real-IP"},
+trustedProxies:      []string{"0.0.0.0/0", "::/0"},
+```
+
+`Context.ClientIP()` mengembalikan isi header **bila peer-nya tepercaya**, dan default di atas membuat
+setiap peer tepercaya. Karena itu `ClientIP()` sekarang adalah **input dari klien**, bukan fakta
+jaringan.
+
+### 1.2 Konfigurasi
+
+Menyusul bentuk `CORS_ALLOWED_ORIGINS` (#30) dan `PUBLIC_API_RATE_LIMIT` (#47) — satu env, di-parse di
+`internal/shared/config`, divalidasi saat boot:
+
+```go
+// TrustedProxies lists the CIDRs whose X-Forwarded-For header may be
+// believed. The literal "none" means no proxy sits in front and the peer
+// address is used directly. Required when AppEnv is production (Rule #36)
+// because both wrong settings fail silently in opposite directions:
+// trusting everyone makes every per-IP limit forgeable, trusting nobody
+// while behind a load balancer collapses all users onto one bucket.
+TrustedProxies []string `env:"TRUSTED_PROXIES" envSeparator:","`
+```
+
+Validasi di `Config.Validate()`, mengikuti pola baris 117–119 yang sudah ada:
+
+```go
+if c.AppEnv == "production" && len(c.TrustedProxies) == 0 {
+    return fmt.Errorf("config invalid: TRUSTED_PROXIES must be set when APP_ENV=production " +
+        "(use \"none\" when no reverse proxy sits in front of this process)")
+}
+```
+
+Setiap entri selain `none` wajib mem-parse sebagai CIDR — divalidasi saat boot, bukan saat request
+pertama:
+
+```go
+for _, p := range c.TrustedProxies {
+    if p == "none" { continue }
+    if _, _, err := net.ParseCIDR(p); err != nil {
+        return fmt.Errorf("config invalid: TRUSTED_PROXIES entry %q is not a CIDR: %w", p, err)
+    }
+}
+```
+
+`none` bercampur dengan CIDR lain ditolak — ia berarti "tidak ada proxy", jadi tidak bisa berdampingan
+dengan daftar proxy.
+
+### 1.3 Pemasangan
+
+Di `newRouter`, **sebelum** middleware apa pun — `httpx.Logging` sudah mencatat IP, dan ia harus
+mencatat yang benar:
+
+```go
+r := gin.New()
+if err := r.SetTrustedProxies(trustedProxyCIDRs(cfg.TrustedProxies)); err != nil { ... }
+```
+
+`trustedProxyCIDRs` mengembalikan `nil` bila daftarnya `["none"]`. `SetTrustedProxies(nil)` membuat
+`isTrustedProxy` selalu `false` (`gin.go:415`), sehingga `ClientIP()` melewati seluruh
+`RemoteIPHeaders` dan mengembalikan alamat peer — persis yang diinginkan saat tidak ada proxy.
+
+`newRouter` sudah mengembalikan `*gin.Engine` tanpa error. Kesalahan CIDR sudah ditangkap di
+`Config.Validate()` sebelum `newRouter` dipanggil, jadi `SetTrustedProxies` di sini tidak bisa gagal
+karena input pengguna; error yang tersisa di-`panic` — konsisten dengan ADR-010 (boot tidak boleh
+setengah jadi).
+
+### 1.4 Nilai untuk lingkungan yang sudah ada
+
+| Berkas | Nilai | Kenapa |
+|---|---|---|
+| `.env.example` | `TRUSTED_PROXIES=none` | Pengembangan lokal: proses diakses langsung |
+| `docker-compose.yml` | `TRUSTED_PROXIES: none` | `api` diekspos langsung ke host, tidak ada proxy |
+| Produksi | Ditentukan saat hosting dipilih | Belum ada — ini justru alasan kontraknya ditetapkan sekarang |
+
+> **Catatan deployment.** Bila nanti ada load balancer, nilainya adalah CIDR **load balancer itu**,
+> bukan `0.0.0.0/0`. Bila LB me-*replace* `X-Forwarded-For` (bukan menambahkan), spoofing sudah mati di
+> LB — konfigurasi ini tetap wajib supaya `ClientIP()` membaca IP klien asli, bukan IP LB.
+
+---
+
+## 2. Eviction dua generasi (keputusan H2)
+
+### 2.1 Kenapa bukan sweep
+
+Sweep berkala harus memindai seluruh map sambil memegang lock. Justru pada kondisi yang membuat
+eviction dibutuhkan — map berisi jutaan key hasil serangan — sweep menjadi pause multi-detik yang
+menghentikan seluruh proses. Mekanisme pertahanannya berubah menjadi senjata penyerang.
+
+Menukar dua map membebaskan satu generasi penuh sekaligus tanpa memindai satu key pun. Biayanya O(1)
+selamanya, dan GC yang mengerjakan sisanya.
+
+### 2.2 `ratelimit.FixedWindow`
+
+```go
+type FixedWindow struct {
+	limit  int
+	window time.Duration
+
+	mu       sync.Mutex
+	current  map[string]*bucket
+	previous map[string]*bucket
+	genStart time.Time
+}
+```
+
+`Take` menukar generasi lebih dulu, lalu berperilaku persis seperti sekarang:
+
+```go
+func (f *FixedWindow) Take(key string) Result {
+	now := time.Now()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.rollLocked(now)
+
+	b, ok := f.current[key]
+	if !ok {
+		// Carry the bucket forward when its window is still live, so a
+		// generation swap never hands anyone a fresh budget mid-window.
+		if pb, pok := f.previous[key]; pok && now.Sub(pb.windowStart) < f.window {
+			b = &bucket{windowStart: pb.windowStart, count: pb.count}
+		} else {
+			b = &bucket{windowStart: now}
+		}
+		f.current[key] = b
+	}
+	if now.Sub(b.windowStart) >= f.window {
+		b.windowStart = now
+		b.count = 0
+	}
+	// … sisanya tidak berubah
+}
+
+func (f *FixedWindow) rollLocked(now time.Time) {
+	if now.Sub(f.genStart) < f.window {
+		return
+	}
+	if now.Sub(f.genStart) >= 2*f.window {
+		f.previous = map[string]*bucket{} // both generations are dead
+	} else {
+		f.previous = f.current
+	}
+	f.current = map[string]*bucket{}
+	f.genStart = now
+}
+```
+
+**Semantik per-key tidak berubah.** Bucket yang jendelanya masih hidup ikut terbawa lengkap dengan
+`windowStart` dan `count`-nya, jadi tidak ada key yang mendapat jatah baru lebih cepat daripada
+sebelumnya. Ini yang membuat kriteria #7 (seluruh test lama lulus tanpa perubahan asersi) bisa
+dipenuhi.
+
+**Batas memori:** key yang terlihat dalam 2 × `window` terakhir. Tanpa traffic, tidak ada pertumbuhan —
+`rollLocked` hanya berjalan saat ada panggilan.
+
+`Allow` tidak disentuh sama sekali; ia tetap `Take(key).Allowed`.
+
+### 2.3 `auth.LoginLimiter`
+
+Bentuk yang sama, dengan interval generasi `loginBackoffCap` (5 menit) — keputusan H4:
+
+```go
+mu       sync.Mutex
+current  map[string]*loginBackoffState
+previous map[string]*loginBackoffState
+genStart time.Time
+```
+
+Aturan carry-forward berbeda karena `LoginLimiter` tidak punya jendela tetap. Entry dibawa maju hanya
+bila backoff-nya **masih berjalan**:
+
+```go
+if ps, pok := l.previous[key]; pok && now.Before(ps.nextAllowedAt) {
+	s = ps
+	l.current[key] = s
+}
+```
+
+Entry yang `nextAllowedAt`-nya sudah lewat dilepas. Yang hilang bersamanya adalah hitungan `failures`,
+sehingga penyerang yang menunggu lebih dari 2 × 5 menit mendapat tangga backoff dari awal lagi. Itu
+berarti laju serangan berkelanjutannya turun dari "1 percobaan per 5 menit" menjadi "1 percobaan per
+~10 menit lalu menaik lagi" — **lebih lambat**, bukan lebih cepat. Tidak ada yang diuntungkan.
+
+`RecordSuccess` menghapus dari **kedua** generasi.
+
+### 2.4 Yang sengaja tidak disentuh (keputusan H3)
+
+| Map | Key | Kenapa dibiarkan |
+|---|---|---|
+| `apikey.Usecase.lastUsedThrottle` | `api_key_id` | Terbatas jumlah kunci yang ada. Hanya bertambah lewat jalur terautentikasi |
+| `lead.Usecase.idempotencyCleanupThrottle` | `organization_id` | Terbatas jumlah tenant |
+
+Komentar di kedua tempat diperbarui: rujukan "same accepted debt as `ratelimit.FixedWindow`" **tidak
+lagi benar** setelah phase ini dan harus diganti dengan alasan yang sebenarnya (ber-key entity bisnis,
+bukan input penyerang).
+
+---
+
+## 3. Rencana test
+
+### 3.1 Kepercayaan proxy
+
+| Test | Berkas | Membuktikan |
+|---|---|---|
+| `TestClientIP_SpoofedHeaderIgnoredWhenNoProxyTrusted` | `internal/shared/httpx/` | `X-Forwarded-For` palsu **tidak** mengubah `ClientIP()` — kriteria #1 |
+| `TestClientIP_TrustedProxyForwardsRealClient` | idem | Di belakang CIDR tepercaya, IP klien asli yang terbaca — kriteria #3 |
+| `TestClientIP_UntrustedPeerHeaderIgnored` | idem | Peer di luar CIDR tepercaya diabaikan headernya |
+| `TestConfig_TrustedProxiesRequiredInProduction` | `internal/shared/config/` | Boot gagal tanpa `TRUSTED_PROXIES` di produksi — kriteria #2 |
+| `TestConfig_TrustedProxiesRejectsNonCIDR` | idem | Nilai salah ketahuan saat boot, bukan saat request |
+
+### 3.2 Aturan #34 — test yang mencoba melewatinya
+
+Ini yang selama ini tidak ada. Untuk `verify-email/resend` dan `password/forgot`, **kedua sisi**:
+
+| Test | Membuktikan |
+|---|---|
+| `TestHandler_Resend_RateLimitNotBypassableByForgedIP` | 10 request dengan `X-Forwarded-For` berbeda-beda dari satu peer → tetap `429` |
+| `TestHandler_Resend_RateLimitNotBypassableByRotatingEmail` | Email berganti tiap request → limiter **IP** tetap menahan |
+| `TestHandler_ForgotPassword_RateLimitNotBypassableByForgedIP` | idem untuk jalur reset password |
+| `TestHandler_Login_BackoffNotBypassableByForgedIP` | Backoff login tidak direset dengan mengganti header |
+
+Test lama (`TestHandler_Register_RateLimited` dan sekerabatnya) **tidak diubah**. Komentarnya di baris
+125 diperbarui: ia bergantung pada `RemoteAddr` konstan, dan setelah phase ini alasannya bukan lagi
+kebetulan `httptest` melainkan konsekuensi konfigurasi yang sudah ditegakkan.
+
+### 3.3 Batas memori — diukur, bukan dibaca
+
+Kriteria #5 menuntut bukti, bukan pembacaan kode. Bentuknya deterministik, bukan `runtime.MemStats`
+(yang membuat test flaky karena GC):
+
+| Test | Membuktikan |
+|---|---|
+| `TestFixedWindow_EvictsAcrossGenerations` | Setelah 2 × window dengan clock yang dimajukan, jumlah entry tidak tumbuh meski key unik terus masuk |
+| `TestFixedWindow_LiveWindowSurvivesGenerationSwap` | Key yang jendelanya masih hidup **tidak** mendapat jatah baru saat generasi ditukar |
+| `TestLoginLimiter_EvictsExpiredBackoff` | Entry yang backoff-nya lewat tidak tertahan melewati dua generasi |
+| `TestLoginLimiter_ActiveBackoffSurvivesGenerationSwap` | Backoff yang masih berjalan tidak hilang |
+
+Keempatnya butuh kontrol waktu. `FixedWindow` dan `LoginLimiter` mendapat field `now func() time.Time`
+internal (default `time.Now`) — **bukan** interface baru dan bukan paket clock; satu field yang hanya
+di-set dari test di paket yang sama.
+
+> Ini satu-satunya penambahan permukaan yang phase ini lakukan pada kode produksi. Alternatifnya adalah
+> `time.Sleep` di test dengan window sungguhan, yang berarti test 2 jam untuk limiter resend.
+
+### 3.4 Terbukti bisa gagal (kriteria #8)
+
+Prosedur yang sama seperti harness isolasi tenant (#8, #11, #23, #30, #46) — dijalankan dan
+**dicatat hasilnya di `notes.md`**, bukan diklaim:
+
+| Proteksi | Dilepas sementara | Harus merah |
+|---|---|---|
+| Trusted proxy | `SetTrustedProxies` dihapus dari `newRouter` | §3.1 dan §3.2 |
+| Carry-forward generasi | `previous` diabaikan saat lookup | `…LiveWindowSurvivesGenerationSwap` |
+| Roll generasi | `rollLocked` di-`return` di awal | `…EvictsAcrossGenerations` |
+
+Perusakan **tidak pernah** ikut ter-commit.
+
+---
+
+## 4. Yang berubah pada dokumentasi
+
+| Berkas | Perubahan |
+|---|---|
+| `architecture/authentication.md` | Bagian baru **Model kepercayaan jaringan** — apa yang dipercaya, dari siapa, kenapa. Bagian *Rate limiting* menyebut `TRUSTED_PROXIES` sebagai prasyarat penegakan Aturan #34 (kriteria #10) |
+| `architecture/api.md` | Bagian *Rate limiting* menambah satu kalimat: header per-IP hanya berarti bila proxy dikonfigurasi |
+| `docs/issues/047-public-lead-api.md` | **Koreksi** — pemisahan dua kelas map; poin `last_used_at` dipindahkan dari "butuh traffic" ke "diselesaikan di Phase 4.5" dengan catatan kenapa kategorisasi awalnya salah (kriteria #9). Dua poin lain tetap terbuka, tidak disentuh |
+| `STATUS.md` | Baris Utang Teknis `ratelimit.FixedWindow` ditutup; catatan Phase 4 yang menyebut tiga map disesuaikan; Phase 4.5 masuk *Progress per Phase* |
+| `.env.example`, `docker-compose.yml` | `TRUSTED_PROXIES` |
+
+`freeze.md` **tidak disentuh** — ia 🔒 FROZEN, dan phase ini tidak mengubah satu pun aturannya. Aturan
+#34 tidak berubah; yang berubah adalah implementasi yang selama ini tidak memenuhinya. Tidak ada ADR
+baru: `TRUSTED_PROXIES` adalah konfigurasi deployment dengan bentuk yang sudah berpreseden
+(`CORS_ALLOWED_ORIGINS`), bukan keputusan arsitektur.
+
+---
+
+## 5. Risiko teknis
+
+| Risiko | Penanganan |
+|---|---|
+| Salah pasang `TRUSTED_PROXIES` di produksi → seluruh pengguna berbagi satu bucket, ditolak massal | Justru ini alasan ia wajib dan fail-fast. Gejalanya terlihat saat boot atau saat pengguna kedua, bukan saat traffic naik |
+| Generasi ditukar tepat saat request → key kehilangan jatah | Tidak bisa terjadi: carry-forward menyalin `windowStart` dan `count` selama jendelanya hidup. Dikunci `…LiveWindowSurvivesGenerationSwap` |
+| Field `now` bocor ke produksi | Tidak diekspor, hanya di-set dari test paket yang sama. Tidak ada konstruktor publik yang menerimanya |
+| Memori masih bisa tumbuh dalam 2 generasi | Benar, dan itu batas yang disengaja. Setelah §1 ditegakkan, laju pembuatan key terikat pada IP nyata penyerang — bukan lagi tak terbatas |
+| Perbaikan ini hilang di refactor mendatang | Kriteria #8 — proteksi yang tidak punya test yang bisa merah tidak dianggap ada |
+
+---
+
+## 6. Kewajiban yang diteruskan ke phase berikutnya
+
+- **Saat hosting dipilih (sebelum deploy produksi pertama):** `TRUSTED_PROXIES` diisi CIDR load
+  balancer sungguhan. Boot akan menolak berjalan tanpanya — itu memang mekanismenya, bukan gangguan.
+- **Phase 5 (Mobile):** tidak terdampak. Mobile memakai user session; `login:ip:` yang sama berlaku,
+  dan kini benar-benar mengikat.
+- **Kapan pun traffic produksi nyata ada:** dua poin di `docs/issues/047` yang tetap terbuka
+  (`PUBLIC_API_RATE_LIMIT=60`, retensi `idempotency_key` di volume tinggi) baru bisa diputuskan.
+  Phase ini **tidak** menyentuh keduanya.
+- **Bila rate limit terdistribusi dibutuhkan** (lebih dari satu instance): `ratelimit.Limiter` sudah
+  interface. Eviction dua generasi adalah detail implementasi in-memory dan ikut hilang bersamanya —
+  bukan sesuatu yang perlu diporting.


### PR DESCRIPTION
## Ringkasan

Phase **tidak direncanakan**, lahir dari pemeriksaan ulang `docs/issues/046` & `047` sebelum Phase 5 dibuka — pemeriksaan yang memang gunanya untuk itu.

PR ini hanya membuka phase: `prd.md`, `td.md`, `issues.md`, plus koreksi `docs/issues/047` dan `STATUS.md`. **Tidak ada kode yang berubah** — implementasinya di #57 dan #58.

## Kesalahan kategorisasi yang ditemukan

Penutupan Phase 4 (#49) mencatat tiga poin "butuh traffic produksi nyata untuk diputuskan jujur". Dua memang begitu. Yang ketiga menggabungkan empat map in-memory jadi satu baris utang, padahal terbelah dua kelas:

| Kelas | Map | Key | Batas |
|---|---|---|---|
| Entity bisnis | `apikey.lastUsedThrottle` | `api_key_id` | Jumlah kunci |
| | `lead.idempotencyCleanupThrottle` | `organization_id` | Jumlah tenant |
| **Input penyerang** | `ratelimit.FixedWindow.buckets` | email, IP | **Tidak ada** |
| | `auth.LoginLimiter.state` | email, IP | **Tidak ada** |

Dua yang pertama memang butuh data traffic. Dua terakhir tidak butuh data apa pun untuk diketahui salah.

## Tiga temuan

**A. `c.ClientIP()` dikendalikan penyerang — akarnya.** `cmd/api/main.go:85` memakai `gin.New()` tanpa `SetTrustedProxies`. Default Gin 1.12 (`trustedProxies: ["0.0.0.0/0","::/0"]`, `ForwardedByClientIP: true`) mempercayai setiap peer sebagai proxy. **Dibuktikan langsung**: satu peer asli `203.0.113.9`, tiga `X-Forwarded-For` palsu → `ClientIP()` melaporkan `1.2.3.4`, `5.6.7.8`, `2001:db8::dead`.

Akibatnya **Aturan #34 secara faktual tidak ditegakkan** — sisi per-IP dilewati lewat header, sisi per-email dengan mengganti alamat tiap request. Email verifikasi & reset password tak terbatas ke alamat mana pun; reputasi domain pengirim (item lead-time di `STATUS.md`) bisa dibakar tanpa biaya. `publiclead:key:` (#47) dan `invite:org:` **tidak** terdampak — ber-key entity.

**B. Memori tak terbatas.** `auth.LoginLimiter` diukur menahan **64,7 MB untuk 500.000 email karangan, 136 byte/entry, tidak pernah dibebaskan** — `RecordSuccess` hanya menghapus saat login *berhasil*, yang tidak akan pernah terjadi untuk akun karangan.

**C. Test memberi lampu hijau palsu.** `internal/auth/handler_test.go:125` justru **bersandar** pada `RemoteAddr` konstan, dan komentarnya menyebutkan itu terang-terangan. Tidak ada satu pun test di `crm_be` yang pernah mengirim `X-Forwarded-For`. Standar "harness terbukti bisa gagal" — diterapkan ketat untuk isolasi tenant di #8, #11, #23, #30, #46 — tidak pernah diterapkan ke rate limit.

## Seberapa mendesak

**Bukan darurat** — belum ada yang ter-deploy, hosting masih terbuka. Tapi tidak boleh dibawa ke produksi, dan lebih murah sekarang: `TRUSTED_PROXIES` adalah kontrak *deployment*, jadi menetapkannya sebelum ada infrastruktur berarti hosting dipilih untuk memenuhi kontrak — bukan kontrak ditambal untuk memenuhi hosting.

## Cakupan

Dua issue, berurutan, sengaja sempit:

- **#57** — `TRUSTED_PROXIES` + validasi boot + `SetTrustedProxies` + test yang **mencoba melewati** Aturan #34
- **#58** — eviction dua generasi (`FixedWindow`, `LoginLimiter`), koreksi dokumentasi, penutup phase

**Di luar cakupan secara eksplisit**: angka rate limit dan retensi `idempotency_key` (keduanya betul-betul butuh traffic nyata), dua map ber-key entity bisnis (keputusan H3), dan utang tak berhubungan (#1, #2, #22). Menariknya ke sini hanya karena bertetangga di kode akan mengulangi persis kesalahan yang phase ini koreksi.

## Kenapa "4.5"

`freeze.md` 🔒 FROZEN dan sudah memakai nomor 5–9; menyisipkan phase akan menggeser semuanya dan membuat setiap rujukan "Phase 6" ambigu. Nomor pecahan juga menandai phase ini apa adanya: **penyelaan tak terencana**, bukan bagian rencana produk.

**`freeze.md` tidak disentuh** — Aturan #34 tidak berubah; yang diperbaiki adalah implementasi yang tidak pernah memenuhinya. Tidak ada ADR baru: `TRUSTED_PROXIES` adalah konfigurasi deployment dengan preseden yang sudah ada (`CORS_ALLOWED_ORIGINS`, #30).

Refs #57
Refs #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)