### PR TITLE
fix(security): bound rate-limiter memory with two-generation eviction

### DIFF
--- a/crm_be/internal/apikey/usecase.go
+++ b/crm_be/internal/apikey/usecase.go
@@ -24,11 +24,16 @@ const lastUsedThrottleWindow = 5 * time.Minute
 type Usecase struct {
 	store Store
 
-	// lastUsedThrottle is an in-memory map[api_key_id]last-write-time,
-	// same shape as ratelimit.FixedWindow's own bucket map — no
-	// eviction, same accepted debt as that map (tracked since #9). A
-	// process restart empties it, which costs at most one extra write
-	// per key; TD §10 explicitly says no correction is needed for that.
+	// lastUsedThrottle is an in-memory map[api_key_id]last-write-time.
+	// Deliberately WITHOUT eviction, unlike ratelimit.FixedWindow and
+	// auth.LoginLimiter (Phase 4.5 #58) — those are keyed by IP/email,
+	// input from someone who hasn't authenticated yet, so an attacker
+	// can grow them without limit. This map is keyed by api_key_id,
+	// bounded by how many keys actually exist, and only grows through
+	// an authenticated, paying path. Adding eviction here would be
+	// solving a problem that doesn't exist (Rule #27–#29). A process
+	// restart empties it, which costs at most one extra write per key;
+	// TD §10 explicitly says no correction is needed for that.
 	lastUsedMu       sync.Mutex
 	lastUsedThrottle map[uuid.UUID]time.Time
 }

--- a/crm_be/internal/auth/login_limiter.go
+++ b/crm_be/internal/auth/login_limiter.go
@@ -15,12 +15,24 @@ import (
 // This is a single concrete type, not a new interface — ratelimit.Limiter
 // stays exactly as-is for register/resend/forgot-password, which only
 // need a flat window.
+//
+// Keyed by IP and email — input from someone who hasn't logged in yet —
+// so state is bounded with the same two-generation eviction as
+// ratelimit.FixedWindow (Phase 4.5 #58, TD §2.3): without it, an
+// attacker who never repeats a key can grow this map without limit.
 type LoginLimiter struct {
 	base time.Duration
 	cap  time.Duration
 
-	mu    sync.Mutex
-	state map[string]*loginBackoffState
+	mu       sync.Mutex
+	current  map[string]*loginBackoffState
+	previous map[string]*loginBackoffState
+	genStart time.Time
+
+	// now is overridable only from this package's own tests
+	// (login_limiter_internal_test.go) to drive generation rollover
+	// deterministically — production code always gets time.Now.
+	now func() time.Time
 }
 
 type loginBackoffState struct {
@@ -35,22 +47,26 @@ const (
 
 func NewLoginLimiter() *LoginLimiter {
 	return &LoginLimiter{
-		base:  loginBackoffBase,
-		cap:   loginBackoffCap,
-		state: make(map[string]*loginBackoffState),
+		base:     loginBackoffBase,
+		cap:      loginBackoffCap,
+		current:  make(map[string]*loginBackoffState),
+		previous: make(map[string]*loginBackoffState),
+		now:      time.Now,
 	}
 }
 
 // Allow reports whether key may attempt a login right now. When it
 // can't, retryAfter is how long the caller should wait.
 func (l *LoginLimiter) Allow(key string) (ok bool, retryAfter time.Duration) {
-	now := time.Now()
+	now := l.now()
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	s, exists := l.state[key]
-	if !exists || now.After(s.nextAllowedAt) || now.Equal(s.nextAllowedAt) {
+	l.rollLocked(now)
+
+	s := l.getLocked(key, now)
+	if s == nil || now.After(s.nextAllowedAt) || now.Equal(s.nextAllowedAt) {
 		return true, 0
 	}
 	return false, s.nextAllowedAt.Sub(now)
@@ -59,15 +75,17 @@ func (l *LoginLimiter) Allow(key string) (ok bool, retryAfter time.Duration) {
 // RecordFailure increases key's backoff. Doubling per failure, capped —
 // no amount of continued failure ever locks the account out permanently.
 func (l *LoginLimiter) RecordFailure(key string) {
-	now := time.Now()
+	now := l.now()
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	s, exists := l.state[key]
-	if !exists {
+	l.rollLocked(now)
+
+	s := l.getLocked(key, now)
+	if s == nil {
 		s = &loginBackoffState{}
-		l.state[key] = s
+		l.current[key] = s
 	}
 	s.failures++
 
@@ -78,9 +96,69 @@ func (l *LoginLimiter) RecordFailure(key string) {
 	s.nextAllowedAt = now.Add(delay)
 }
 
-// RecordSuccess clears key's backoff state entirely.
+// RecordSuccess clears key's backoff state entirely, from both
+// generations — a key demoted to previous but not yet read back (and so
+// not yet migrated into current) must still be cleared.
 func (l *LoginLimiter) RecordSuccess(key string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	delete(l.state, key)
+	delete(l.current, key)
+	delete(l.previous, key)
+}
+
+// getLocked finds key's state, migrating it from the previous generation
+// into current when its backoff is still active — the same
+// carry-forward shape as ratelimit.FixedWindow.Take (Phase 4.5 TD §2.3),
+// so an in-progress backoff is never shortened by a generation swap
+// (decision H4: entries whose backoff has already lapsed are simply
+// dropped, which is indistinguishable from letting them expire).
+// Caller must hold l.mu.
+func (l *LoginLimiter) getLocked(key string, now time.Time) *loginBackoffState {
+	if s, ok := l.current[key]; ok {
+		return s
+	}
+	if s, ok := l.previous[key]; ok && now.Before(s.nextAllowedAt) {
+		l.current[key] = s
+		return s
+	}
+	return nil
+}
+
+// rollLocked swaps generations roughly every loginBackoffCap — long
+// enough that an active backoff (capped at the same duration) always
+// survives at least one swap via getLocked's carry-forward. If more
+// than 2*cap has passed with no activity at all, both generations are
+// stale and are dropped outright. Caller must hold l.mu.
+func (l *LoginLimiter) rollLocked(now time.Time) {
+	if l.genStart.IsZero() {
+		l.genStart = now
+		return
+	}
+	if now.Sub(l.genStart) < l.cap {
+		return
+	}
+	if now.Sub(l.genStart) >= 2*l.cap {
+		l.previous = map[string]*loginBackoffState{}
+	} else {
+		l.previous = l.current
+	}
+	l.current = map[string]*loginBackoffState{}
+	l.genStart = now
+}
+
+// Len reports how many distinct keys are currently tracked across both
+// generations. It exists only so tests can prove eviction actually
+// bounds growth (Phase 4.5 #58) — not a general-purpose introspection
+// API, and no production call site needs it.
+func (l *LoginLimiter) Len() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	seen := make(map[string]struct{}, len(l.current)+len(l.previous))
+	for k := range l.current {
+		seen[k] = struct{}{}
+	}
+	for k := range l.previous {
+		seen[k] = struct{}{}
+	}
+	return len(seen)
 }

--- a/crm_be/internal/auth/login_limiter_internal_test.go
+++ b/crm_be/internal/auth/login_limiter_internal_test.go
@@ -1,0 +1,90 @@
+package auth
+
+// package auth (not auth_test) — these tests need to set the unexported
+// `now` field directly to drive generation rollover deterministically.
+// Every other LoginLimiter test stays external (login_limiter_test.go);
+// this mirrors the same isolated exception ratelimit's own
+// limiter_internal_test.go takes for the identical reason (Phase 4.5
+// #58).
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestLoginLimiter_EvictsExpiredBackoff is Phase 4.5 #58's direct proof
+// for LoginLimiter: an attacker who never repeats a key (rotating IP or
+// email per attempt, exactly what #57 proved doesn't bypass the limit
+// itself) must not grow this map without bound. Twenty generations of 50
+// never-repeated, already-expired keys each would accumulate 1000
+// tracked entries without eviction.
+func TestLoginLimiter_EvictsExpiredBackoff(t *testing.T) {
+	l := NewLoginLimiter()
+	clock := time.Now()
+	l.now = func() time.Time { return clock }
+
+	const keysPerGeneration = 50
+	const generations = 20
+
+	maxLen := 0
+	for g := 0; g < generations; g++ {
+		for i := 0; i < keysPerGeneration; i++ {
+			l.RecordFailure(fmt.Sprintf("gen%d-key%d", g, i))
+		}
+		if n := l.Len(); n > maxLen {
+			maxLen = n
+		}
+		clock = clock.Add(loginBackoffCap) // advance past this generation's window
+	}
+
+	if maxLen > 2*keysPerGeneration {
+		t.Errorf("expected tracked keys to stay near %d (current + previous generation), peaked at %d — memory is not bounded", 2*keysPerGeneration, maxLen)
+	}
+	if final := l.Len(); final > 2*keysPerGeneration {
+		t.Errorf("expected final tracked key count to stay near %d, got %d", 2*keysPerGeneration, final)
+	}
+}
+
+// TestLoginLimiter_ActiveBackoffSurvivesGenerationSwap proves eviction
+// never shortens a backoff that's still in force — the property that
+// keeps #58 from weakening the exact protection #57 just finished
+// proving can't be bypassed (PRD Phase 4.5 acceptance criterion #3:
+// active backoff survives a generation swap).
+func TestLoginLimiter_ActiveBackoffSurvivesGenerationSwap(t *testing.T) {
+	l := NewLoginLimiter()
+	start := time.Now()
+	clock := start
+	l.now = func() time.Time { return clock }
+
+	l.RecordFailure("seed") // establishes genStart = start
+
+	// K's own backoff starts partway through this generation. A single
+	// failure backs off by loginBackoffBase (1s), so K stays blocked
+	// until start+31s.
+	clock = start.Add(30 * time.Second)
+	l.RecordFailure("K")
+
+	// Past genStart+cap (start+5m) — the next call triggers a generation
+	// swap. K's own backoff (until start+30s+1s) has long since expired
+	// by real time, so pick a moment BEFORE that expiry instead: back off
+	// with enough failures that K's backoff still covers the swap point.
+	// A second failure doubles the delay to 2s, still trivially short —
+	// so record failures until the capped delay (5m) safely outlasts the
+	// gap to the swap.
+	for i := 0; i < 10; i++ {
+		l.RecordFailure("K")
+	}
+	// K's backoff is now capped at loginBackoffCap (5m) from start+30s,
+	// i.e. active until start+30s+5m.
+
+	clock = start.Add(loginBackoffCap + time.Second) // triggers the swap; K's backoff is still active
+	ok, retryAfter := l.Allow("K")
+
+	if ok {
+		t.Fatal("expected K's active backoff to survive the generation swap, got allowed")
+	}
+	if retryAfter <= 0 {
+		t.Errorf("expected a positive retryAfter for K's still-active backoff, got %v", retryAfter)
+	}
+}

--- a/crm_be/internal/lead/usecase.go
+++ b/crm_be/internal/lead/usecase.go
@@ -37,8 +37,13 @@ type Usecase struct {
 	store Store
 
 	// idempotencyCleanupThrottle is an in-memory map[organization_id]
-	// last-sweep-time — no eviction, same accepted debt as
-	// ratelimit.FixedWindow's bucket map (tracked since #9).
+	// last-sweep-time. Deliberately WITHOUT eviction, unlike
+	// ratelimit.FixedWindow and auth.LoginLimiter (Phase 4.5 #58) —
+	// those are keyed by IP/email, input from someone who hasn't
+	// authenticated yet, so an attacker can grow them without limit.
+	// This map is keyed by organization_id, bounded by how many tenants
+	// actually exist. Adding eviction here would be solving a problem
+	// that doesn't exist (Rule #27–#29).
 	idempotencyCleanupMu       sync.Mutex
 	idempotencyCleanupThrottle map[uuid.UUID]time.Time
 }

--- a/crm_be/internal/shared/ratelimit/limiter.go
+++ b/crm_be/internal/shared/ratelimit/limiter.go
@@ -22,12 +22,30 @@ type Limiter interface {
 // clock time. Simplicity over precision is deliberate — this only needs
 // to make brute-forcing and spam expensive, not implement a perfectly
 // smooth rate.
+//
+// Keys are chosen by the caller — IP addresses and email addresses, for
+// every existing call site (Phase 1 #9, Phase 4 #47's publiclead:key:
+// being the one exception, keyed by an authenticated api_key_id). An IP
+// or email is input from someone who hasn't authenticated yet, so the
+// bucket map is bounded with two-generation eviction (Phase 4.5 #58,
+// TD §2) — without it, an attacker who never repeats a key can grow this
+// map without limit. See docs/phases/04.5-hardening/td.md §2 for why
+// two generations rather than a periodic sweep (a sweep over a
+// multi-million-key map while holding the lock turns the defense into
+// the attack).
 type FixedWindow struct {
 	limit  int
 	window time.Duration
 
-	mu      sync.Mutex
-	buckets map[string]*bucket
+	mu       sync.Mutex
+	current  map[string]*bucket
+	previous map[string]*bucket
+	genStart time.Time
+
+	// now is overridable only from this package's own tests
+	// (limiter_internal_test.go) to drive generation rollover
+	// deterministically — production code always gets time.Now.
+	now func() time.Time
 }
 
 type bucket struct {
@@ -37,9 +55,11 @@ type bucket struct {
 
 func NewFixedWindow(limit int, window time.Duration) *FixedWindow {
 	return &FixedWindow{
-		limit:   limit,
-		window:  window,
-		buckets: make(map[string]*bucket),
+		limit:    limit,
+		window:   window,
+		current:  make(map[string]*bucket),
+		previous: make(map[string]*bucket),
+		now:      time.Now,
 	}
 }
 
@@ -65,15 +85,29 @@ type Result struct {
 // this, not the other way around, so there is exactly one place the
 // bucket logic lives.
 func (f *FixedWindow) Take(key string) Result {
-	now := time.Now()
+	now := f.now()
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	b, ok := f.buckets[key]
-	if !ok || now.Sub(b.windowStart) >= f.window {
-		b = &bucket{windowStart: now}
-		f.buckets[key] = b
+	f.rollLocked(now)
+
+	b, ok := f.current[key]
+	if !ok {
+		// Carry a still-live bucket forward from the previous generation
+		// so a generation swap never hands a key a fresh budget mid-window
+		// — this is what keeps per-key behavior identical to before
+		// eviction existed (Phase 4.5 TD §2.2).
+		if pb, pok := f.previous[key]; pok && now.Sub(pb.windowStart) < f.window {
+			b = &bucket{windowStart: pb.windowStart, count: pb.count}
+		} else {
+			b = &bucket{windowStart: now}
+		}
+		f.current[key] = b
+	}
+	if now.Sub(b.windowStart) >= f.window {
+		b.windowStart = now
+		b.count = 0
 	}
 	resetAt := b.windowStart.Add(f.window)
 
@@ -82,4 +116,43 @@ func (f *FixedWindow) Take(key string) Result {
 	}
 	b.count++
 	return Result{Allowed: true, Limit: f.limit, Remaining: f.limit - b.count, ResetAt: resetAt}
+}
+
+// rollLocked swaps generations roughly every window: current becomes
+// previous (carrying still-live buckets forward on next access), and a
+// fresh current starts. If more than 2*window has passed with no calls
+// at all, both generations are stale and are dropped outright instead of
+// demoting a previous that's just as dead. Caller must hold f.mu.
+func (f *FixedWindow) rollLocked(now time.Time) {
+	if f.genStart.IsZero() {
+		f.genStart = now
+		return
+	}
+	if now.Sub(f.genStart) < f.window {
+		return
+	}
+	if now.Sub(f.genStart) >= 2*f.window {
+		f.previous = map[string]*bucket{}
+	} else {
+		f.previous = f.current
+	}
+	f.current = map[string]*bucket{}
+	f.genStart = now
+}
+
+// Len reports how many distinct keys are currently tracked across both
+// generations. It exists only so tests can prove eviction actually
+// bounds growth (Phase 4.5 #58) — not a general-purpose introspection
+// API, and no production call site needs it.
+func (f *FixedWindow) Len() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	seen := make(map[string]struct{}, len(f.current)+len(f.previous))
+	for k := range f.current {
+		seen[k] = struct{}{}
+	}
+	for k := range f.previous {
+		seen[k] = struct{}{}
+	}
+	return len(seen)
 }

--- a/crm_be/internal/shared/ratelimit/limiter_internal_test.go
+++ b/crm_be/internal/shared/ratelimit/limiter_internal_test.go
@@ -1,0 +1,88 @@
+package ratelimit
+
+// package ratelimit (not ratelimit_test) — these tests need to set the
+// unexported `now` field directly to drive generation rollover
+// deterministically. Every other test in this package stays external
+// (limiter_test.go); this is the same deliberate, isolated exception
+// internal/apikey/entity_test.go already sets a precedent for (Phase 4
+// #46) — access to an unexported detail, not a general pattern.
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestFixedWindow_EvictsAcrossGenerations is Phase 4.5 #58's direct
+// proof that memory is bounded — measured, not read from the code
+// (PRD Phase 4.5 acceptance criterion #5). Twenty generations of 50
+// never-repeated keys each (the shape of an attacker who never reuses
+// an IP/email) would accumulate 1000 tracked keys without eviction;
+// with it, only the current and previous generation are ever held at
+// once.
+func TestFixedWindow_EvictsAcrossGenerations(t *testing.T) {
+	l := NewFixedWindow(1, time.Minute)
+	clock := time.Now()
+	l.now = func() time.Time { return clock }
+
+	const keysPerGeneration = 50
+	const generations = 20
+
+	maxLen := 0
+	for g := 0; g < generations; g++ {
+		for i := 0; i < keysPerGeneration; i++ {
+			l.Take(fmt.Sprintf("gen%d-key%d", g, i))
+		}
+		if n := l.Len(); n > maxLen {
+			maxLen = n
+		}
+		clock = clock.Add(time.Minute) // advance exactly one window
+	}
+
+	if maxLen > 2*keysPerGeneration {
+		t.Errorf("expected tracked keys to stay near %d (current + previous generation), peaked at %d — memory is not bounded", 2*keysPerGeneration, maxLen)
+	}
+	if final := l.Len(); final > 2*keysPerGeneration {
+		t.Errorf("expected final tracked key count to stay near %d, got %d", 2*keysPerGeneration, final)
+	}
+}
+
+// TestFixedWindow_LiveWindowSurvivesGenerationSwap proves eviction is
+// invisible to a key whose own window is still live — the exact
+// property that keeps Phase 4.5 #58 from changing any existing rate
+// limit's observable behavior (PRD acceptance criterion #7). Without
+// this, a generation swap could silently hand an in-progress window a
+// fresh budget, weakening the very limits #57 just finished proving
+// can't be bypassed.
+func TestFixedWindow_LiveWindowSurvivesGenerationSwap(t *testing.T) {
+	l := NewFixedWindow(3, time.Minute)
+	start := time.Now()
+	clock := start
+	l.now = func() time.Time { return clock }
+
+	l.Take("seed") // establishes genStart = start
+
+	// K's own window starts partway through this generation, so it
+	// outlives the generation itself once a swap happens.
+	clock = start.Add(30 * time.Second)
+	r1 := l.Take("K")
+	if !r1.Allowed || r1.Remaining != 2 {
+		t.Fatalf("expected K's first call allowed with Remaining=2, got %+v", r1)
+	}
+	wantResetAt := clock.Add(time.Minute) // start+90s, K's own window end
+
+	// Past genStart+window (start+60s) — the next Take triggers a
+	// generation swap. K's own window (ends start+90s) is still live.
+	clock = start.Add(61 * time.Second)
+	r2 := l.Take("K")
+
+	if !r2.Allowed {
+		t.Fatalf("expected K's second call to still be allowed across the generation swap, got %+v", r2)
+	}
+	if r2.Remaining != 1 {
+		t.Errorf("expected Remaining to keep decreasing (1) as if no swap happened, got %d — the generation swap reset K's count", r2.Remaining)
+	}
+	if !r2.ResetAt.Equal(wantResetAt) {
+		t.Errorf("expected ResetAt to stay %v (K's own window, unaffected by the swap), got %v", wantResetAt, r2.ResetAt)
+	}
+}

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 29 Agustus 2026 — **Phase 4.5 — Hardening dibuka** (#57, #58) setelah pemeriksaan `docs/issues/` menemukan Aturan #34 tidak pernah ditegakkan.
-**Phase sekarang:** Phase 4.5 — Hardening. Phase 4 selesai; Phase 5 menunggu, lihat *Berikutnya*.
+**Last updated:** 29 Agustus 2026 — Issue #58 selesai. **Phase 4.5 — Hardening selesai.**
+**Phase sekarang:** Phase 4.5 selesai — phase berikutnya (5) belum dibuka, lihat *Berikutnya*.
 
 ---
 
@@ -46,6 +46,7 @@
 | **Issue #48 — Dashboard: manajemen API key** | — | 4 | Layar dashboard terakhir Phase 4. Aturan #21 ditegakkan **secara struktural** di level tipe: `APIKey` (dipakai daftar) tidak punya field `secret` sama sekali — hanya `CreatedAPIKey`, tipe terpisah yang cuma dikembalikan `createAPIKey()` — jadi "render secret dari daftar" adalah type error, bukan sekadar bug yang mungkin lolos review. Dialog buat kunci dua tahap **dalam satu komponen** (`step: "form" \| "reveal"`), `secret` tidak pernah diteruskan ke layar daftar. **Guard "penutupan mengharuskan konfirmasi" ada di `onOpenChange` itu sendiri**, bukan cuma tombol footer — `DialogContent` bawaan memicu `onOpenChange(false)` lewat tiga jalur (tombol X, Escape, klik backdrop), jadi tombol X disembunyikan dan ketiganya diblokir di satu titik selama secret belum dikonfirmasi tersimpan. "Menu masuk ke app shell" (checklist issue) diartikan sebagai Card baru di layar Settings, bukan entri baru di `NAV_ITEMS` — `NAV_ITEMS` tidak punya mekanisme per-role sama sekali, sementara TD §12 menaruh path-nya sebagai sub-halaman Pengaturan. Gerbang role di level **fetch**, bukan cuma UI — `listAPIKeys()` di-skip total untuk Manager/Employee, pola yang sama seperti `canManageTeam` di #34, memenuhi "mengetik URL langsung tidak menampilkan daftar" secara harfiah. `formatApproximateID(iso, now)` baru — `last_used_at` yang di-throttle 5 menit di backend (TD §10) dirender sebagai "sekitar N menit/jam/hari lalu", tidak pernah jam presisi, dikunci test regex. `toAPIKeyRow`/`canManageAPIKeys` dipisah dan diuji tanpa React, pola `lib/nav.ts`/`lib/team-permissions.ts`. **Tidak ada bug atau deviasi TD/PRD ditemukan kali ini** — bentuk endpoint sudah stabil sejak #46, tidak disentuh #47. 5 test baru. Diverifikasi lewat `curl` terhadap `crm_be` sungguhan: bentuk response `create` persis `CreatedAPIKey`, `list` setelahnya **tidak pernah** membawa `secret`, kunci revoked tetap tampil dengan `revoked_at` terisi, `created_by_membership_id` cocok persis dengan `id` di `GET /v1/memberships`. |
 | **Issue #49 — Halaman dokumentasi integrasi, penutup Phase 4** | — | 4 | **Kontradiksi TD ditemukan sebelum menulis kode**: "curl bisa disalin dan langsung bekerja" vs "key_prefix kunci yang sedang dilihat sudah terisi" tidak bisa dipenuhi bersamaan oleh halaman statis — raw secret (Aturan #21) tidak pernah ada lagi setelah dialog reveal #48 ditutup. Diselesaikan dengan memisah dua kebutuhan: dialog reveal `CreateAPIKeyDialog` (#48) dapat blok curl **sungguhan bekerja** (satu-satunya momen secret penuh tersedia); halaman `/settings/api-keys/docs` menampilkan format sama dengan `key_prefix` terpilih + placeholder, mengarahkan ke pembuatan kunci bila belum ada yang aktif — bukan kotak "tempel secret Anda" yang terasa mencurigakan. **Acceptance criterion #10 diverifikasi benar-benar dari nol**: register → belum punya kunci → dialog reveal → salin curl → jalankan dari terminal → `201` percobaan pertama, `source=api` terisi; idempotency retry → id sama; `assigned_to_membership_id` → `403 insufficient_scope`; body kosong → `400 validation_failed`; revoke → `401` seketika — setiap klaim di halaman dicek satu per satu terhadap response nyata. `api.md`/`authentication.md`/`authorization.md`/`multi-tenancy.md` diperbarui dari rencana jadi kenyataan (TD §18) — termasuk `multi-tenancy.md`'s struct `tenant.Context` yang ternyata **belum pernah** menyebut `Scopes` sejak #47. **ADR-004 diperbaiki langsung**: dua ketidakkonsistenan yang dicatat sejak #46 (`<secret:32char>` vs "entropi 256-bit"; "8 karakter pertama" vs contohnya sendiri) — diperbaiki di badan ADR dengan catatan koreksi (Aturan #30), bukan didiamkan. `docs/issues/046-*.md` dan `047-*.md` ditinjau penuh: 6 dari 9 poin diselesaikan, 3 poin (angka rate limit, retensi idempotency di volume tinggi, peta `last_used_at` tanpa eviction) **sengaja dibiarkan terbuka** — butuh traffic produksi nyata untuk diputuskan jujur, bukan ditutup paksa demi checklist rapi. **Seluruh 13 acceptance criteria PRD Phase 4 dicek satu per satu dan terpenuhi. Phase 4 selesai.** |
 | **Issue #57 — Trusted proxy: tegakkan Aturan #34** | — | 4.5 | Ditemukan saat meninjau `docs/issues/047` sebelum Phase 5 dibuka — bukan direncanakan. `cmd/api/main.go`'s `newRouter` memakai `gin.New()` tanpa `SetTrustedProxies`; default Gin 1.12 mempercayai setiap peer sebagai proxy, sehingga `c.ClientIP()` bisa dipalsukan lewat `X-Forwarded-For` — **dibuktikan langsung** sebelum implementasi (satu peer asli, tiga header palsu, tiga IP berbeda dilaporkan). Akibatnya **Aturan #34 secara faktual tidak ditegakkan sejak Phase 1** — seluruh limit per-IP (`register`, `resend`, `forgot`, `login`) bisa dilewati satu header. `TRUSTED_PROXIES` baru (`internal/shared/config`) — daftar IP/CIDR atau literal `none`, wajib diisi saat `APP_ENV=production` (Aturan #36, pola sama seperti `CORS_ALLOWED_ORIGINS`). `SetTrustedProxies` dipasang di `newRouter` sebelum middleware apa pun. **6 test baru di `cmd/api/trusted_proxy_test.go`** terhadap router produksi sungguhan, mencakup keempat titik panggil `ClientIP()` (bukan satu endpoint wakil) — **terbukti bisa gagal**: `SetTrustedProxies` dilepas sementara → 5 dari 6 test merah (satu test positif tetap hijau, sebagaimana mestinya) → dikembalikan, tidak pernah ter-commit. Test lama (`TestHandler_Register_RateLimited` dari #9) **tidak diubah asersinya** — hanya komentarnya diperbarui untuk jujur bahwa router tiruan `internal/auth` tidak pernah memanggil `SetTrustedProxies` sama sekali, sehingga bukti anti-spoofing yang sebenarnya sekarang hidup di `cmd/api`. 7 test baru di `internal/shared/config`. `authentication.md` mendapat bagian baru *Model kepercayaan jaringan* (diagram alur, tabel dua kesalahan konfigurasi dan gejala berlawanannya); `api.md` menunjuk ke sana. **Belum menutup phase** — eviction map (#58) belum disentuh; map masih tumbuh, hanya lebih lambat karena laju pertumbuhannya kini terikat pada IP nyata penyerang. |
+| **Issue #58 — Eviction map ber-key penyerang, penutup Phase 4.5** | — | 4.5 | Eviction **dua generasi** (`current`/`previous`, ditukar tiap ~1 window) di `ratelimit.FixedWindow` dan `auth.LoginLimiter` — bukan sweep berkala (memindai map besar sambil memegang lock justru mengubah pertahanan jadi bagian serangan, dan freeze melarang worker tanpa kebutuhan async nyata). **Carry-forward lewat lookup, bukan filter saat swap**: bucket/backoff yang masih hidup dipindahkan dari `previous` ke `current` hanya saat diakses lagi, disalin apa adanya (`windowStart`/`count` atau `failures`/`nextAllowedAt`) — sehingga key manapun yang masih aktif berperilaku **identik** dengan sebelum eviction ada, dan seluruh test lama lulus tanpa perubahan asersi. Field `now func() time.Time` unexported ditambahkan ke kedua tipe untuk kontrol waktu deterministik di test, di-set hanya dari file test internal paket yang sama (`limiter_internal_test.go`, `login_limiter_internal_test.go` — deviasi `package ratelimit`/`package auth`, pola sama seperti `internal/apikey/entity_test.go`). **4 test baru membuktikan batas memori lewat pengukuran**: 20 generasi × 50 key unik (1000 total) tetap terlacak ≤100 di kedua tipe. **Terbukti bisa gagal** — empat run adversarial terpisah (roll dimatikan, carry-forward dimatikan, di kedua tipe), semuanya merah persis seperti diprediksi, dikembalikan, tidak pernah ter-commit. Dua map ber-key entity bisnis (`apikey.lastUsedThrottle`, `lead.idempotencyCleanupThrottle`) **sengaja tetap tanpa eviction** (keputusan H3) — komentarnya diperbarui untuk berhenti menyamakan diri dengan `ratelimit.FixedWindow` dan menjelaskan alasan sebenarnya. **Seluruh 10 acceptance criteria PRD Phase 4.5 dicek satu per satu dan terpenuhi. Phase 4.5 — Hardening selesai.** |
 
 ---
 
@@ -57,48 +58,24 @@ _(kosong)_
 
 ## Berikutnya
 
-### Phase 4.5 — Hardening (#57, #58) — dikerjakan lebih dulu
+**Phase 4.5 — Hardening selesai** (#57, #58) — tidak direncanakan, lahir dari pemeriksaan ulang
+`docs/issues/046` & `047` sebelum Phase 5 dibuka. Ringkasan lengkap ada di baris Selesai #57/#58 dan
+`docs/phases/04.5-hardening/notes.md`; intinya: Aturan #34 tidak pernah benar-benar ditegakkan sejak
+Phase 1 (`c.ClientIP()` bisa dipalsukan lewat header karena `SetTrustedProxies` tidak pernah dipanggil)
+— sekarang ditegakkan dan dua map yang ber-key input penyerang (`ratelimit.FixedWindow`,
+`auth.LoginLimiter`) punya batas memori yang terbukti lewat pengukuran, bukan cuma dibaca dari kode.
 
-**Tidak direncanakan.** Lahir dari pemeriksaan ulang `docs/issues/046` & `047` sebelum Phase 5 dibuka —
-pemeriksaan yang memang gunanya untuk itu. Dokumen: `docs/phases/04.5-hardening/`.
-
-Penutupan Phase 4 mencatat tiga poin "butuh traffic produksi nyata". Dua di antaranya memang begitu.
-Yang ketiga (peta tanpa eviction) **salah dikategorikan** — empat map digabung jadi satu baris utang
-padahal dua ber-key entity bisnis (terbatas, penundaannya benar) dan dua ber-key input penyerang
-(tidak butuh data apa pun untuk diketahui salah). Menarik benang itu menemukan bahwa **Aturan #34
-secara faktual tidak pernah ditegakkan sejak Phase 1**:
-
-- `cmd/api/main.go:85` memakai `gin.New()` tanpa `SetTrustedProxies`; default Gin 1.12 mempercayai
-  setiap peer sebagai proxy, sehingga `c.ClientIP()` mengembalikan isi `X-Forwarded-For` — **dibuktikan
-  langsung**. Seluruh limit per-IP bisa dilewati satu header; sisi per-email dilewati dengan mengganti
-  alamat tiap request. Konsekuensinya: email verifikasi & reset password tak terbatas ke alamat mana
-  pun, membakar reputasi domain pengirim yang justru item lead-time di bawah.
-- `auth.LoginLimiter` diukur menahan **64,7 MB untuk 500.000 email karangan, tidak pernah dibebaskan**.
-- Test-nya memberi lampu hijau palsu: `internal/auth/handler_test.go:125` justru **bersandar** pada
-  `RemoteAddr` konstan. Tidak ada satu pun test di `crm_be` yang pernah mengirim `X-Forwarded-For`.
-  Standar "harness terbukti bisa gagal" yang diterapkan ketat untuk isolasi tenant (#8, #11, #23, #30,
-  #46) tidak pernah diterapkan ke rate limit.
-
-**Bukan darurat** — belum ada yang ter-deploy. Tapi tidak boleh dibawa ke produksi, dan lebih murah
-sekarang: `TRUSTED_PROXIES` adalah keputusan deployment, dan hosting belum dipilih — jadi hosting bisa
-dipilih untuk memenuhi kontraknya, bukan kontraknya ditambal untuk memenuhi hosting.
-
-**Tidak memblokir Phase 5.** Dikerjakan lebih dulu karena murah, terbatas, dan menyentuh kode yang akan
-lebih mahal diubah setelah ada klien kedua menempel padanya.
-
-### Setelah itu
-
-Dua hal menunggu keputusan manusia — bukan sesuatu yang bisa diputuskan sepihak dalam sesi agent, pola
-yang sama seperti saat Phase 3 tutup:
+Dua hal menunggu keputusan manusia sebelum sesi coding berikutnya dimulai — bukan sesuatu yang bisa
+diputuskan sepihak dalam sesi agent, pola yang sama seperti saat Phase 3 tutup:
 
 1. **Demo ke calon pengguna** (freeze bagian 4) — tujuan Phase 3, **masih belum dilakukan**. Dicatat
-   lagi di sini karena penutupan Phase 4 adalah titik alami kedua untuk mengingatkannya — dua phase
-   sudah selesai tanpa satu pun calon pengguna melihatnya.
+   lagi di sini karena penutupan Phase 4.5 adalah titik alami ketiga berturut-turut untuk
+   mengingatkannya — tiga penutupan phase sudah lewat tanpa satu pun calon pengguna melihatnya.
 2. **Pilih phase berikutnya**: Phase 5 (Employee Mobile) adalah satu-satunya phase MVP yang tersisa dan
    ada di jalur utama freeze (`Phase 3 → Phase 5 → GATE`) — tapi **cek dulu status Apple Developer
    Program & Firebase** di bagian *Punya Lead Time* di bawah. Kalau keduanya masih belum diurus, Phase 5
    akan berhenti tepat di bagian build iOS dan push notification, persis alasan Phase 4 dikerjakan lebih
-   dulu kemarin. Bila keduanya sudah beres, Phase 5 bisa langsung dibuka (PRD + TD, pola yang sama
+   dulu sebelumnya. Bila keduanya sudah beres, Phase 5 bisa langsung dibuka (PRD + TD, pola yang sama
    seperti Phase 2→3→4).
 
 ### Kewajiban yang diwarisi phase-phase berikutnya (TD phase 4 §19)
@@ -129,7 +106,6 @@ Riwayat #46–#49 di `docs/phases/04-public-api/issues.md` dan `notes.md`. Riway
 |---|---|---|
 | Tidak ada test end-to-end otomatis untuk graceful shutdown | Issue #1 | Diverifikasi manual (build binary + SIGINT). Otomatisasi butuh test yang menjalankan binary sungguhan dan mengirim sinyal OS — `go run` tidak meneruskan sinyal ke child process, jadi tidak bisa diuji lewat itu. Belum ada issue yang mencakup ini; angkat saat menyentuh area shutdown lagi. |
 | Tidak ada auto-migrate saat container `api` start | Issue #2 | `make migrate-up` dijalankan manual. Sengaja dipisah dari entrypoint `api` — migration dan serving punya kelas kegagalan berbeda. |
-| `ratelimit.FixedWindow` & `auth.LoginLimiter` tidak pernah membersihkan key lama | Issue #9, #10 | **Dijadwalkan Phase 4.5 (#58).** Keduanya ber-key email/IP — yaitu **input penyerang yang belum terautentikasi**, bukan entity bisnis. `LoginLimiter` diukur menahan 64,7 MB untuk 500.000 email karangan tanpa pernah membebaskannya (`RecordSuccess` hanya menghapus saat login *berhasil*). Catatan #49 sebelumnya menggabungkan ini dengan dua map Phase 4 di bawah dan menunda semuanya dengan alasan "butuh traffic" — **kategorisasi itu salah**, lihat `docs/phases/04.5-hardening/prd.md`. |
 | `apikey.lastUsedThrottle` & `lead.idempotencyCleanupThrottle` tanpa eviction | Issue #47 | **Sengaja dibiarkan** (keputusan H3 Phase 4.5). Ber-key `api_key_id` dan `organization_id` — terbatas oleh jumlah entity bisnis yang benar-benar ada, dan hanya bertambah lewat jalur terautentikasi. Menambahkan eviction ke sini berarti membangun mekanisme untuk masalah yang belum ada (Aturan #27–#29). |
 | Angka rate limit (register 5/jam, resend 3/jam+10/jam) belum final | Issue #9 | Cukup untuk membuktikan mekanisme aktif, bukan hasil tuning. **Sebagian ditutup di Phase 4**: batas API publik ditetapkan (D4 — 60/menit per kunci, `PUBLIC_API_RATE_LIMIT`) — tapi angka itu sendiri **juga belum hasil pengukuran** (`docs/issues/047-public-lead-api.md`), baru bisa ditinjau ulang begitu integrator produksi nyata mulai mengirim lead. Angka endpoint email masih default konservatif. |
 | `notifications` tidak punya retensi | Issue #22, TD §2 | Sama seperti `idempotency_key` — tidak ada scheduler di Phase 2 untuk membersihkan notifikasi lama. Tidak mendesak di volume MVP. |
@@ -140,6 +116,16 @@ Riwayat #46–#49 di `docs/phases/04-public-api/issues.md` dan `notes.md`. Riway
 > ~~`leads.idempotency_key` tidak punya retensi~~ — **selesai di issue #47.** `UPDATE ... SET
 > idempotency_key = NULL` untuk baris > 48 jam, di luar transaksi lead, throttle 1×/organization/jam,
 > hanya berjalan di jalur API key (keputusan D3).
+>
+> ~~`ratelimit.FixedWindow` & `auth.LoginLimiter` tidak pernah membersihkan key lama~~ — **selesai di
+> issue #58.** Eviction dua generasi (`current`/`previous`, ditukar tiap ~1 window) — bukan sweep
+> berkala (freeze bagian 6 aturan 4 melarang worker; memindai map besar sambil memegang lock justru
+> mengubah pertahanan jadi bagian serangan). Bucket/backoff yang masih hidup dibawa maju apa adanya
+> saat generasi ditukar, jadi tidak ada perilaku rate limit yang berubah untuk key manapun yang masih
+> aktif — dibuktikan lewat `TestFixedWindow_EvictsAcrossGenerations`/`…LiveWindowSurvivesGenerationSwap`
+> dan `TestLoginLimiter_EvictsExpiredBackoff`/`…ActiveBackoffSurvivesGenerationSwap`. `docs/issues/047`
+> sudah mengoreksi kategorisasi sebelumnya — dua map lain (`apikey.lastUsedThrottle`,
+> `lead.idempotencyCleanupThrottle`) **tetap sengaja tanpa eviction** (baris di atas, keputusan H3).
 
 > Bagian ini sama pentingnya dengan bagian Selesai. Kompromi yang diambil di session 3 akan terlupa di session 12 lalu ditemukan kembali sebagai bug produksi.
 
@@ -213,7 +199,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 2 | CRM Core | ✅ | ✅ | ✅ #19–#23 | ✅ |
 | 3 | Owner Dashboard | ✅ | ✅ | ✅ #30–#35, #40 | ✅ |
 | 4 | Public API | ✅ | ✅ | ✅ #46–#49 | ✅ |
-| 4.5 | Hardening | ✅ | ✅ | ✅ #57–#58 | ⬜ |
+| 4.5 | Hardening | ✅ | ✅ | ✅ #57–#58 | ✅ |
 | 5 | Employee Mobile | ⬜ | ⬜ | ⬜ | ⬜ |
 
 Pekerjaan yang sedang berjalan: `gh issue list --state open`

--- a/docs/phases/04.5-hardening/notes.md
+++ b/docs/phases/04.5-hardening/notes.md
@@ -96,3 +96,96 @@ sungguhan — komentar itu sekarang menunjuk ke sana secara eksplisit.
 Issue ini menutup akar masalahnya (Aturan #34 kini benar-benar ditegakkan), tapi **belum** menyentuh
 eviction map (`ratelimit.FixedWindow`, `auth.LoginLimiter` masih tumbuh tanpa batas — hanya lebih
 lambat sekarang, karena laju pertumbuhan key terikat pada IP nyata penyerang). Itu #58, penutup phase.
+
+---
+
+## #58 — Eviction map ber-key penyerang + koreksi kategorisasi utang, penutup Phase 4.5
+
+### Keputusan implementasi
+
+- **Dua generasi (`current`/`previous`), bukan sweep berkala** — keputusan H2 diikuti persis seperti
+  ditulis di TD §2.1: memindai map besar sambil memegang lock justru mengubah pertahanan jadi bagian
+  dari serangan. Ditukar setiap kurang lebih satu `window` (`FixedWindow`) atau satu `loginBackoffCap`
+  (`LoginLimiter`, keputusan H4) — dua generasi sekaligus di memori setiap saat, tidak pernah lebih.
+- **Carry-forward lewat lookup, bukan filter saat swap.** Baik `FixedWindow.Take` maupun
+  `LoginLimiter.getLocked` memindahkan entry dari `previous` ke `current` **hanya saat entry itu
+  diakses lagi** dan masih hidup (`FixedWindow`: `windowStart` belum lewat `window`; `LoginLimiter`:
+  `nextAllowedAt` belum lewat). Entry yang tidak pernah diakses lagi setelah demosi cukup dibiarkan —
+  ia akan lenyap otomatis di swap berikutnya tanpa perlu langkah pembersihan terpisah. Ini membuat
+  kedua map memenuhi kriteria #7 (test lama lulus tanpa perubahan asersi): key mana pun yang masih
+  hidup berperilaku **identik** dengan sebelum eviction ada, karena `windowStart`/`count` (atau
+  `failures`/`nextAllowedAt`) disalin apa adanya, bukan direset.
+- **`now func() time.Time` unexported, di-set hanya dari test paket yang sama** — satu-satunya
+  penambahan permukaan ke kode produksi (TD §3.3). `NewFixedWindow`/`NewLoginLimiter` publik keduanya
+  tetap tidak berubah tanda tangannya; tidak ada konstruktor baru yang menerima clock, jadi tidak ada
+  jalan bagi produksi untuk memakai clock palsu. Empat test butuh kontrol waktu presisi
+  (`limiter_internal_test.go`, `login_limiter_internal_test.go`, keduanya `package ratelimit`/`package
+  auth` bukan `_test` — deviasi yang sama seperti `internal/apikey/entity_test.go` sejak #46) — alternatifnya
+  `time.Sleep` dengan window sungguhan, yang berarti test menunggu jam sungguhan untuk lolos.
+- **`Len()` ditambahkan ke kedua tipe**, hanya untuk kebutuhan test membuktikan batas memori lewat
+  pengukuran (kriteria #5), bukan API introspeksi umum — tidak ada pemanggil produksi.
+- **Dua map ber-key entity bisnis (`apikey.lastUsedThrottle`, `lead.idempotencyCleanupThrottle`)
+  sengaja tidak disentuh** (keputusan H3) — komentarnya diperbarui di kedua tempat untuk berhenti
+  menyamakan diri dengan `ratelimit.FixedWindow`; sekarang menjelaskan alasan sebenarnya (ber-key
+  entity bisnis yang terbatas jumlahnya, bukan input penyerang tanpa batas) dan menunjuk balik ke #58.
+
+### Test yang membuktikan batas memori — diukur, bukan dibaca
+
+| Test | Membuktikan |
+|---|---|
+| `TestFixedWindow_EvictsAcrossGenerations` | 20 generasi × 50 key unik (1000 total) tetap terlacak ≤100 sepanjang waktu |
+| `TestFixedWindow_LiveWindowSurvivesGenerationSwap` | Key yang jendelanya masih hidup melewati swap dengan `Remaining`/`ResetAt` **identik** seolah tidak ada swap sama sekali |
+| `TestLoginLimiter_EvictsExpiredBackoff` | Sama untuk `LoginLimiter` — 20×50 key tetap terlacak ≤100 |
+| `TestLoginLimiter_ActiveBackoffSurvivesGenerationSwap` | Backoff yang masih aktif (di-dorong ke batas `loginBackoffCap` lewat 10 kegagalan berturut) tetap menahan permintaan setelah swap |
+
+### Verifikasi — terbukti bisa gagal
+
+Prosedur sama seperti #57 dan harness isolasi tenant. Dua titik dirusak sementara di **masing-masing**
+tipe, dijalankan, dicatat, dikembalikan — total empat run terpisah, `git diff` bersih setelah setiap
+pengembalian:
+
+```
+FixedWindow — rollLocked dipaksa `return` di awal (generasi tidak pernah ditukar):
+--- FAIL: TestFixedWindow_EvictsAcrossGenerations
+    peaked at 1000 — seharusnya ≤100
+
+FixedWindow — carry-forward previous→current dipaksa mati (kondisi `false &&`):
+--- FAIL: TestFixedWindow_LiveWindowSurvivesGenerationSwap
+    Remaining got 2 (seharusnya 1), ResetAt bergeser +31s — window K ter-reset oleh swap
+
+LoginLimiter — rollLocked dipaksa `return` di awal:
+--- FAIL: TestLoginLimiter_EvictsExpiredBackoff
+    peaked at 1000 — seharusnya ≤100
+
+LoginLimiter — carry-forward previous→current dipaksa mati:
+--- FAIL: TestLoginLimiter_ActiveBackoffSurvivesGenerationSwap
+    got allowed — backoff aktif hilang begitu saja saat swap
+```
+
+Keempat kali merah persis seperti diprediksi. Tidak satu pun perusakan ter-commit.
+
+### Verifikasi
+
+- `go test -race ./...` — seluruh paket lulus, termasuk 4 test baru di `ratelimit` dan 2 test baru di
+  `auth`, tanpa perubahan asersi pada test lama manapun di kedua paket.
+- `go build ./...`, `go vet ./...`, `gofmt -l .` — bersih.
+- Dokumentasi: `internal/apikey/usecase.go` dan `internal/lead/usecase.go`'s komentar diperbarui
+  (dijelaskan di atas). `docs/issues/047-public-lead-api.md` sudah dikoreksi sejak PR pembuka phase
+  (#59) — ditinjau ulang di sini, tidak perlu perubahan lagi.
+
+### Seluruh 10 acceptance criteria PRD Phase 4.5
+
+| # | Kriteria | Bukti |
+|---|---|---|
+| 1 | `X-Forwarded-For` palsu tidak mengubah `ClientIP()` tanpa proxy tepercaya | `TestClientIP_Register/Resend/ForgotPassword_ForgedIPDoesNotBypassRateLimit`, `TestClientIP_Login_BackoffNotBypassableByForgedIP` (#57) |
+| 2 | `TRUSTED_PROXIES` wajib saat produksi, boot gagal tanpanya | `TestLoad_ProductionRequiresTrustedProxies` (#57) |
+| 3 | Proxy tepercaya meneruskan IP klien asli | `TestClientIP_TrustedProxyHeaderIsHonored` (#57) |
+| 4 | Test yang mencoba melewati Aturan #34, kedua sisi | `TestClientIP_Resend_*`, `TestClientIP_ForgotPassword_*` (#57) |
+| 5 | Map tidak tumbuh tanpa batas — diukur | `TestFixedWindow_EvictsAcrossGenerations`, `TestLoginLimiter_EvictsExpiredBackoff` (#58) |
+| 6 | Dua map ber-key entity tidak disentuh, alasan tertulis | `internal/apikey/usecase.go`, `internal/lead/usecase.go` komentar (#58) |
+| 7 | Seluruh test lama lulus tanpa perubahan asersi | `go test -race ./...` bersih di #57 dan #58, nol asersi diubah |
+| 8 | Setiap proteksi terbukti bisa gagal | Prosedur adversarial #57 (5 kasus) dan #58 (4 kasus), transkrip di atas |
+| 9 | `docs/issues/047` dikoreksi | Dikoreksi di PR pembuka phase (#59), sebelum #57/#58 dikerjakan |
+| 10 | `authentication.md` menyatakan model kepercayaan jaringan | Bagian *Model kepercayaan jaringan* (#57) |
+
+**Seluruh 10 kriteria terpenuhi. Phase 4.5 — Hardening selesai.**


### PR DESCRIPTION
## Ringkasan

`ratelimit.FixedWindow` dan `auth.LoginLimiter` ber-key IP/email — input dari orang yang belum terautentikasi. Tidak ada satu pun yang pernah mengevict key, jadi penyerang yang tidak pernah mengulang key (rotasi IP/email tiap request — persis bentuk yang #57 baru buktikan tidak melewati limit itu sendiri) bisa membuat kedua map tumbuh tanpa batas.

**Diukur sebelum menulis kode**: `LoginLimiter` dengan 500.000 email karangan menahan **64,7 MB, tidak pernah dibebaskan** — `RecordSuccess` hanya menghapus saat login *berhasil*.

Ini menutup kesalahan kategorisasi #49: empat map digabung jadi satu baris utang dan ditunda semuanya dengan alasan "butuh traffic produksi". Hanya dua (`apikey.lastUsedThrottle`, `lead.idempotencyCleanupThrottle` — ber-key entity bisnis, terbatas, hanya bertambah lewat jalur terautentikasi) yang memang begitu. Dua lainnya tidak butuh data traffic apa pun untuk diketahui salah — `docs/issues/047-public-lead-api.md` sudah mengoreksi ini sejak PR pembuka phase; PR ini adalah perbaikan yang ditunjuknya.

## Perubahan

**Eviction dua generasi** (`current`/`previous`, ditukar tiap ~1 window) di kedua tipe — bukan sweep berkala (memindai map besar sambil memegang lock justru mengubah pertahanan jadi bagian serangan; freeze melarang worker tanpa kebutuhan async nyata).

**Carry-forward lewat lookup, bukan filter saat swap**: bucket/backoff yang masih hidup dipindahkan dari `previous` ke `current` hanya saat diakses lagi, disalin apa adanya (`windowStart`/`count` atau `failures`/`nextAllowedAt`) — bukan direset. Key manapun yang masih aktif berperilaku **identik** dengan sebelum eviction ada, itulah yang membuat seluruh test lama lulus tanpa perubahan asersi.

`now func() time.Time` unexported di kedua tipe (default `time.Now`), di-set **hanya** dari file test internal paket yang sama (`limiter_internal_test.go`, `login_limiter_internal_test.go` — `package ratelimit`/`package auth`, bukan `_test`, mengikuti preseden `internal/apikey/entity_test.go`). Tidak ada konstruktor produksi yang menerima clock.

`apikey.lastUsedThrottle` dan `lead.idempotencyCleanupThrottle` **sengaja tetap tidak disentuh** (keputusan H3) — komentarnya diperbarui untuk berhenti menyamakan diri dengan `ratelimit.FixedWindow` dan menjelaskan alasan sebenarnya.

## Test

Empat test baru membuktikan batas memori lewat **pengukuran**, bukan pembacaan kode:

| Test | Membuktikan |
|---|---|
| `TestFixedWindow_EvictsAcrossGenerations` | 20 generasi × 50 key unik (1000 total) tetap terlacak ≤100 |
| `TestFixedWindow_LiveWindowSurvivesGenerationSwap` | Key yang jendelanya masih hidup melewati swap dengan `Remaining`/`ResetAt` identik |
| `TestLoginLimiter_EvictsExpiredBackoff` | Sama untuk `LoginLimiter` |
| `TestLoginLimiter_ActiveBackoffSurvivesGenerationSwap` | Backoff aktif tetap menahan permintaan setelah swap |

**Terbukti bisa gagal** — empat run adversarial terpisah (roll dimatikan, carry-forward dimatikan, di kedua tipe): keempatnya merah persis seperti diprediksi, dikembalikan segera, tidak pernah ter-commit. Transkrip lengkap di `docs/phases/04.5-hardening/notes.md`.

`go test -race ./...` — seluruh paket lulus, **nol perubahan asersi** pada test lama manapun. `go build`, `go vet`, `gofmt -l` — bersih.

## Penutup Phase 4.5

Seluruh 10 acceptance criteria PRD Phase 4.5 dicek satu per satu terhadap bukti nyata di `docs/phases/04.5-hardening/notes.md`'s `## #58`. `docs/STATUS.md` diperbarui: Phase 4.5 selesai, Progress-per-Phase → ✅, Utang Teknis baris `ratelimit.FixedWindow`/`auth.LoginLimiter` dipindah ke bagian selesai, *Berikutnya* ditulis ulang.

Refs #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)