### PR TITLE
docs(testing): add manual end-to-end flow guide

### DIFF
--- a/docs/testing/flow/00-menjalankan-aplikasi.md
+++ b/docs/testing/flow/00-menjalankan-aplikasi.md
@@ -1,0 +1,157 @@
+# 0 — Menjalankan aplikasi
+
+Tujuan: **backend** (`crm_be`) dan **dashboard** (`crm_dashboard`) menyala dari clone bersih, sampai
+bisa dibuka di browser. Semua perintah `make`/`docker compose` dijalankan dari **akar repository**.
+
+## 1. Siapkan environment backend
+
+```bash
+cp .env.example .env
+```
+
+Nilai default di `.env.example` sudah cukup untuk lokal — tidak perlu diubah kecuali Anda tahu kenapa.
+
+## 2. Nyalakan PostgreSQL + API
+
+```bash
+make dev
+```
+
+Ini menjalankan `docker compose up --build`. Tunggu sampai log berhenti bergulir cepat dan terlihat
+baris mirip:
+
+```
+api-1  | time=2026-08-29T15:23:53.922Z level=INFO msg="server starting" port=8080 env=development
+```
+
+**Biarkan terminal ini terbuka** — inilah tempat mencari "email" (LogMailer) di langkah-langkah
+berikutnya. Buka **terminal baru** untuk langkah selanjutnya.
+
+## 3. Jalankan migration
+
+Container `api` **tidak** menjalankan migration otomatis (keputusan sadar — `docs/STATUS.md`'s Utang
+Teknis). Dari terminal baru, di akar repo:
+
+```bash
+set -a && source .env && set +a
+make migrate-up
+```
+
+Hasil yang diharapkan — baris terakhir mirip:
+
+```
+goose: successfully migrated database to version: 5
+```
+
+Bila muncul `connection refused`: postgres di langkah 2 belum siap sepenuhnya — tunggu beberapa detik
+dan ulangi.
+
+## 4. Pastikan backend benar-benar hidup
+
+```bash
+curl -s http://localhost:8080/health | jq
+curl -s http://localhost:8080/health/ready | jq
+```
+
+Hasil yang diharapkan — keduanya `200`:
+
+```json
+{"data":{"status":"ok","version":"dev"}}
+{"data":{"database":"reachable","status":"ok"}}
+```
+
+(Tidak punya `jq`? Hilangkan `| jq`, hasilnya tetap terbaca sebagai satu baris JSON.)
+
+## 5. Siapkan environment dashboard
+
+```bash
+cp crm_dashboard/.env.example crm_dashboard/.env.local
+```
+
+Default-nya sudah menunjuk ke `http://localhost:8080` — cocok dengan backend di langkah 2.
+
+## 6. Nyalakan dashboard
+
+Di terminal baru (ketiga):
+
+```bash
+cd crm_dashboard
+npm install
+npm run dev
+```
+
+Tunggu sampai muncul:
+
+```
+▲ Next.js 16.3.3
+- Local:   http://localhost:3000
+✓ Ready in ...
+```
+
+## 7. Buka di browser
+
+Buka **http://localhost:3000**.
+
+**Hasil yang diharapkan:** otomatis diarahkan ke `/login` — belum ada sesi login (`SessionGate`
+memanggil `GET /v1/me`, dapat `401`, redirect). Ini **bukan** bug — memang begitu perilakunya untuk
+siapa pun yang belum login.
+
+Kalau langkah ini lolos, lanjut ke [`01-registrasi-dan-autentikasi.md`](./01-registrasi-dan-autentikasi.md).
+
+---
+
+## 8. Cara mengambil tautan "email" dari log
+
+Dipakai berulang di berkas-berkas berikutnya (verifikasi email, reset password, undangan) — belum ada
+penyedia email sungguhan, jadi setiap tautan hanya tercatat di log `api`
+(`internal/shared/mailer.LogMailer`).
+
+Baris log-nya berbentuk seperti ini:
+
+```
+api-1  | time=... level=INFO msg="email (not sent — LogMailer)" to=owner@test.local subject="Verifikasi email Jualin CRM Anda" body="Klik tautan berikut untuk memverifikasi email Anda: http://localhost:3000/verify-email?token=WrnunLAJuz8v...\n\nTautan berlaku 24 jam."
+```
+
+⚠️ **Jangan salin manual dengan mata.** Di dalam `body=`, URL diikuti langsung oleh `\n\n` (dua
+karakter literal, bukan baris baru) — ikut tersalin dan token jadi tidak valid. Pakai perintah ini,
+yang sudah memotong tepat di ujung token:
+
+```bash
+docker compose logs api | grep -o 'http://localhost:3000/[^\\"]*' | tail -1
+```
+
+Hasilnya satu baris bersih siap tempel ke browser, misalnya:
+
+```
+http://localhost:3000/verify-email?token=WrnunLAJuz8vTf6wQtVpAx5MKRKostypB2g4SHRAXtE
+```
+
+`tail -1` mengambil **tautan terbaru**. Kalau sedang menguji beberapa email sekaligus (mis. beberapa
+undangan berturut-turut), saring dulu per jenis:
+
+```bash
+docker compose logs api | grep -o 'http://localhost:3000/verify-email[^\\"]*'      | tail -1
+docker compose logs api | grep -o 'http://localhost:3000/reset-password[^\\"]*'    | tail -1
+docker compose logs api | grep -o 'http://localhost:3000/invitations/accept[^\\"]*' | tail -1
+```
+
+---
+
+## Kalau ada yang tidak beres
+
+| Gejala | Kemungkinan penyebab |
+|---|---|
+| `docker compose up` gagal, port sudah dipakai | Ada proses lain memakai `5432` atau `8080`. Matikan proses itu, atau ubah pemetaan port di `docker-compose.yml` (jangan commit perubahan ini). |
+| `make migrate-up` → `connection refused` | Postgres container belum sehat. `docker compose ps` — pastikan `postgres` berstatus `healthy`, bukan cuma `running`. |
+| `make migrate-up` → `DATABASE_URL required` | Lupa `source .env` di terminal yang sama sebelum `make migrate-up` — env var ini **tidak** otomatis terbaca dari file `.env`. |
+| Dashboard menampilkan error jaringan terus-menerus | `crm_dashboard/.env.local` belum ada, atau `next dev` dinyalakan **sebelum** file itu dibuat — restart `npm run dev` setelah membuat/mengubah `.env.local` (Next.js hanya membaca env saat start). |
+| `curl http://localhost:8080/health` → connection refused | `api` container belum selesai boot, atau gagal boot — cek log di terminal langkah 2 untuk pesan `failed to connect to database` atau error validasi config. |
+
+## Mematikan semuanya
+
+```bash
+docker compose down          # hentikan postgres + api, data tetap ada
+docker compose down -v       # sama, TAPI data postgres ikut terhapus — pipeline test harus diulang dari 0
+```
+
+Hentikan `npm run dev` dengan `Ctrl+C` di terminalnya.

--- a/docs/testing/flow/01-registrasi-dan-autentikasi.md
+++ b/docs/testing/flow/01-registrasi-dan-autentikasi.md
@@ -1,0 +1,107 @@
+# 1 — Registrasi & Autentikasi
+
+Prasyarat: [`00-menjalankan-aplikasi.md`](./00-menjalankan-aplikasi.md) selesai — backend dan
+dashboard menyala, `http://localhost:3000` mengarahkan ke `/login`.
+
+Menguji: registrasi organization baru, verifikasi email (lewat log — belum ada email sungguhan),
+login, logout, lupa password, reset password. Ini membangun **akun Owner** yang dipakai di seluruh
+berkas berikutnya — jangan hapus datanya sampai seluruh urutan panduan ini selesai.
+
+## 1.1 Registrasi organization baru
+
+1. Dari `/login`, klik tautan **Daftar** (atau buka langsung `http://localhost:3000/register`).
+2. Isi form:
+   - **Nama organization**: `Toko Testing`
+   - **Nama lengkap**: `Budi Owner`
+   - **Email**: `owner@test.local`
+   - **Password**: `correct horse battery staple` (atau apa pun ≥ panjang minimum — kalau terlalu
+     pendek, form akan menolak sebelum submit)
+3. Klik **Daftar**.
+
+**Hasil yang diharapkan:** form berganti jadi pesan *"Kami mengirim tautan verifikasi ke
+owner@test.local..."* — **bukan** langsung masuk ke dashboard. Ini sengaja (keputusan B3: verifikasi
+email menggerbangi login).
+
+## 1.2 Cari tautan verifikasi di log
+
+Belum ada email sungguhan — tautannya ada di log `api`. Dari akar repo:
+
+```bash
+docker compose logs api | grep -o 'http://localhost:3000/verify-email[^\\"]*' | tail -1
+```
+
+**Hasil yang diharapkan:** satu baris bersih siap tempel, mis.
+
+```
+http://localhost:3000/verify-email?token=WrnunLAJuz8vTf6wQtVpAx5MKRKostypB2g4SHRAXtE
+```
+
+> ⚠️ Jangan menyalin URL-nya manual dari baris log mentah — di sana ia diikuti `\n\n` literal yang
+> ikut tersalin dan membuat token tidak valid. Penjelasan lengkap:
+> [`00-menjalankan-aplikasi.md`](./00-menjalankan-aplikasi.md) §8.
+
+## 1.3 Verifikasi email
+
+1. Tempel URL yang disalin ke address bar browser, buka.
+
+**Hasil yang diharapkan:** halaman menampilkan status berhasil terverifikasi, dengan tautan/tombol
+menuju `/login`.
+
+2. Coba buka **URL yang sama sekali lagi** (token sudah terpakai).
+
+**Hasil yang diharapkan:** pesan bahwa token tidak valid / sudah kedaluwarsa — bukan halaman kosong
+dan bukan error 500. (Backend menjawab `400 invalid_token` di sini; yang perlu dinilai adalah apakah
+tampilannya di layar masuk akal bagi orang awam.)
+
+## 1.4 Login
+
+1. Buka `/login`.
+2. Email: `owner@test.local`, Password: sesuai yang didaftarkan.
+3. Klik **Masuk**.
+
+**Hasil yang diharapkan:** masuk ke **Beranda** (`/`) — kartu-kartu metrik (Lead baru, per status,
+dst.) semuanya kosong/nol, karena belum ada lead sama sekali. Menu kiri/atas menampilkan: Beranda,
+Lead, Customer, Tugas, Tim, Pengaturan.
+
+### Uji negatif — jangan lewati
+
+- **Password salah**: coba login dengan password yang salah. Harus muncul pesan error yang **tidak**
+  membedakan "email tidak ada" dari "password salah" (mis. "Email atau password salah.") — bukan
+  detail teknis, bukan status 500.
+- **Login berkali-kali dengan password salah** (5–6 kali berturut dalam beberapa detik): percobaan
+  berikutnya harus mulai ditolak dengan pesan "terlalu banyak percobaan" (backoff progresif,
+  `auth.LoginLimiter`) — bukan terus mencoba tanpa batas.
+
+## 1.5 Logout
+
+Klik ikon **Keluar** (biasanya di pojok header/sidebar app shell).
+
+**Hasil yang diharapkan:** kembali ke `/login`. Coba buka `http://localhost:3000/` langsung — harus
+diarahkan balik ke `/login`, **tidak** menampilkan Beranda sesaat (tidak ada sesi yang bocor).
+
+## 1.6 Lupa password
+
+1. Dari `/login`, klik **Lupa password**.
+2. Masukkan `owner@test.local`, submit.
+
+**Hasil yang diharapkan:** pesan generik seperti "kalau email terdaftar, kami mengirim tautan" —
+**sama persis** baik email-nya terdaftar maupun tidak (anti-enumeration, TD §6.3). Coba juga dengan
+email yang **tidak pernah didaftarkan** (mis. `tidak-ada@test.local`) — pesannya harus identik,
+supaya orang luar tidak bisa menebak email mana yang punya akun.
+
+3. Ambil tautannya dari log (pola sama seperti §1.2):
+
+```bash
+docker compose logs api | grep -o 'http://localhost:3000/reset-password[^\\"]*' | tail -1
+```
+4. Buka tautan tersebut. Isi **Password baru** + **Konfirmasi password**, submit.
+
+**Hasil yang diharapkan:** berhasil, diarahkan ke `/login`.
+
+5. Login dengan password **baru** — harus berhasil.
+6. Coba login dengan password **lama** — harus **gagal** (password lama tidak lagi berlaku).
+
+---
+
+Selesai di sini: satu akun Owner (`owner@test.local`) terverifikasi dan bisa login dengan password
+yang sudah diganti. Lanjut ke [`02-tim-dan-undangan.md`](./02-tim-dan-undangan.md).

--- a/docs/testing/flow/02-tim-dan-undangan.md
+++ b/docs/testing/flow/02-tim-dan-undangan.md
@@ -1,0 +1,139 @@
+# 2 — Tim & Undangan
+
+Prasyarat: [`01-registrasi-dan-autentikasi.md`](./01-registrasi-dan-autentikasi.md) selesai — login
+sebagai `owner@test.local` (password yang sudah diganti di langkah 1.6).
+
+Menguji: undang anggota, terima undangan (dua cabang — user baru vs. user yang sudah punya akun),
+ganti role, nonaktifkan anggota (tiga cabang), notifikasi.
+
+## 2.1 Undang anggota baru (Employee)
+
+1. Buka menu **Tim** (`/team`).
+2. Klik **+ Undang anggota**.
+3. Isi **Email**: `employee1@test.local`, **Role**: `Employee`. Kirim.
+
+**Hasil yang diharapkan:** muncul di daftar **Undangan tertunda**. Perhatikan pilihan role di
+dropdown — harus ada **Admin, Manager, Employee** (bukan Owner — Owner tidak bisa diundang langsung,
+hanya dipromosikan belakangan).
+
+4. Ambil tautan undangan dari log (pola sama seperti
+   [`01-registrasi-dan-autentikasi.md`](./01-registrasi-dan-autentikasi.md) §1.2):
+
+```bash
+docker compose logs api | grep -o 'http://localhost:3000/invitations/accept[^\\"]*' | tail -1
+```
+
+## 2.2 Terima undangan — cabang "user baru"
+
+`employee1@test.local` **belum** pernah punya akun di sistem ini sama sekali (email berbeda dari
+Owner), jadi ini menguji cabang "buat akun baru".
+
+1. **Logout** dari akun Owner dulu (Aturan #24 — dua sesi tidak bercampur; lebih aman diuji terpisah).
+2. Buka tautan undangan dari 2.1 di browser (bisa browser yang sama setelah logout, atau jendela
+   private/incognito supaya lebih jelas terisolasi).
+
+**Hasil yang diharapkan:** form meminta **nama** + **password** (bukan cuma tombol "Gabung" — email
+ini belum terdaftar).
+
+3. Isi nama `Sari Employee`, password apa saja yang valid, submit.
+
+**Hasil yang diharapkan:** diarahkan ke `/login`. Login dengan `employee1@test.local` + password yang
+baru saja dibuat.
+
+**Hasil yang diharapkan:** berhasil masuk ke Beranda — **tanpa** perlu verifikasi email terpisah
+(menerima undangan sekaligus memverifikasi, sesuai TD).
+
+4. Menu **Tim** tetap muncul di navigasi untuk Employee (nav tidak difilter per-role) — buka `/team`.
+
+**Hasil yang diharapkan:** daftar anggota **terlihat** (read-only — siapa saja perlu tahu siapa
+rekan setimnya), tapi tombol **+ Undang anggota**, ganti role, dan **Nonaktifkan** **tidak ada**.
+Bagian **Undangan tertunda** juga tidak muncul sama sekali untuk role ini (bukan cuma disembunyikan —
+`listInvitations` tidak pernah dipanggil untuk role tanpa hak itu).
+
+5. Buka `/settings/api-keys` sebagai Employee.
+
+**Hasil yang diharapkan:** **tidak** ada daftar kunci sama sekali — hanya pesan *"Manajemen API key
+tidak tersedia untuk role Anda."* Buka tab Network di devtools browser: **tidak ada** panggilan ke
+`/v1/api-keys` sama sekali (gerbangnya ada di atas fetch, bukan cuma menyembunyikan hasilnya).
+
+## 2.3 Undang orang yang sudah punya akun — uji cabang "user sudah ada" + login multi-organization
+
+Cabang ini muncul saat email yang diundang **sudah** terdaftar (di organization mana pun — ADR-007:
+satu user bisa jadi anggota lebih dari satu organization). Cara paling realistis mengujinya:
+daftarkan dulu akun mandiri di organization **lain**, baru undang emailnya ke `Toko Testing`.
+
+1. **Logout.** Daftar organization **baru** (ulangi [`01-registrasi-dan-autentikasi.md`](./01-registrasi-dan-autentikasi.md)
+   §1.1–§1.3): **Nama organization** `Toko Lain`, **Nama lengkap** `Rina Sudah Terdaftar`, **Email**
+   `manager1@test.local`, password bebas. Verifikasi emailnya lewat tautan di log seperti biasa.
+2. **Logout** dari `manager1@test.local`, login kembali sebagai `owner@test.local`.
+3. Di `/team` milik `Toko Testing`, klik **+ Undang anggota** dengan **Email**: `manager1@test.local`,
+   **Role**: `Manager`.
+4. Cari tautan undangannya di log (§2.1 langkah 4), lalu **logout** dan login sebagai
+   `manager1@test.local` (pakai password dari langkah 1).
+
+**Hasil yang diharapkan saat login:** karena `manager1@test.local` sekarang anggota **dua**
+organization (`Toko Lain` sebagai Owner, `Toko Testing` — belum, undangan belum diterima), pada
+titik ini login masih hanya mengarah ke `Toko Lain` (satu-satunya organization yang statusnya aktif).
+
+5. Buka tautan undangan `Toko Testing` dari langkah 4 sambil sesi `manager1@test.local` ini aktif.
+
+**Hasil yang diharapkan:** form **tidak** meminta nama/password lagi — cukup satu tombol konfirmasi
+("Gabung"), karena akun sudah ada.
+
+6. **Logout**, login lagi sebagai `manager1@test.local`.
+
+**Hasil yang diharapkan:** sekarang muncul layar **"Pilih organization"** — karena user ini kini
+anggota **dua** organization sekaligus (ADR-007). Pilih `Toko Testing` — harus masuk sebagai Manager
+di organization itu, terpisah total datanya dari `Toko Lain`.
+
+7. Coba buka tautan undangan yang sama sekali lagi (sudah diterima) **tanpa login** (logout dulu):
+   harus diarahkan untuk login dulu, bukan layar error.
+
+## 2.4 Ganti role
+
+1. Login kembali sebagai `owner@test.local`.
+2. Di `/team`, ubah role `manager1@test.local` dari Manager ke **Admin**.
+
+**Hasil yang diharapkan:** berhasil, badge role di baris itu berubah jadi Admin.
+
+3. **Login sebagai Admin baru** (`manager1@test.local`) di jendela terpisah, coba ubah role Owner
+   (`owner@test.local`) jadi apa pun.
+
+**Hasil yang diharapkan:** **ditolak** (403) — Admin tidak boleh mengubah role Owner.
+
+4. Balik ke sesi Owner, coba promosikan Admin (`manager1@test.local`) jadi **Owner** (co-owner).
+
+**Hasil yang diharapkan:** **berhasil** — Owner boleh menaikkan orang lain jadi Owner juga (co-owner
+sah, lihat `architecture/authorization.md`). Setelah ini, turunkan lagi role-nya ke Admin supaya
+langkah berikutnya (nonaktifkan) tidak terganggu — Owner terakhir di organization tidak boleh
+dinonaktifkan.
+
+## 2.5 Nonaktifkan anggota — cabang tanpa lead terbuka
+
+Anggota **tanpa** lead terbuka (`employee1@test.local`, belum pernah ditugaskan apa pun sampai titik
+ini):
+
+1. Di `/team`, klik **Nonaktifkan** pada baris `employee1@test.local`.
+
+**Hasil yang diharapkan:** **langsung** nonaktif — **tanpa** dialog muncul (tidak ada lead terbuka
+untuk dipindahkan).
+
+> Dua cabang lain (member **punya** lead terbuka → ditolak `409` → dialog **lepas penugasan**
+> atau **pindahkan ke anggota lain**) butuh lead yang sudah ditugaskan lebih dulu — diuji nanti di
+> [`03-lead-dan-pipeline.md`](./03-lead-dan-pipeline.md) §3.7, bukan di sini. `manager1@test.local`
+> sengaja dibiarkan aktif untuk itu — jangan dinonaktifkan sekarang.
+
+## 2.6 Notifikasi
+
+Selama §3 (lead) nanti menugaskan lead ke seseorang, **cek ikon lonceng notifikasi** (selalu terlihat
+di header, di halaman mana pun) untuk anggota yang menerima penugasan itu:
+
+**Hasil yang diharapkan:** setelah login sebagai anggota yang ditugaskan, lonceng menunjukkan
+notifikasi baru berisi kalimat lengkap Bahasa Indonesia (bukan kode/ID mentah) tentang lead yang
+ditugaskan. Klik notifikasi menandainya terbaca; badge count berkurang.
+
+---
+
+Selesai di sini: `employee1@test.local` (Employee, **nonaktif**) dan `manager1@test.local`
+(Admin, **aktif** — sengaja dibiarkan begitu untuk §3.7 di berkas berikutnya). Lanjut ke
+[`03-lead-dan-pipeline.md`](./03-lead-dan-pipeline.md).

--- a/docs/testing/flow/03-lead-dan-pipeline.md
+++ b/docs/testing/flow/03-lead-dan-pipeline.md
@@ -1,0 +1,138 @@
+# 3 — Lead & Pipeline
+
+Prasyarat: [`02-tim-dan-undangan.md`](./02-tim-dan-undangan.md) selesai — login sebagai
+`owner@test.local`. Anggota `manager1@test.local` (Admin) masih **aktif**, sengaja belum
+dinonaktifkan.
+
+Menguji: buat lead manual, filter/pencarian, detail lead, edit, transisi status (jalur utama + kalah
++ buka kembali), penugasan, task, activity timeline. Ini layar dengan hampir seluruh aksi tulis
+produk — luangkan waktu paling banyak di sini.
+
+## 3.1 Buat lead manual
+
+1. Buka **Lead** (`/leads`).
+2. Klik tombol buat lead baru. Isi:
+   - **Nama**: `Andi Calon Pelanggan`
+   - **Email**: `andi@calon.test`
+   - **Telepon**: `081234567890`
+3. Simpan.
+
+**Hasil yang diharapkan:** muncul di daftar dengan status **Baru**, sumber **Manual**, belum ada
+pemilik. Buat **satu lead lagi** dengan data berbeda (mis. `Citra Calon Pelanggan`) — beberapa
+berkas berikutnya butuh lebih dari satu lead untuk menguji filter/pencarian secara berarti.
+
+## 3.2 Filter & pencarian
+
+Di `/leads`:
+
+1. Ketik sebagian nama (`Andi`) di kotak pencarian **"Cari nama, email, atau telepon…"**.
+
+**Hasil yang diharapkan:** daftar menyempit ke lead yang cocok saja, sedikit tertunda (debounce),
+tidak instan per huruf.
+
+2. Bersihkan pencarian, coba filter **status** = Baru.
+
+**Hasil yang diharapkan:** kedua lead yang baru dibuat muncul (keduanya masih status Baru).
+
+3. Perhatikan URL browser berubah mengikuti filter (`?status=new&q=...`) — coba **refresh halaman**
+   dengan URL itu: filter harus tetap sama setelah reload (bukan ke-reset).
+
+## 3.3 Detail lead & edit
+
+1. Klik salah satu lead (`Andi Calon Pelanggan`) untuk membuka detailnya.
+2. Klik **Edit**, ubah **Perusahaan** jadi `PT Andi Jaya`, simpan.
+
+**Hasil yang diharapkan:** perubahan tersimpan dan langsung terlihat di halaman detail.
+
+## 3.4 Transisi status — jalur utama sampai Menang
+
+Dari halaman detail `Andi Calon Pelanggan`:
+
+1. Ubah status **Baru → Dihubungi**.
+2. **Dihubungi → Memenuhi Syarat**.
+3. **Memenuhi Syarat → Penawaran**.
+4. **Penawaran → Menang**.
+
+**Hasil yang diharapkan tiap langkah:** berhasil, badge status berubah, dan **satu entri baru**
+muncul di activity timeline (`status_changed`) mencatat dari→ke. Coba loncat status (mis. dari Baru
+langsung ke Menang, kalau UI mengizinkan mengetik/memilihnya) — backend harus **menolak** lompatan
+lebih dari satu langkah di jalur utama.
+
+Lead ini (`Andi Calon Pelanggan`, sekarang **Menang**) dipakai lagi di
+[`04-customer.md`](./04-customer.md) — jangan diubah statusnya lagi setelah titik ini.
+
+## 3.5 Transisi status — Kalah + alasan, lalu buka kembali
+
+Pada lead **kedua** (`Citra Calon Pelanggan`):
+
+1. Ubah status ke **Kalah**.
+
+**Hasil yang diharapkan:** diminta memilih **alasan kalah** (Harga / Kompetitor / Waktu Tidak Tepat /
+Tidak Merespons / Tidak Tertarik / Lainnya) — **tidak bisa** disimpan tanpa memilih alasan.
+
+2. Pilih alasan apa saja, simpan.
+
+**Hasil yang diharapkan:** badge **Kalah**, dan detail menampilkan "Alasan kalah: ..." sesuai pilihan.
+
+3. Cari opsi **"Buka kembali ke Baru"**.
+
+**Hasil yang diharapkan:** status kembali ke **Baru**, alasan kalah tidak lagi ditampilkan (atau
+ditampilkan sebagai riwayat lama di timeline, bukan status aktif).
+
+## 3.6 Konflik versi (optimistic locking)
+
+1. Buka detail `Citra Calon Pelanggan` di **dua tab browser** sekaligus.
+2. Di tab pertama, ubah statusnya (mis. ke Dihubungi), simpan — berhasil.
+3. Di tab **kedua** (yang belum di-refresh, masih memegang data lama), coba ubah field apa saja dan
+   simpan.
+
+**Hasil yang diharapkan:** ditolak dengan pesan konflik (bukan menimpa diam-diam), dengan tombol
+**Muat ulang**. Klik tombol itu — data terbaru dari tab pertama muncul, tab kedua **tidak**
+otomatis menerapkan perubahannya sendiri di atasnya.
+
+## 3.7 Penugasan (assignment)
+
+1. Buka detail `Citra Calon Pelanggan`.
+2. Di dropdown penugasan, pilih **`manager1@test.local`**.
+
+**Hasil yang diharapkan:** tersimpan, muncul entri `lead_assigned` di timeline. Login sebagai
+`manager1@test.local` di jendela terpisah — **lonceng notifikasi** menunjukkan notifikasi baru
+(lihat [`02-tim-dan-undangan.md`](./02-tim-dan-undangan.md) §2.6).
+
+3. **Kembali ke `/team` sebagai Owner.** Sekarang coba **Nonaktifkan** `manager1@test.local` — anggota
+   ini sekarang **punya** lead terbuka yang ditugaskan padanya.
+
+**Hasil yang diharapkan:** **ditolak** dulu (`409`), dialog muncul dengan dua pilihan — **lepas
+penugasan** atau **pindahkan ke anggota lain**. Pilih salah satu, konfirmasi.
+
+**Hasil yang diharapkan:** berhasil nonaktif, dan lead `Citra Calon Pelanggan` sesuai pilihan tadi
+(kosong pemiliknya, atau berpindah ke anggota lain) — cek langsung di halaman detail leadnya.
+
+## 3.8 Task
+
+Pada lead `Andi Calon Pelanggan` (masih status Menang dari §3.4):
+
+1. Buat task baru: **Judul** `Follow-up kontrak`, **Jatuh tempo** besok, **Penanggung jawab**: diri
+   sendiri (Owner) atau anggota aktif mana pun.
+2. Simpan — muncul di daftar task lead ini, dan entri `task_created` di timeline.
+3. Tandai task **selesai** (checkbox).
+
+**Hasil yang diharapkan:** status task berubah jadi selesai, entri `task_completed` muncul di
+timeline. Coba centang lagi (klik dua kali) — task **tidak** bisa dibuka kembali lewat checkbox
+(satu arah, buka→selesai saja).
+
+4. Buka **Tugas** (`/tasks`) dari menu utama — task yang baru dibuat harus muncul di sana juga, bisa
+   difilter per penanggung jawab dan tanggal jatuh tempo.
+
+## 3.9 Activity timeline — tinjau ulang
+
+Di halaman detail `Andi Calon Pelanggan`, timeline seharusnya sekarang berisi (urut waktu): lead
+dibuat → beberapa `status_changed` → `task_created` → `task_completed`. Pastikan setiap entri
+menampilkan kalimat yang masuk akal dalam Bahasa Indonesia — **bukan** kode/enum mentah seperti
+`status_changed` tertulis apa adanya di layar.
+
+---
+
+Selesai di sini: `Andi Calon Pelanggan` — status **Menang**, satu task selesai. `Citra Calon
+Pelanggan` — status **Dihubungi** (dari §3.6), sempat ditugaskan lalu dipindahkan/dilepas di §3.7.
+Lanjut ke [`04-customer.md`](./04-customer.md).

--- a/docs/testing/flow/04-customer.md
+++ b/docs/testing/flow/04-customer.md
@@ -1,0 +1,59 @@
+# 4 — Customer
+
+Prasyarat: [`03-lead-dan-pipeline.md`](./03-lead-dan-pipeline.md) selesai — lead `Andi Calon
+Pelanggan` berstatus **Menang**, login sebagai `owner@test.local`.
+
+Menguji: konversi lead → customer, halaman detail customer, edit customer, dan bukti bahwa lead
+sumbernya tidak ikut berubah saat customer-nya diedit.
+
+## 4.1 Konversi lead yang menang
+
+1. Buka detail lead `Andi Calon Pelanggan` (masih status **Menang**).
+2. Klik **Konversi menjadi customer**.
+
+**Hasil yang diharapkan:** berhasil, diarahkan (atau muncul tautan) ke halaman Customer baru. Kembali
+ke detail lead ini — tombol Konversi **sudah hilang** (tidak bisa dikonversi dua kali), dan timeline-nya
+punya entri konversi.
+
+3. Coba konversi lead yang **belum** menang (mis. `Citra Calon Pelanggan`, masih Dihubungi) — cek
+   apakah tombol Konversi memang tidak muncul/tidak bisa diklik untuk lead berstatus selain Menang.
+
+## 4.2 Halaman detail customer
+
+1. Buka **Customer** (`/customers`) dari menu — pastikan customer hasil konversi tadi muncul di
+   daftar.
+2. Klik untuk membuka detailnya (`/customers/{id}`).
+
+**Hasil yang diharapkan:** data (nama, email, telepon) sama dengan lead asalnya. Ada tautan **"Berasal
+dari lead"** — klik, harus membawa balik ke `/leads/{id}` lead `Andi Calon Pelanggan`.
+
+## 4.3 Edit customer — dan buktikan lead tidak ikut berubah
+
+1. Di halaman detail customer, klik **Ubah customer**.
+2. Ubah **Nama** jadi `Andi Sudah Jadi Pelanggan`, simpan.
+
+**Hasil yang diharapkan:** nama customer berubah.
+
+3. **Buka lagi lead asalnya** (`Andi Calon Pelanggan`, lewat tautan "Berasal dari lead" atau langsung
+   dari `/leads`).
+
+**Hasil yang diharapkan — ini bagian pentingnya:** nama di lead **tetap** `Andi Calon Pelanggan`,
+**tidak** ikut berubah jadi nama customer yang baru. Konversi menyalin data sekali saat itu terjadi;
+setelahnya lead dan customer adalah dua record independen.
+
+## 4.4 Akses Manager (RBAC baca-tulis)
+
+`manager1@test.local` tidak bisa dipakai untuk uji ini — perannya sudah **Admin** (dipromosikan di
+[`02-tim-dan-undangan.md`](./02-tim-dan-undangan.md) §2.4) dan sudah **dinonaktifkan** di
+[`03-lead-dan-pipeline.md`](./03-lead-dan-pipeline.md) §3.7. Undang satu anggota **baru** dengan
+role **Manager** khusus untuk langkah ini (mis. `manager2@test.local`), selesaikan penerimaan
+undangannya seperti di §2.2, lalu login sebagai dia.
+
+**Hasil yang diharapkan:** Manager bisa **membaca** daftar dan detail customer (`200`), tapi
+tombol **Ubah customer**/**Hapus** tidak tersedia atau ditolak (`403`) — RBAC customer adalah
+Owner/Admin untuk tulis, siapa saja yang berhak melihat untuk baca.
+
+---
+
+Selesai di sini: satu Customer (`Andi Sudah Jadi Pelanggan`) hasil konversi, terverifikasi tidak
+memutasi lead asalnya. Lanjut ke [`05-api-publik.md`](./05-api-publik.md).

--- a/docs/testing/flow/05-api-publik.md
+++ b/docs/testing/flow/05-api-publik.md
@@ -1,0 +1,175 @@
+# 5 — API Publik
+
+Prasyarat: [`04-customer.md`](./04-customer.md) selesai. Login sebagai `owner@test.local`.
+
+Menguji: bagian dari kalimat inti MVP yang paling sering dilewatkan — **"website mengirim lead"**
+lewat API key, dari luar dashboard sama sekali. Ini juga satu-satunya berkas yang memakai terminal
+(`curl`) sebagai "klien", bukan cuma browser.
+
+## 5.1 Buat API key
+
+1. Buka **Pengaturan** (`/settings`) → kartu **API Key** (atau langsung `/settings/api-keys`).
+2. Klik **+ Buat kunci baru**.
+3. **Nama**: `Website Testing`, submit.
+
+**Hasil yang diharapkan:** dialog berganti ke tahap **"Kunci Anda"**, menampilkan secret **lengkap**
+satu kali — dengan tombol **Salin kunci** dan blok contoh `curl` siap pakai + tombol **Salin
+perintah**.
+
+4. Klik **Salin perintah** — ini menyalin curl yang **sungguhan bisa dijalankan** (bukan placeholder).
+5. **Sebelum menutup dialog**: buka terminal, tempel, jalankan.
+
+**Hasil yang diharapkan:** status `201`, dengan body memuat `"source":"api"` dan `source_api_key_id`
+terisi:
+
+```json
+{"data":{"id":"01a04e20-...","lead_number":1,"name":"Budi Santoso","source":"api",
+         "source_api_key_id":"01a04e20-...","status":"new","version":1, ...}}
+```
+
+Perhatikan `created_by_membership_id` bernilai `null` — lead dari API memang tidak dibuat oleh
+anggota mana pun.
+
+Kalau dialog belum ditutup dan Anda ragu sudah menyalin dengan benar, ulangi salin — begitu dialog
+ditutup, secret **tidak bisa dilihat lagi selamanya** (sengaja, Aturan #21).
+
+6. **Masih sebelum dialog ditutup** — klik **Salin kunci**, lalu simpan ke variabel shell untuk
+   dipakai di seluruh sisa berkas ini:
+
+```bash
+export JUALIN_KEY="jln_live_....."   # tempel secret lengkap dari dialog
+```
+
+7. **Sekarang** tutup dialog (klik konfirmasi bahwa kunci sudah disimpan). Cek daftar API key —
+   kunci baru muncul dengan **prefix** saja (mis. `jln_live_kSa6`), dan field `secret` **sama sekali
+   tidak ada** di response daftar (bukan dikosongkan — memang tidak ada field-nya).
+
+## 5.2 Konfirmasi lead muncul di dashboard
+
+Buka `/leads`, cari lead dengan nama `Budi Santoso` (dari contoh curl bawaan).
+
+**Hasil yang diharapkan:** ada, dengan **sumber = API** (bukan Manual), dan kalau dibuka detailnya,
+menampilkan kunci mana yang mengirimnya (nama kunci `Website Testing` atau ID-nya).
+
+## 5.3 Idempotency — kirim ulang tidak membuat duplikat
+
+Memakai `$JUALIN_KEY` yang sudah di-`export` di §5.1 langkah 6.
+
+```bash
+curl -s -X POST http://localhost:8080/v1/leads \
+  -H "Authorization: Bearer $JUALIN_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: test-idem-001" \
+  -d '{"name": "Lead Idempotent", "email": "idem@test.local"}'
+```
+
+Jalankan **persis perintah yang sama** (`Idempotency-Key` sama) **dua kali berturut-turut**.
+
+**Hasil yang diharapkan:** respons kedua punya **`id` yang sama persis** dengan respons pertama —
+bukan lead baru, bukan error. Cek di `/leads`: hanya **satu** `Lead Idempotent`, bukan dua.
+
+## 5.4 Scope — kunci tidak bisa melakukan hal lain
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8080/v1/leads \
+  -H "Authorization: Bearer $JUALIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Lead Nakal", "assigned_to_membership_id": "00000000-0000-0000-0000-000000000000"}'
+```
+
+**Hasil yang diharapkan:** `403` dengan
+`{"error":{"code":"insufficient_scope","message":"Kredensial API tidak memiliki scope untuk field ini."}}`
+— API key hanya boleh `leads:write` polos, tidak boleh menentukan penugasan.
+
+Coba juga panggil endpoint **lain** dengan kunci yang sama, mis.:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/v1/leads \
+  -H "Authorization: Bearer $JUALIN_KEY"
+```
+
+**Hasil yang diharapkan:** `401 authentication_required` — bukan `403`. API key ditolak di
+**autentikasi** untuk route selain `POST /v1/leads`, sebelum otorisasi sempat dikonsultasi sama
+sekali (lihat `architecture/authentication.md` bagian *API key*).
+
+## 5.5 Validasi field
+
+```bash
+curl -s -w "\n%{http_code}\n" -X POST http://localhost:8080/v1/leads \
+  -H "Authorization: Bearer $JUALIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "tanpa-nama@test.local"}'
+```
+
+**Hasil yang diharapkan:** `400` dengan `details` yang menyebut field mana yang salah — bukan pesan
+generik:
+
+```json
+{"error":{"code":"validation_failed","message":"Permintaan tidak valid.",
+          "details":[{"field":"name","code":"required"}]}}
+```
+
+## 5.6 Rate limit header
+
+```bash
+curl -s -D - -o /dev/null -X POST http://localhost:8080/v1/leads \
+  -H "Authorization: Bearer $JUALIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Cek Header"}'
+```
+
+**Hasil yang diharapkan:** ketiga header ada, mis.
+
+```
+X-Ratelimit-Limit: 60
+X-Ratelimit-Remaining: 54
+X-Ratelimit-Reset: 1788017229
+```
+
+Nilai `Remaining` harus **berkurang** setiap kali dijalankan ulang (`Limit` mengikuti
+`PUBLIC_API_RATE_LIMIT`, default 60/menit per kunci).
+
+*(Opsional, butuh waktu:* jalankan perintah ini berulang cepat sampai `Remaining` mencapai `0` —
+permintaan berikutnya harus `429` dengan header `Retry-After`.)
+
+## 5.7 Halaman dokumentasi integrasi
+
+1. Di `/settings/api-keys`, klik **Dokumentasi integrasi**.
+
+**Hasil yang diharapkan:** halaman referensi menampilkan `key_prefix` kunci `Website Testing` (bukan
+secret lengkap — sudah tidak bisa ditampilkan lagi sejak §5.1), contoh curl dengan placeholder
+`<secret_anda>`, tabel field, katalog error, penjelasan `Idempotency-Key`, rate limit, dan peringatan
+kenapa kunci **tidak boleh** dipakai dari kode sisi browser.
+
+## 5.8 Cabut kunci
+
+1. Kembali ke `/settings/api-keys`, klik **Cabut** pada kunci `Website Testing`, konfirmasi.
+
+**Hasil yang diharapkan:** status kunci berubah jadi tercabut (`revoked_at` terisi), tapi baris
+kuncinya **tetap terlihat** di daftar (tidak dihapus — supaya Owner tahu ia pernah ada). Revoke juga
+idempoten: mencabut kunci yang sama dua kali tidak menghasilkan error.
+
+2. Segera coba kirim lead lagi dengan kunci yang sama:
+
+```bash
+curl -s -w "\n%{http_code}\n" -X POST http://localhost:8080/v1/leads \
+  -H "Authorization: Bearer $JUALIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Lead Setelah Revoke"}'
+```
+
+**Hasil yang diharapkan:** `401` **seketika** — tanpa jeda cache, tanpa masa tenggang:
+
+```json
+{"error":{"code":"invalid_api_key",
+          "message":"Kredensial API tidak valid, sudah kedaluwarsa, atau sudah dicabut."}}
+```
+
+Perhatikan pesannya sengaja **tidak** membedakan "kunci tidak pernah ada", "kedaluwarsa", dan "sudah
+dicabut" — orang luar tidak boleh bisa menyimpulkan kunci mana yang pernah valid.
+
+---
+
+Selesai di sini: seluruh jalur "website mengirim lead" dari kalimat inti MVP sudah diuji ujung ke
+ujung, dari luar dashboard sama sekali. Lanjut ke
+[`06-checklist-akhir.md`](./06-checklist-akhir.md) untuk rekap.

--- a/docs/testing/flow/06-checklist-akhir.md
+++ b/docs/testing/flow/06-checklist-akhir.md
@@ -1,0 +1,99 @@
+# 6 — Checklist akhir
+
+Rekap satu halaman. Centang setelah **benar-benar** mengklik lewat browser/`curl` — bukan diasumsikan
+dari membaca kode. Kalau ada yang gagal, jangan dicentang; catat sebagai issue baru (lihat
+[`README.md`](./README.md) bagian *Kalau sesuatu gagal*).
+
+## Kalimat inti MVP — dari nol sampai selesai
+
+- [ ] Owner mendaftar
+- [ ] Verifikasi email (lewat tautan di log — LogMailer)
+- [ ] Login
+- [ ] Undang employee
+- [ ] Employee menerima undangan & login
+- [ ] Owner membuat API key
+- [ ] "Website" (curl) mengirim lead lewat API key
+- [ ] Owner meng-assign lead ke seseorang
+- [ ] Anggota yang ditugaskan menerima notifikasi
+- [ ] ~~Follow-up dari HP~~ — **di luar cakupan**, Phase 5 (mobile) belum dibangun. Follow-up diuji
+      lewat dashboard sebagai gantinya.
+- [ ] Update lead (status, catatan)
+- [ ] Konversi lead menang ke Customer
+
+## 0 — Menjalankan aplikasi
+
+- [ ] `docker compose` (postgres + api) menyala tanpa error
+- [ ] Migration berhasil sampai versi terbaru
+- [ ] `GET /health` dan `/health/ready` keduanya `200`
+- [ ] Dashboard (`npm run dev`) menyala, `http://localhost:3000` bisa dibuka
+- [ ] Belum login → otomatis diarahkan ke `/login`
+
+## 1 — Registrasi & Autentikasi
+
+- [ ] Registrasi organization baru berhasil, **tidak** langsung login
+- [ ] Tautan verifikasi ditemukan di log, berhasil memverifikasi
+- [ ] Membuka tautan verifikasi **kedua kalinya** tidak error/500
+- [ ] Login berhasil setelah verifikasi
+- [ ] Password salah → pesan generik, bukan detail teknis
+- [ ] Login berulang gagal → mulai diblokir (backoff)
+- [ ] Logout mengembalikan ke `/login`, sesi benar-benar hilang
+- [ ] Lupa password: pesan sama persis untuk email terdaftar maupun tidak
+- [ ] Reset password via tautan di log berhasil
+- [ ] Password lama tidak lagi berlaku setelah reset
+
+## 2 — Tim & Undangan
+
+- [ ] Undang anggota — dropdown role: Admin, Manager, Employee (bukan Owner)
+- [ ] Terima undangan, cabang **user baru** (isi nama+password)
+- [ ] Terima undangan, cabang **user sudah ada** (satu tombol konfirmasi)
+- [ ] Employee di `/team`: daftar anggota terlihat (read-only), tapi tanpa tombol undang/ubah/nonaktifkan
+- [ ] Employee di `/settings/api-keys`: pesan "tidak tersedia untuk role Anda", **nol** panggilan API
+- [ ] Admin **tidak bisa** ubah role Owner (403)
+- [ ] Owner **bisa** promosikan orang lain jadi co-Owner
+- [ ] Nonaktifkan anggota **tanpa** lead terbuka → langsung, tanpa dialog
+- [ ] Nonaktifkan anggota **dengan** lead terbuka → `409` → dialog unassign/reassign
+- [ ] Notifikasi penugasan muncul di lonceng, bisa ditandai terbaca
+
+## 3 — Lead & Pipeline
+
+- [ ] Buat lead manual berhasil, status awal **Baru**, sumber **Manual**
+- [ ] Pencarian & filter status bekerja, filter bertahan setelah refresh (di URL)
+- [ ] Edit field lead tersimpan
+- [ ] Transisi status jalur utama: Baru → Dihubungi → Memenuhi Syarat → Penawaran → Menang
+- [ ] Lompat status lebih dari satu langkah **ditolak**
+- [ ] Kalah **wajib** memilih alasan
+- [ ] "Buka kembali ke Baru" dari status Kalah berhasil
+- [ ] Edit dari tab basi (versi lama) → konflik `409`, **tidak** menimpa diam-diam
+- [ ] Penugasan lead tersimpan, entri activity muncul
+- [ ] Task: buat, tandai selesai, **tidak bisa** dibuka kembali lewat checkbox
+- [ ] Activity timeline berisi kalimat Indonesia yang masuk akal, bukan enum mentah
+
+## 4 — Customer
+
+- [ ] Konversi hanya muncul/berhasil untuk lead status **Menang**
+- [ ] Tidak bisa konversi dua kali
+- [ ] Data customer hasil konversi cocok dengan lead asalnya
+- [ ] Tautan "Berasal dari lead" mengarah balik dengan benar
+- [ ] Edit nama customer **tidak** mengubah nama lead asalnya
+- [ ] Manager bisa baca customer, **tidak bisa** tulis (403)
+
+## 5 — API Publik
+
+- [ ] Buat API key: secret lengkap tampil **satu kali**, hilang setelah dialog ditutup
+- [ ] Contoh curl dari dialog reveal **benar-benar berhasil** (201) pada percobaan pertama
+- [ ] Lead dari API muncul di dashboard dengan sumber **API** + nama kunci
+- [ ] `Idempotency-Key` sama, dikirim dua kali → `id` sama, bukan duplikat
+- [ ] Field di luar `leads:write` (mis. `assigned_to_membership_id`) → `403 insufficient_scope`
+- [ ] Endpoint selain `POST /v1/leads` dengan API key → `401` (bukan `403`)
+- [ ] Body tanpa `name` → `400 validation_failed`
+- [ ] Header `X-RateLimit-*` ada dan `Remaining` berkurang tiap request
+- [ ] Halaman dokumentasi integrasi menampilkan `key_prefix` kunci yang dipilih + placeholder
+- [ ] Cabut kunci → daftar tetap menampilkan barisnya (bukan hilang)
+- [ ] Request setelah cabut → `401 invalid_api_key` seketika
+
+## Kalau semua tercentang
+
+Alur inti MVP (Phase 0–4.5) terbukti benar-benar jalan sebagai **satu rangkaian utuh**, bukan cuma
+lolos test per-fitur satu-satu. Simpan hasil pengecekan ini (tanggal + siapa yang menjalankan) di
+`docs/STATUS.md` atau catatan sesi Anda sendiri — dokumen ini sendiri **tidak** menyimpan status,
+sesuai konvensi repo (ADR-008).

--- a/docs/testing/flow/README.md
+++ b/docs/testing/flow/README.md
@@ -1,0 +1,71 @@
+# Testing Manual — Alur
+
+Panduan langkah-demi-langkah untuk **manusia** mengklik-klik seluruh aplikasi dari nol sampai
+menjalankan skenario inti produk. Ini **bukan** pengganti test otomatis (`make test` / `npm run test`
+di `crm_dashboard`) — test otomatis membuktikan kode benar; panduan ini membuktikan **rangkaian
+layar sungguhan** enak dipakai dan tidak ada yang patah saat dijalankan sebagai satu alur utuh,
+sesuatu yang sulit dilihat dari test per-fitur.
+
+## Cakupan
+
+Mengikuti kalimat inti MVP (`architecture/freeze.md` bagian 3, `product/decisions.md` §23):
+
+> Owner mendaftar → verifikasi email → login → undang employee → employee login →
+> owner membuat API key → website mengirim lead → owner meng-assign →
+> employee menerima notifikasi → follow-up dari HP → update → konversi ke Customer
+
+Bagian yang **bisa** diuji manual sekarang: semuanya kecuali "follow-up dari HP" — **Phase 5 (mobile)
+belum dibangun**, jadi employee follow-up di panduan ini dilakukan lewat dashboard, bukan HP.
+Phase 0–4.5 sudah selesai (`docs/STATUS.md`); panduan ini menguji hasilnya.
+
+## Urutan berkas
+
+| # | Berkas | Apa yang diuji |
+|---|---|---|
+| 0 | [`00-menjalankan-aplikasi.md`](./00-menjalankan-aplikasi.md) | Backend + dashboard menyala, bisa diakses browser |
+| 1 | [`01-registrasi-dan-autentikasi.md`](./01-registrasi-dan-autentikasi.md) | Daftar org baru, verifikasi email, login, lupa/reset password |
+| 2 | [`02-tim-dan-undangan.md`](./02-tim-dan-undangan.md) | Undang anggota, terima undangan, ganti role, nonaktifkan |
+| 3 | [`03-lead-dan-pipeline.md`](./03-lead-dan-pipeline.md) | Buat lead, ubah status, tugaskan, task, activity timeline |
+| 4 | [`04-customer.md`](./04-customer.md) | Konversi lead menang jadi Customer, edit Customer |
+| 5 | [`05-api-publik.md`](./05-api-publik.md) | Buat API key, kirim lead lewat `curl`, cabut kunci |
+| 6 | [`06-checklist-akhir.md`](./06-checklist-akhir.md) | Rekap satu halaman — centang semua sebelum bilang "beres" |
+
+Kerjakan berurutan — setiap berkas mengasumsikan data dari berkas sebelumnya masih ada (org yang sama,
+lead yang sama, dst).
+
+## Yang perlu disiapkan dulu
+
+- Docker Desktop (atau daemon Docker apa pun) menyala
+- Node.js 20+ dan `npm`
+- Terminal yang bisa dibuka beberapa tab/jendela sekaligus (untuk mengawasi log sambil mengklik di browser)
+- Browser apa saja
+
+## Soal email — LogMailer
+
+Belum ada penyedia email sungguhan (`docs/STATUS.md`'s *Punya Lead Time* — domain & email provider
+belum diurus). Setiap "email" (verifikasi, reset password, undangan) hanya **dicatat ke log**, tidak
+benar-benar dikirim (`internal/shared/mailer.LogMailer`). Sepanjang panduan ini, tautan yang biasanya
+ada di badan email harus **dicari di log `api`**, bukan di kotak masuk. Caranya dijelaskan di
+`00-menjalankan-aplikasi.md` dan dipakai berulang di berkas-berkas berikutnya.
+
+Baris log-nya selalu berbentuk:
+
+```
+api-1  | time=... level=INFO msg="email (not sent — LogMailer)" to=... subject="..." body="Klik tautan berikut ...: http://localhost:3000/...?token=...\n\nTautan berlaku ..."
+```
+
+Cara mengambilnya tanpa salah salin (URL diikuti `\n\n` literal di dalam `body=`) ada di
+[`00-menjalankan-aplikasi.md`](./00-menjalankan-aplikasi.md) §8 — perintahnya satu baris, dipakai
+berulang di sepanjang panduan ini.
+
+## Kalau sesuatu gagal
+
+Jangan diam-diam dilewati. Catat langkah mana yang gagal, pesan error persisnya, dan cek dulu:
+
+1. Apakah langkah di `00-menjalankan-aplikasi.md` benar-benar semuanya lolos?
+2. Apakah data dari berkas sebelumnya masih ada (mis. belum tidak sengaja `docker compose down -v`)?
+3. Apakah ini regresi nyata, atau memang di luar cakupan yang tertulis di `docs/phases/*/prd.md`
+   bagian *Di luar cakupan*?
+
+Bug nyata yang ditemukan selama testing manual dicatat sebagai issue GitHub baru — bukan diperbaiki
+diam-diam di sesi yang sama, ikuti workflow biasa (`docs/workflow.md`).


### PR DESCRIPTION
## Ringkasan

Panduan langkah-demi-langkah untuk **manusia** mengklik seluruh produk dari clone bersih, mengikuti kalimat inti MVP (freeze bagian 3):

> Owner mendaftar → verifikasi email → login → undang employee → employee login → owner membuat API key → website mengirim lead → owner meng-assign → employee menerima notifikasi → update → konversi ke Customer

Test otomatis membuktikan **kode benar per fitur**; panduan ini membuktikan **rangkaian layar sungguhan** tidak patah saat dijalankan sebagai satu alur utuh — sesuatu yang sulit terlihat dari test per-fitur.

## Isi

`docs/testing/flow/` — 8 berkas, berurutan, tiap berkas memakai data yang ditinggalkan berkas sebelumnya:

| Berkas | Isi |
|---|---|
| `README.md` | Cakupan, prasyarat, cara kerja LogMailer, apa yang dilakukan kalau ada yang gagal |
| `00-menjalankan-aplikasi.md` | Clone bersih → `localhost:3000` terbuka. §8: cara mengambil tautan "email" dari log |
| `01-registrasi-dan-autentikasi.md` | Daftar, verifikasi, login, logout, lupa/reset password + uji negatif |
| `02-tim-dan-undangan.md` | Undang, dua cabang penerimaan, RBAC per role, ganti role, nonaktifkan |
| `03-lead-dan-pipeline.md` | Lead, filter, transisi status, konflik versi, penugasan, task, timeline |
| `04-customer.md` | Konversi, edit, bukti lead asal tidak ikut berubah |
| `05-api-publik.md` | API key, kirim lead via `curl`, idempotency, scope, rate limit, cabut |
| `06-checklist-akhir.md` | Rekap satu halaman, disusun mengikuti kalimat inti MVP |

## Ditulis sambil menjalankan aplikasinya, bukan dari membaca kode

Tiga hal di draf awal ternyata **salah** dan sudah diperbaiki:

1. **Format log** — ditulis JSON, aslinya logfmt (`time=... level=INFO msg=...`).
2. **Urutan key `/health/ready`** — `database` lebih dulu, bukan `status`.
3. **Jebakan salin tautan** — di dalam `body=` LogMailer, URL diikuti `\n\n` **literal**. Menyalin dengan mata ikut membawa dua karakter itu dan token gagal diam-diam. Diganti perintah satu baris yang memotong tepat di ujung token, lalu **token hasilnya diuji benar-benar berhasil** (`{"data":{"status":"verified"}}`).

Bagian §5 (API publik) dijalankan penuh terhadap backend hidup: `201` dengan `source=api`, retry idempoten mengembalikan `id` identik, `403 insufficient_scope`, `401 authentication_required` untuk route lain, `400` dengan `details` per-field, ketiga header `X-Ratelimit-*`, dan `401 invalid_api_key` seketika setelah revoke. Payload error di dokumen **dikutip persis** dari respons nyata, bukan diparafrase.

## Batas

Mobile (Phase 5) belum ada, jadi **"follow-up dari HP" ditandai eksplisit di luar cakupan** — bukan dilewatkan diam-diam. Langkah itu dilakukan lewat dashboard sebagai gantinya.

Dokumen ini **tidak menyimpan status** (ADR-008) — hasil pengecekan disimpan di catatan sesi penguji, bukan di berkas ini.

---

Tidak terikat issue GitHub tertentu — pola yang sama seperti PR #53 dan #54 (dokumen pendukung, bukan pekerjaan fitur ber-issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)