### PR TITLE
docs: open Phase 4.6 — Email Delivery (PRD, TD, issues)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 29 Agustus 2026 — Issue #58 selesai. **Phase 4.5 — Hardening selesai.**
-**Phase sekarang:** Phase 4.5 selesai — phase berikutnya (5) belum dibuka, lihat *Berikutnya*.
+**Last updated:** 29 Agustus 2026 — **Phase 4.6 — Email Delivery dibuka** (#63, #64), prasyarat demo ke calon pengguna.
+**Phase sekarang:** Phase 4.6 — Email Delivery. Phase 4.5 selesai; Phase 5 menunggu, lihat *Berikutnya*.
 
 ---
 
@@ -65,12 +65,36 @@ Phase 1 (`c.ClientIP()` bisa dipalsukan lewat header karena `SetTrustedProxies` 
 — sekarang ditegakkan dan dua map yang ber-key input penyerang (`ratelimit.FixedWindow`,
 `auth.LoginLimiter`) punya batas memori yang terbukti lewat pengukuran, bukan cuma dibaca dari kode.
 
-Dua hal menunggu keputusan manusia sebelum sesi coding berikutnya dimulai — bukan sesuatu yang bisa
-diputuskan sepihak dalam sesi agent, pola yang sama seperti saat Phase 3 tutup:
+### Phase 4.6 — Email Delivery (#63, #64) — sedang dibuka
 
-1. **Demo ke calon pengguna** (freeze bagian 4) — tujuan Phase 3, **masih belum dilakukan**. Dicatat
-   lagi di sini karena penutupan Phase 4.5 adalah titik alami ketiga berturut-turut untuk
-   mengingatkannya — tiga penutupan phase sudah lewat tanpa satu pun calon pengguna melihatnya.
+**Prasyarat demo ke calon pengguna** (poin 1 di bawah), diminta pemilik produk. Dokumen:
+`docs/phases/04.6-email-delivery/`.
+
+Sejak Phase 1, `MAIL_PROVIDER` hanya punya satu nilai sah (`log`) — **tidak ada satu email pun yang
+pernah benar-benar terkirim**. Verifikasi email menggerbangi login (keputusan B3), jadi calon pengguna
+yang mencoba produk ini tidak akan bisa masuk kecuali ada yang membacakan tautan dari log server.
+Dua hal ikut ketahuan saat menyiapkan phase ini:
+
+- **`MAIL_FROM` tidak pernah dibaca siapa pun** sejak Phase 1 — `LogMailer` mengabaikan `From`
+  sepenuhnya. Konfigurasi mati sejak awal.
+- **`LogMailer` menulis token verifikasi ke log** — wajar untuk dev, tapi berarti `MAIL_PROVIDER=log`
+  di produksi menaruh kredensial sekali-pakai ke berkas log. Kombinasi itu ditolak boot mulai phase ini.
+
+`mailer.Mailer` **sudah** interface sejak Phase 1 dan komentarnya sendiri menyebut implementasi kedua
+akan datang — phase ini mengisinya, bukan membuat abstraksi baru. SMTP dipilih (bukan SDK provider)
+justru supaya **pemilihan provider produksi bisa ditunda tanpa biaya**: Resend, Postmark, dan SES
+ketiganya berbicara SMTP, jadi menggantinya nanti = mengganti env, bukan menulis adapter.
+
+### Setelah itu
+
+Dua hal menunggu keputusan manusia — bukan sesuatu yang bisa diputuskan sepihak dalam sesi agent,
+pola yang sama seperti saat Phase 3 tutup:
+
+1. **Demo ke calon pengguna** (freeze bagian 4) — tujuan Phase 3, **masih belum dilakukan** setelah
+   tiga penutupan phase. Dua hambatan praktisnya sedang/sudah ditutup: panduan langkah-demi-langkah
+   sekarang ada (`docs/testing/flow/`), dan email sungguhan sedang dikerjakan (Phase 4.6 di atas —
+   tanpanya calon pengguna berhenti di layar "cek email Anda"). Setelah #64 merge, tidak ada lagi
+   penghalang teknis.
 2. **Pilih phase berikutnya**: Phase 5 (Employee Mobile) adalah satu-satunya phase MVP yang tersisa dan
    ada di jalur utama freeze (`Phase 3 → Phase 5 → GATE`) — tapi **cek dulu status Apple Developer
    Program & Firebase** di bagian *Punya Lead Time* di bawah. Kalau keduanya masih belum diurus, Phase 5
@@ -137,7 +161,7 @@ Tidak ada yang memblokir. Semuanya diputuskan saat fitur terkait dikerjakan.
 
 | Kode | Keputusan | Diputuskan sebelum |
 |---|---|---|
-| — | Email provider (Resend / Postmark / SES) | Phase 1 — ⏳ *lead time, lihat bawah* |
+| — | Email provider (Resend / Postmark / SES) | **Tidak lagi memblokir** sejak Phase 4.6 — transport SMTP, ganti provider = ganti env |
 | — | Domain final & branding | Phase 1 — ⏳ *lead time, lihat bawah* |
 | — | Hosting & managed PostgreSQL | Phase 0 akhir |
 | — | Retensi data free tier | Phase 8 |
@@ -178,6 +202,13 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 
 > Domain juga menentukan konfigurasi cookie (`Secure`, `SameSite`, scope), CORS, dan alamat pengirim email — semuanya disentuh di Phase 1.
 
+> **Diperbarui saat Phase 4.6 dibuka.** Memilih **provider** (baris kedua) tidak lagi memblokir
+> apa pun: transportnya SMTP, dan Resend/Postmark/SES ketiganya berbicara SMTP — menggantinya nanti
+> adalah perubahan env, bukan perubahan kode. Yang **tetap** punya lead time dan **tetap** wajib
+> sebelum email produksi bisa dipercaya adalah **domain + SPF/DKIM/DMARC** (baris pertama dan ketiga
+> di daftar status). Phase 4.6 membuat email terkirim; ia **tidak** membuat email sampai ke inbox
+> alih-alih folder spam — itu pekerjaan DNS, di luar repository.
+
 ---
 
 ## Progress per Phase
@@ -200,6 +231,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 3 | Owner Dashboard | ✅ | ✅ | ✅ #30–#35, #40 | ✅ |
 | 4 | Public API | ✅ | ✅ | ✅ #46–#49 | ✅ |
 | 4.5 | Hardening | ✅ | ✅ | ✅ #57–#58 | ✅ |
+| 4.6 | Email Delivery | ✅ | ✅ | ✅ #63–#64 | ⬜ |
 | 5 | Employee Mobile | ⬜ | ⬜ | ⬜ | ⬜ |
 
 Pekerjaan yang sedang berjalan: `gh issue list --state open`

--- a/docs/phases/04.6-email-delivery/issues.md
+++ b/docs/phases/04.6-email-delivery/issues.md
@@ -1,0 +1,54 @@
+# Phase 4.6 — Email Delivery · Issues
+
+> Indeks pekerjaan. **Tanpa kolom status** — status hidup di GitHub ([ADR-008](../../decisions/ADR-008-delivery-workflow.md)).
+>
+> Status terkini: `gh issue list --milestone "Phase 4.6 — Email Delivery"`
+
+**Milestone:** [Phase 4.6 — Email Delivery](https://github.com/Pravasta/jualin-crm/milestone/8)
+
+---
+
+## Daftar
+
+| # | Judul | Aplikasi | Cakupan | TD |
+|---|---|---|---|---|
+| [63](https://github.com/Pravasta/jualin-crm/issues/63) | `SMTPMailer`: kirim email sungguhan, tutup `MAIL_FROM` yang tidak pernah dipakai | `crm_be` | `SMTPMailer` + `buildRFC5322`, config `SMTP_*` + validasi boot, composition root. Test unit (tanpa jaringan) + integrasi Mailpit lewat testcontainers | §2–§7, §9.1, §9.3 |
+| [64](https://github.com/Pravasta/jualin-crm/issues/64) | Mailpit di dev environment + perbarui alur testing | `crm_be`, root, docs | Service `mailpit` di compose, `.env.example`, 5 berkas `docs/testing/flow/`, `authentication.md`. **Penutup phase** | §8, §9.2, §10 |
+
+---
+
+## Urutan
+
+```
+#63 SMTPMailer ──► #64 dev environment + docs (penutup)
+```
+
+| Dependensi | Sifat |
+|---|---|
+| #64 → #63 | **Keras.** Menyalakan Mailpit sebelum ada `SMTPMailer` yang bisa mengiriminya berarti menambah container yang tidak pernah menerima apa pun, dan memperbarui dokumentasi alur testing ke perilaku yang belum ada. |
+
+**Tidak ada pekerjaan paralel.** Phase ini dua issue, berurutan.
+
+---
+
+## Batas per issue
+
+| Issue | Berhenti di |
+|---|---|
+| #63 | SMTP **bisa** dipakai lewat env, dan terbukti mengirim ke Mailpit sungguhan di test. Tapi `make dev` **belum** menyalakan apa pun yang menerimanya, dan `docs/testing/flow/` masih menyuruh menggali log. |
+| #64 | Phase 4.6 tutup. Pemilihan provider produksi, domain, dan SPF/DKIM/DMARC **tidak** disentuh. |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Kenapa hanya dua issue
+
+Phase ini sengaja kecil. Bentuk yang dibutuhkan **sudah ada sejak Phase 1** — `mailer.Mailer` adalah
+interface, dan komentarnya sendiri menyebut implementasi kedua akan datang. Yang dikerjakan di sini
+hanya mengisinya, lalu membuat hasilnya terasa saat mengembangkan.
+
+Godaan yang ditolak: menarik pemilihan provider produksi ke sini karena "sekalian sedang menyentuh
+email". Justru sebaliknya — memilih SMTP sebagai transport adalah yang **membuat** keputusan provider
+bisa ditunda tanpa biaya, karena Resend, Postmark, dan SES ketiganya berbicara SMTP. Menutupnya
+sekarang berarti memilih di bawah tekanan tenggat demo, bukan berdasarkan kebutuhan yang terbukti.

--- a/docs/phases/04.6-email-delivery/prd.md
+++ b/docs/phases/04.6-email-delivery/prd.md
@@ -1,0 +1,117 @@
+# Phase 4.6 — Email Delivery · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md).
+> Sumber: [`architecture/freeze.md`](../../architecture/freeze.md) bagian 6 (efek samping di luar transaksi — Aturan #32), Aturan #26 (jangan log token), #34 (rate limit endpoint email), #36 (fail-fast) · [`architecture/authentication.md`](../../architecture/authentication.md) · [`docs/STATUS.md`](../../STATUS.md) bagian *Punya Lead Time* (domain + email sender)
+
+---
+
+## Kenapa phase ini ada
+
+Pemilik produk ingin **demo ke calon pengguna** — tujuan yang sudah tercatat sejak Phase 3 tutup dan
+diingatkan lagi di penutupan Phase 4 dan 4.5. Demo itu tidak bisa jalan dengan keadaan sekarang:
+
+**Tidak ada satu pun email yang pernah benar-benar terkirim.** Sejak Phase 1, `MAIL_PROVIDER` hanya
+punya satu nilai sah (`log`), dan `LogMailer` hanya mencatat pesan ke log aplikasi. Verifikasi email
+menggerbangi login (keputusan B3) — artinya calon pengguna yang mencoba produk ini **tidak akan bisa
+masuk sama sekali** kecuali seseorang membacakan tautan dari log server untuknya.
+
+Dua hal lain yang ikut ketahuan saat menyiapkan phase ini:
+
+- **`MAIL_FROM` tidak pernah dipakai.** Ia ada di `internal/shared/config` sejak Phase 1 dengan default
+  `no-reply@localhost`, tapi tidak ada satu baris kode pun yang membacanya — `LogMailer` mengabaikan
+  `From` sepenuhnya. Konfigurasi yang tidak pernah dibaca adalah janji yang belum ditepati; phase ini
+  yang menepatinya.
+- **`LogMailer` menulis token verifikasi ke log.** Wajar untuk pengembangan lokal, tapi berarti
+  `MAIL_PROVIDER=log` di produksi menaruh kredensial sekali-pakai ke berkas log — bertentangan dengan
+  semangat Aturan #26. Sekarang belum bisa terjadi karena `smtp` belum ada sebagai alternatif; begitu
+  ada, kombinasi itu harus ditolak secara eksplisit.
+
+## Yang diminta
+
+Pemilik produk meminta secara spesifik: **SMTP**, dengan **Mailpit** untuk pengembangan, disusun
+sedemikian rupa sehingga **ganti ke SMTP produksi nanti tidak menyentuh kode**.
+
+Itu tepat, dan sudah didukung bentuk yang ada: `mailer.Mailer` sudah interface sejak Phase 1 —
+komentarnya bahkan menyebut alasannya, bahwa implementasi kedua "sudah diketahui akan datang".
+Phase ini adalah implementasi kedua itu. Tidak ada abstraksi baru yang perlu dibuat (Aturan #27–#29);
+yang ada tinggal diisi.
+
+**SMTP dipilih, bukan SDK provider tertentu** — dan itu justru yang membuat "ganti provider nanti"
+menjadi perubahan konfigurasi, bukan perubahan kode. Resend, Postmark, dan SES ketiganya menyediakan
+endpoint SMTP; memilih di antaranya nanti berarti mengganti `SMTP_HOST`/kredensial, bukan menulis
+adapter baru. Keputusan provider (`docs/STATUS.md`'s *Keputusan Belum Diambil*) **tetap terbuka** —
+phase ini justru membuatnya bisa ditunda tanpa biaya.
+
+---
+
+## Kebutuhan
+
+| # | Sebagai… | Saya butuh… | Supaya… |
+|---|---|---|---|
+| 1 | Pemilik produk | Calon pengguna yang mencoba produk menerima email verifikasi sungguhan | Demo tidak berhenti di layar "cek email Anda" |
+| 2 | Pemilik produk | Bisa melihat email yang terkirim saat mengembangkan, tanpa mengirim ke alamat sungguhan | Tidak ada risiko mengirim email uji ke orang nyata, dan tidak perlu inbox sungguhan untuk mengembangkan |
+| 3 | Pemilik produk | Ganti ke SMTP produksi tanpa menyentuh kode | Keputusan provider bisa ditunda sampai benar-benar perlu, dan bisa diubah lagi kalau ternyata salah |
+| 4 | Pemilik sistem | Proses gagal boot bila konfigurasi email tidak masuk akal untuk lingkungannya | Tidak ada produksi yang diam-diam tidak pernah mengirim email |
+| 5 | Pemilik sistem | Kegagalan kirim tidak menggantung request atau membatalkan pendaftaran yang sudah tersimpan | Satu server SMTP lambat tidak menjatuhkan pendaftaran |
+| 6 | Developer berikutnya | Bukti bahwa email benar-benar sampai, bukan hanya "fungsi Send dipanggil" | Jalur email tidak rusak diam-diam di refactor berikutnya |
+
+---
+
+## Acceptance Criteria
+
+Phase 4.6 selesai bila **semuanya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | `MAIL_PROVIDER=smtp` mengirim email sungguhan lewat SMTP — dibuktikan dengan pesan yang **benar-benar sampai** dan bisa dibaca isinya, bukan dengan memeriksa bahwa `Send` dipanggil |
+| 2 | `make dev` menyalakan Mailpit; email dari alur registrasi/undangan/reset password terlihat di UI-nya **tanpa** konfigurasi tambahan |
+| 3 | Ganti ke SMTP lain (host, port, kredensial berbeda) **tidak** menyentuh satu baris kode Go pun |
+| 4 | `MAIL_FROM` benar-benar dipakai sebagai alamat pengirim — dan berhenti menjadi konfigurasi mati |
+| 5 | `MAIL_PROVIDER=log` saat `APP_ENV=production` **menghentikan boot** (Aturan #36) |
+| 6 | `MAIL_PROVIDER=smtp` tanpa host/port yang sah **menghentikan boot**, bukan gagal saat pengguna pertama mendaftar |
+| 7 | Server SMTP yang menggantung **tidak** menggantung request HTTP — ada batas waktu, dan kegagalannya tidak membatalkan pendaftaran yang sudah commit (Aturan #32) |
+| 8 | Alamat penerima yang mengandung karakter kontrol **tidak** bisa menyuntikkan header email tambahan |
+| 9 | Password SMTP **tidak pernah** muncul di log, termasuk saat pengiriman gagal (Aturan #26) |
+| 10 | Subject dan body non-ASCII sampai utuh, tidak jadi karakter rusak |
+| 11 | Seluruh test yang sudah ada tetap lulus **tanpa perubahan asersi** — `LogMailer` dan `spyMailer` di test tidak berubah perilakunya |
+| 12 | `docs/testing/flow/` diperbarui — instruksi "cari tautan di log" diganti alur Mailpit, dan `06-checklist-akhir.md` ikut menyesuaikan |
+
+---
+
+## Keputusan yang ditutup di phase ini
+
+| # | Pertanyaan | Keputusan | Alasan |
+|---|---|---|---|
+| **E1** | Pustaka SMTP atau `net/smtp` stdlib? | **`net/smtp` stdlib**, dengan koneksi dibangun manual (bukan `smtp.SendMail`). | Aturan #27 — jangan tambah dependensi untuk yang sudah ada di stdlib. `net/smtp` memang "frozen" di Go, tapi frozen berarti tidak menerima fitur baru, bukan rusak; kebutuhan di sini (plaintext + STARTTLS + PLAIN auth) persis yang sudah didukungnya. Koneksi dibangun manual karena `smtp.SendMail` **tidak punya batas waktu sama sekali** — dan `Send` dipanggil sinkron di jalur request (kriteria #7). |
+| **E2** | Boleh `MAIL_PROVIDER=log` di produksi? | **Tidak. Boot gagal.** | Dua alasan yang masing-masing sudah cukup: (a) produksi yang tidak pernah mengirim email **tidak menghasilkan satu pun error** — funnel registrasi mati diam-diam, gejala yang sama persis dengan yang `STATUS.md` peringatkan soal email masuk spam; (b) `LogMailer` menulis **token verifikasi** ke log, dan token itu kredensial sekali-pakai (Aturan #26). |
+| **E3** | Mode TLS apa yang didukung? | **STARTTLS** (port 587) dan **tanpa TLS** (dev saja). TLS implisit (port 465) **tidak** didukung dulu. | Ketiga kandidat provider di `freeze.md` bagian 7 — Resend, Postmark, SES — semuanya menyediakan 587/STARTTLS, jadi tidak ada yang terhalang. TLS implisit butuh jalur dial terpisah; menuliskannya sekarang berarti membangun untuk kebutuhan yang belum ada (Aturan #28). Tanpa-TLS ditolak saat `APP_ENV=production`. |
+| **E4** | Email HTML atau plaintext? | **Plaintext saja**, `text/plain; charset=UTF-8`. | `mailer.Message` sudah berbentuk `To/Subject/Body` sejak Phase 1 dan tidak punya field HTML. Seluruh email di produk ini transaksional dan pendek (verifikasi, reset, undangan). Email campaign eksplisit **di luar scope** (`CLAUDE.md`). Menambah HTML sekarang berarti menambah templating untuk kebutuhan yang belum ada. |
+| **E5** | Bagaimana jalur SMTP diuji? | **Mailpit sungguhan lewat testcontainers**, membaca kembali pesan yang masuk lewat API-nya — bukan mock, bukan server SMTP tiruan buatan sendiri. | Pola yang sama persis dengan harness PostgreSQL sejak issue #3: menguji terhadap barang sungguhan menangkap kelas kesalahan yang mock tidak akan pernah tangkap (format RFC 5322 salah, header hilang, encoding rusak). Kriteria #1 menuntut bukti "sampai dan terbaca", dan hanya server SMTP sungguhan yang bisa memberikannya. |
+
+---
+
+## Di luar cakupan
+
+| Tidak dikerjakan | Kenapa |
+|---|---|
+| Memilih provider produksi (Resend / Postmark / SES) | Justru **dibuat bisa ditunda** oleh phase ini — ganti provider = ganti env. Tetap terbuka di `STATUS.md` |
+| Domain, SPF, DKIM, DMARC | Pekerjaan DNS/administratif di luar repository. Tetap item *Punya Lead Time* di `STATUS.md`, dan tetap wajib sebelum email produksi sungguhan dipercaya |
+| Email HTML, template, branding visual | Keputusan E4 |
+| Tabel `jobs` / outbox / worker retry | Freeze bagian 6 memutuskan **kirim setelah commit tanpa `jobs`**, dan alasannya masih berlaku: jalur pemulihannya sudah ada (tombol kirim ulang) |
+| Retry otomatis saat SMTP gagal | Sama — pemulihannya adalah tombol kirim ulang yang sudah ada sejak Phase 1, bukan mekanisme baru |
+| Bounce/complaint handling, webhook provider | Butuh provider yang sudah dipilih. Belum dijadwalkan |
+| Email campaign / marketing | **Di luar scope produk** (`CLAUDE.md`) |
+| Mengubah bentuk `mailer.Message` atau isi teks email | Bukan pekerjaan phase ini. Isi email tidak disentuh sama sekali — hanya cara mengirimnya |
+
+---
+
+## Dependensi
+
+| Bergantung pada | Sifat |
+|---|---|
+| Phase 1 (#9, #10, #11) | **Keras.** Seluruh alur email (verifikasi, reset, undangan) lahir di sana; phase ini hanya mengganti transportasinya |
+| Pilihan provider produksi | **Tidak memblokir** — itu justru intinya |
+| Domain + SPF/DKIM/DMARC | **Tidak memblokir pekerjaan ini**, tapi **memblokir email produksi yang bisa dipercaya**. Dicatat lagi di `STATUS.md` |
+
+**Tidak memblokir Phase 5.** Dikerjakan sekarang karena demo ke calon pengguna — tujuan yang sudah
+tertunda tiga penutupan phase — tidak bisa berjalan tanpanya.

--- a/docs/phases/04.6-email-delivery/td.md
+++ b/docs/phases/04.6-email-delivery/td.md
@@ -1,0 +1,368 @@
+# Phase 4.6 — Email Delivery · Technical Design
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+> Hanya **delta** untuk phase ini — aturan yang sudah ada di [`freeze.md`](../../architecture/freeze.md) dirujuk, tidak diulang.
+> Sumber: freeze bagian 6 (Aturan #32 — efek samping di luar transaksi), Aturan #26, #36 · [ADR-010](../../decisions/ADR-010-fail-fast-startup.md)
+
+---
+
+## 1. Yang sudah ada, dan yang tidak berubah
+
+```go
+// internal/shared/mailer/mailer.go — TIDAK diubah oleh phase ini
+type Message struct {
+	To      string
+	Subject string
+	Body    string
+}
+
+type Mailer interface {
+	Send(ctx context.Context, msg Message) error
+}
+```
+
+Interface ini sudah ada sejak Phase 1, dan komentarnya sudah menjelaskan kenapa ia dibuat lebih awal
+dari biasanya: implementasi kedua sudah diketahui akan datang. **Phase ini adalah implementasi kedua
+itu** — tidak ada abstraksi baru yang perlu dibuat (Aturan #27–#29).
+
+**Yang tidak disentuh sama sekali:** `Message`, `Mailer`, `LogMailer`, `spyMailer` di test, isi teks
+setiap email, dan setiap pemanggil `Send` di `internal/auth` dan `internal/invitation`. Satu-satunya
+perubahan di luar paket `mailer` adalah `config` dan composition root.
+
+---
+
+## 2. Konfigurasi
+
+Menyusul bentuk `CORS_ALLOWED_ORIGINS` (#30) dan `TRUSTED_PROXIES` (#57) — satu env per hal, di-parse
+di `internal/shared/config`, divalidasi saat boot.
+
+```go
+// validMailProviders bertambah "smtp" — sebelumnya hanya {"log"} sejak Phase 1.
+var validMailProviders = []string{"log", "smtp"}
+
+// MailFrom sudah ada sejak Phase 1 tapi TIDAK PERNAH DIBACA siapa pun —
+// LogMailer mengabaikan From sepenuhnya. Phase ini yang membuatnya hidup.
+MailFrom string `env:"MAIL_FROM" envDefault:"no-reply@localhost"`
+
+SMTPHost     string `env:"SMTP_HOST"`
+SMTPPort     int    `env:"SMTP_PORT" envDefault:"587"`
+SMTPUsername string `env:"SMTP_USERNAME"`
+SMTPPassword string `env:"SMTP_PASSWORD"`
+// starttls (default) | none. TLS implisit port 465 sengaja tidak didukung — keputusan E3.
+SMTPTLS      string `env:"SMTP_TLS" envDefault:"starttls"`
+// Batas waktu SELURUH percakapan SMTP, bukan hanya dial — keputusan E1, §4.
+SMTPTimeout  time.Duration `env:"SMTP_TIMEOUT" envDefault:"10s"`
+```
+
+### 2.1 Validasi (Aturan #36)
+
+Ditambahkan ke `Config.validate()`, mengikuti pola baris `CORS_ALLOWED_ORIGINS`/`TRUSTED_PROXIES`:
+
+| Kondisi | Pesan |
+|---|---|
+| `AppEnv == production && MailProvider == "log"` | `MAIL_PROVIDER must not be "log" when APP_ENV=production` — keputusan E2 |
+| `MailProvider == "smtp" && SMTPHost == ""` | `SMTP_HOST must be set when MAIL_PROVIDER=smtp` |
+| `MailProvider == "smtp" && (SMTPPort <= 0 \|\| > 65535)` | pola sama seperti `HTTP_PORT` |
+| `SMTPTLS` bukan `starttls`/`none` | daftar nilai sah, pola sama seperti `LOG_LEVEL` |
+| `AppEnv == production && MailProvider == "smtp" && SMTPTLS == "none"` | kredensial dan token verifikasi lewat jaringan tanpa enkripsi |
+| `SMTPTimeout <= 0` | pola sama seperti `PUBLIC_API_RATE_LIMIT` |
+
+`SMTP_USERNAME`/`SMTP_PASSWORD` **boleh kosong** — Mailpit tidak memakai auth. Bila keduanya kosong,
+langkah `AUTH` dilewati (§4).
+
+> **Tidak ada validasi "MAIL_FROM harus alamat sah"** di luar pengecekan karakter kontrol (§5).
+> Memvalidasi bentuk alamat email dengan benar adalah lubang kelinci; server SMTP-lah yang akan
+> menolaknya, dan itu terjadi saat boot-nya sudah lewat. Yang penting dijaga di sini adalah keamanan
+> (injeksi header), bukan kebenaran alamat.
+
+---
+
+## 3. Paket — `internal/shared/mailer`
+
+```
+mailer.go        Message, Mailer, LogMailer          (sudah ada — tidak diubah)
+smtp.go          SMTPMailer, SMTPConfig              (baru)
+message.go       buildRFC5322 — fungsi murni         (baru)
+smtp_test.go     integrasi, Mailpit via testcontainers (baru)
+message_test.go  unit, tanpa jaringan sama sekali    (baru)
+```
+
+`buildRFC5322` **dipisah sebagai fungsi murni** dari `SMTPMailer.Send` supaya format pesan bisa diuji
+tanpa server, jaringan, atau container — pola yang sama seperti `lib/nav.ts`/`lib/api-key-rows.ts` di
+dashboard, dan `apikey.parseCredential` di backend.
+
+---
+
+## 4. `SMTPMailer.Send` — kenapa bukan `smtp.SendMail`
+
+`smtp.SendMail` adalah satu panggilan yang menutup seluruh percakapan SMTP, dan itu menggoda. Tapi ia
+**tidak punya batas waktu sama sekali** — ia memakai `net.Dial` telanjang. `Send` dipanggil **sinkron
+di jalur request** (`auth.Usecase.sendVerificationEmail` dipanggil langsung dari `Register`), jadi
+server SMTP yang menggantung akan menggantung request HTTP sampai timeout OS. Itu melanggar kriteria
+#7.
+
+Karena itu percakapannya dibangun manual:
+
+```go
+func (m *SMTPMailer) Send(ctx context.Context, msg Message) error {
+	raw, err := buildRFC5322(m.from, msg, m.now())
+	if err != nil {
+		return err   // injeksi header ditolak SEBELUM koneksi dibuka (§5)
+	}
+
+	deadline := time.Now().Add(m.timeout)
+	conn, err := (&net.Dialer{Timeout: m.timeout}).DialContext(ctx, "tcp", m.addr)
+	if err != nil {
+		return fmt.Errorf("mailer: dial %s: %w", m.addr, err)
+	}
+	defer conn.Close()
+	// Satu deadline untuk SELURUH percakapan, bukan per operasi — server yang
+	// menjawab satu byte per detik tetap terputus tepat waktu.
+	_ = conn.SetDeadline(deadline)
+
+	c, err := smtp.NewClient(conn, m.host)
+	if err != nil { return ... }
+	defer func() { _ = c.Close() }()
+
+	if m.tls == "starttls" {
+		if ok, _ := c.Extension("STARTTLS"); !ok {
+			return fmt.Errorf("mailer: server %s does not advertise STARTTLS", m.addr)
+		}
+		if err := c.StartTLS(&tls.Config{ServerName: m.host, MinVersion: tls.VersionTLS12}); err != nil { ... }
+	}
+
+	if m.username != "" || m.password != "" {
+		if err := c.Auth(smtp.PlainAuth("", m.username, m.password, m.host)); err != nil {
+			return errors.New("mailer: smtp authentication failed")  // §6 — err asli TIDAK dibungkus
+		}
+	}
+
+	if err := c.Mail(m.from); err != nil { ... }
+	if err := c.Rcpt(msg.To); err != nil { ... }
+	w, err := c.Data(); ...
+	if _, err := w.Write(raw); err != nil { ... }
+	if err := w.Close(); err != nil { ... }
+	return c.Quit()
+}
+```
+
+Catatan yang mengikat:
+
+- **`ctx` dipakai di `DialContext`** — request yang dibatalkan tidak meninggalkan dial menggantung.
+  Percakapan setelahnya dijaga `SetDeadline`, karena `net/smtp` tidak menerima `context`.
+- **STARTTLS diperiksa lewat `Extension` lebih dulu**, bukan langsung `StartTLS` — supaya pesan
+  errornya menyebutkan servernya yang tidak mendukung, bukan kegagalan handshake yang membingungkan.
+- **`smtp.PlainAuth` menolak mengirim kredensial di koneksi tak terenkripsi** kecuali host-nya
+  localhost. Itu perilaku stdlib dan **sengaja tidak diakali** — ia justru menegakkan E3 secara gratis.
+- Kegagalan `Send` **tidak** membatalkan apa pun yang sudah commit; pemanggilnya sudah mencatat error
+  secara terstruktur sejak Phase 1 (Aturan #32). Phase ini tidak mengubah kontrak itu.
+
+---
+
+## 5. `buildRFC5322` — format dan pertahanan injeksi header
+
+```go
+func buildRFC5322(from string, msg Message, now time.Time) ([]byte, error)
+```
+
+Header yang ditulis:
+
+```
+From: <MAIL_FROM>
+To: <msg.To>
+Subject: <RFC 2047 bila perlu>
+Date: <RFC1123Z>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+```
+
+### 5.1 Injeksi header — kriteria #8
+
+`msg.To` berasal dari **input pengguna** (form registrasi, form undangan). Alamat yang mengandung
+`\r` atau `\n` bisa menyisipkan header tambahan — mis. `korban@x.com\r\nBcc: penyerang@y.com` membuat
+salinan email verifikasi terkirim ke penyerang.
+
+`buildRFC5322` **menolak** (`error`, bukan sanitasi diam-diam) bila `from`, `To`, atau `Subject`
+mengandung `\r` atau `\n`. Diverifikasi saat menulis TD ini: `strings.ContainsAny(s, "\r\n")`
+mendeteksi ketiga bentuk (`\r\n`, `\n` telanjang, `\r` telanjang).
+
+> **Kenapa menolak, bukan membuang karakternya.** Membuang menghasilkan alamat yang *terlihat* sah
+> tapi bukan yang diminta pemanggil — email terkirim ke tempat yang salah tanpa jejak. Menolak
+> menghasilkan error terstruktur yang sudah ditangani pemanggil sejak Phase 1.
+
+`Body` **tidak** perlu diperiksa: ia berada setelah baris kosong pemisah header, jadi `\n` di sana
+memang isi pesan, bukan header baru.
+
+### 5.2 Encoding subject — kriteria #10
+
+`mime.QEncoding.Encode("utf-8", subject)`. Diverifikasi saat menulis TD ini:
+
+| Input | Output |
+|---|---|
+| `Verifikasi email Jualin CRM Anda` | tidak berubah — ASCII dibiarkan apa adanya |
+| `Anda diundang bergabung di Jualin CRM` | tidak berubah |
+| `Sudah — kami kirim ulang` | `=?utf-8?q?Sudah_=E2=80=94_kami_kirim_ulang?=` |
+
+Ketiga subject yang dipakai produk ini hari ini semuanya ASCII, jadi header-nya tetap terbaca biasa;
+encoding baru aktif kalau nanti ada teks Indonesia dengan tanda baca tipografis. **Justru itu
+alasannya dipasang sekarang** — kalau tidak, subject pertama yang memakai `—` akan sampai sebagai
+karakter rusak, dan tidak ada yang akan mengaitkannya dengan perubahan teks yang tampak sepele.
+
+Body dikirim `8bit` dengan `charset=UTF-8` — Mailpit dan setiap MTA modern menerimanya.
+
+---
+
+## 6. Rahasia dan log (Aturan #26, kriteria #9)
+
+| Aturan |
+|---|
+| `SMTPPassword` **tidak pernah** masuk pesan error atau log. Kegagalan auth dikembalikan sebagai `errors.New("mailer: smtp authentication failed")` — error asli dari `net/smtp` **tidak** dibungkus, karena ia bisa memuat echo kredensial dari server |
+| `SMTPMailer` **tidak** memiliki logger sama sekali. Ia mengembalikan error; pemanggil yang mencatat — dan pemanggil sudah mencatat `err` + `to` saja sejak Phase 1, bukan isi pesan |
+| `Config` **tidak** punya `String()`/`LogValue()` yang mencetak seluruh struct. Tidak ada yang menambahkannya di phase ini |
+| Body email (yang memuat token verifikasi) **tidak pernah** dicatat oleh `SMTPMailer` — berbeda dari `LogMailer`, yang memang tugasnya begitu, dan justru karena itu dilarang di produksi (E2) |
+
+---
+
+## 7. Composition root
+
+```go
+func newMailer(cfg *config.Config, log *slog.Logger) mailer.Mailer {
+	switch cfg.MailProvider {
+	case "log":
+		return mailer.NewLogMailer(log)
+	case "smtp":
+		return mailer.NewSMTPMailer(mailer.SMTPConfig{
+			Host: cfg.SMTPHost, Port: cfg.SMTPPort,
+			Username: cfg.SMTPUsername, Password: cfg.SMTPPassword,
+			From: cfg.MailFrom, TLS: cfg.SMTPTLS, Timeout: cfg.SMTPTimeout,
+		})
+	default:
+		panic(...)  // sudah ada — tidak berubah bentuknya
+	}
+}
+```
+
+Cabang `default` yang sudah ada tetap: ia tidak bisa tercapai karena `validate()` sudah menyaring
+nilainya, dan itu memang pesannya.
+
+---
+
+## 8. Mailpit di `docker-compose.yml`
+
+```yaml
+mailpit:
+  image: axllent/mailpit:latest
+  ports:
+    - "1025:1025"   # SMTP
+    - "8025:8025"   # web UI
+```
+
+`api` mendapat:
+
+```yaml
+MAIL_PROVIDER: smtp
+MAIL_FROM: no-reply@jualin.local
+SMTP_HOST: mailpit
+SMTP_PORT: 1025
+SMTP_TLS: none          # Mailpit lokal, tanpa TLS — ditolak kalau APP_ENV=production (§2.1)
+```
+
+Tanpa `depends_on: mailpit`: SMTP hanya dipakai saat ada email dikirim, bukan saat boot, dan `api`
+yang menunggu Mailpit sehat hanya memperlambat `docker compose up` tanpa manfaat. Kegagalan kirim
+sudah punya perlakuan yang benar sejak Phase 1 (Aturan #32).
+
+**`make dev` setelah ini langsung menyalakan Mailpit** — memenuhi kriteria #2 tanpa langkah tambahan.
+UI di `http://localhost:8025`.
+
+---
+
+## 9. Rencana test
+
+### 9.1 Unit — tanpa jaringan (`message_test.go`)
+
+| Test | Membuktikan |
+|---|---|
+| `TestBuildRFC5322_HeadersAndBody` | Seluruh header wajib ada, urutannya benar, body dipisah baris kosong |
+| `TestBuildRFC5322_RejectsHeaderInjectionInTo` | `\r\n`, `\n`, dan `\r` di `To` ketiganya ditolak — kriteria #8 |
+| `TestBuildRFC5322_RejectsHeaderInjectionInSubjectAndFrom` | Sama untuk dua field lain |
+| `TestBuildRFC5322_ASCIISubjectNotEncoded` | Subject produk hari ini tetap terbaca polos |
+| `TestBuildRFC5322_NonASCIISubjectEncoded` | `=?utf-8?q?…?=` — kriteria #10 |
+| `TestBuildRFC5322_BodyNewlinesAreNotHeaders` | `\n` di body bukan kerentanan, tidak ikut ditolak |
+
+### 9.2 Integrasi — Mailpit sungguhan (`smtp_test.go`, keputusan E5)
+
+Testcontainers `axllent/mailpit`, tunggu port 8025 siap, kirim lewat `SMTPMailer`, lalu **baca kembali
+pesannya lewat API Mailpit** (`GET /api/v1/messages`, lalu detailnya) — bukan memeriksa bahwa `Send`
+mengembalikan `nil`.
+
+| Test | Membuktikan |
+|---|---|
+| `TestSMTPMailer_MessageActuallyArrives` | Kriteria #1 — pesan ada di kotak masuk, `From`/`To`/`Subject`/body cocok persis |
+| `TestSMTPMailer_UsesMailFromAsSender` | Kriteria #4 — `MAIL_FROM` benar-benar jadi pengirim, bukan diabaikan seperti sebelumnya |
+| `TestSMTPMailer_NonASCIISubjectArrivesIntact` | Kriteria #10 dari sisi penerima, bukan hanya dari sisi encoder |
+| `TestSMTPMailer_UnreachableServerFailsWithinTimeout` | Kriteria #7 — port tertutup/host blackhole gagal **dalam** batas waktu, diukur, bukan menggantung |
+
+`smtp_test.go` memakai build constraint/skip yang sama seperti harness `dbtest` bila Docker tidak
+tersedia — polanya diikuti dari `internal/shared/db/dbtest`, tidak dibuat baru.
+
+### 9.3 Config (`config_test.go`, menambah — tidak mengubah yang ada)
+
+| Test | Membuktikan |
+|---|---|
+| `TestLoad_ProductionRejectsLogMailProvider` | Kriteria #5 |
+| `TestLoad_SMTPRequiresHost` | Kriteria #6 |
+| `TestLoad_ProductionRejectsSMTPWithoutTLS` | E3 |
+| `TestLoad_InvalidSMTPTLSMode` | Nilai `SMTP_TLS` di luar daftar ditolak saat boot |
+
+Test produksi yang sudah ada (`TestLoad_ProductionMode`, `…RequiresCookieSecure`,
+`…RequiresCORSAllowedOrigins`, `…RequiresTrustedProxies`) **perlu ditambahi `MAIL_PROVIDER=smtp` +
+`SMTP_HOST`** supaya tetap lolos — penambahan setup, **bukan** perubahan asersi. Kriteria #11 tetap
+terpenuhi; ini konsekuensi wajar dari menambah aturan validasi produksi baru, sama seperti yang
+terjadi saat `TRUSTED_PROXIES` ditambahkan di #57.
+
+---
+
+## 10. Yang berubah pada dokumentasi
+
+| Berkas | Perubahan |
+|---|---|
+| `architecture/authentication.md` | Bagian baru **Pengiriman email** — dua provider, kenapa `log` dilarang di produksi, di mana batas waktunya, kenapa kegagalan tidak membatalkan commit |
+| `docs/testing/flow/README.md` | Bagian *Soal email — LogMailer* diganti: email sekarang **benar-benar terkirim** ke Mailpit |
+| `docs/testing/flow/00-menjalankan-aplikasi.md` | §8 (mengambil tautan dari log) diganti alur Mailpit; §7 bertambah langkah membuka `http://localhost:8025` |
+| `docs/testing/flow/01-…`, `02-…` | Perintah `docker compose logs api \| grep …` diganti "buka Mailpit, klik email terbaru" |
+| `docs/testing/flow/06-checklist-akhir.md` | Baris yang menyebut "tautan di log" disesuaikan |
+| `.env.example` | `MAIL_PROVIDER`, `SMTP_*`, dan `MAIL_FROM` yang kini benar-benar dipakai |
+| `docker-compose.yml` | Service `mailpit` + env `api` |
+| `STATUS.md` | Baris Selesai; Phase 4.6 di *Progress per Phase*; *Punya Lead Time* diperbarui — pemilihan provider kini **tidak lagi memblokir demo** |
+
+`freeze.md` **tidak disentuh** — tidak ada aturannya yang berubah. Keputusan freeze bagian 6 (kirim
+setelah commit, tanpa `jobs`) justru ditegaskan, bukan direvisi. Tidak ada ADR baru: memilih SMTP
+sebagai transport adalah pengisian `mailer.Mailer` yang sudah ada, bukan keputusan arsitektur baru.
+
+---
+
+## 11. Risiko teknis
+
+| Risiko | Penanganan |
+|---|---|
+| `net/smtp` "frozen" di stdlib | Frozen = tidak menerima fitur baru, bukan tidak dipelihara. Kebutuhan di sini persis yang sudah didukungnya. Bila kelak butuh TLS implisit atau OAuth2, itu pemicu sah untuk meninjau ulang — dicatat di §12 |
+| Provider produksi ternyata menuntut port 465 | E3 menyatakan ini eksplisit di luar cakupan. Ketiga kandidat di `freeze.md` mendukung 587, jadi tidak ada yang terhalang hari ini |
+| Test Mailpit menambah waktu CI | Satu container ringan, sepola dengan Postgres yang sudah ada. Test unit `buildRFC5322` sengaja bebas jaringan supaya bagian tercepatnya tetap cepat |
+| `MAIL_FROM` default `no-reply@localhost` ditolak MTA produksi | Sudah tertangani: produksi tanpa `MAIL_FROM` yang benar akan ditolak server SMTP, dan itu kegagalan yang terlihat. Domain sungguhan tetap item *Punya Lead Time* |
+| Orang mengira phase ini menyelesaikan deliverability | Tidak. SPF/DKIM/DMARC eksplisit di luar cakupan (PRD) dan tetap wajib sebelum email produksi bisa dipercaya. Dinyatakan lagi di `STATUS.md` |
+
+---
+
+## 12. Kewajiban yang diteruskan ke phase berikutnya
+
+- **Sebelum email produksi sungguhan dipercaya:** domain final + SPF/DKIM/DMARC — tetap item *Punya
+  Lead Time* di `STATUS.md`, **tidak** ditutup oleh phase ini.
+- **Saat provider dipilih:** cukup mengganti `SMTP_HOST`/`SMTP_PORT`/kredensial. Bila provider yang
+  dipilih **hanya** menyediakan TLS implisit (465) atau menuntut OAuth2, barulah E1/E3 ditinjau ulang
+  — itu pemicunya, bukan sebelumnya.
+- **Phase 5 (Mobile):** tidak terdampak. Mobile memakai jalur user session yang sama; email verifikasi
+  dan reset password justru baru benar-benar bekerja setelah phase ini.
+- **Kalau kelak butuh retry/outbox:** freeze bagian 6 sudah memutuskan **tidak**, dengan alasan yang
+  masih berlaku (jalur pemulihannya adalah tombol kirim ulang). Mengubah itu butuh ADR, bukan
+  keputusan di tengah implementasi.


### PR DESCRIPTION
## Ringkasan

Diminta pemilik produk sebagai **prasyarat demo ke calon pengguna**: SMTP sebagai transport, **Mailpit** untuk pengembangan, disusun supaya ganti ke SMTP produksi nanti **tidak menyentuh kode**.

PR ini hanya membuka phase: `prd.md`, `td.md`, `issues.md`, plus `STATUS.md`. **Tidak ada kode yang berubah** — implementasinya di #63 dan #64.

## Kenapa sekarang

Demo sudah jadi tujuan sejak Phase 3 tutup dan terbawa lewat **tiga penutupan phase**. Ia tidak bisa jalan dengan keadaan sekarang: sejak Phase 1, `MAIL_PROVIDER` hanya punya satu nilai sah (`log`) — **tidak ada satu email pun yang pernah benar-benar terkirim**. Verifikasi email menggerbangi login (keputusan B3), jadi calon pengguna **tidak akan bisa masuk sama sekali** kecuali ada yang membacakan tautan dari log server.

Dua hal ikut ketahuan saat menyiapkan phase ini:

- **`MAIL_FROM` tidak pernah dibaca siapa pun** — ada di `internal/shared/config` sejak Phase 1, `LogMailer` mengabaikan `From` sepenuhnya. Konfigurasi mati sejak awal.
- **`LogMailer` menulis token verifikasi ke log.** Wajar untuk dev, tapi berarti `MAIL_PROVIDER=log` di produksi menaruh kredensial sekali-pakai ke berkas log. Kombinasi itu ditolak boot mulai phase ini.

## Tidak ada abstraksi baru

`mailer.Mailer` **sudah** interface sejak Phase 1, dan komentarnya sendiri sudah menyebut implementasi kedua akan datang. Phase ini mengisinya (Aturan #27–#29). `Message`, `Mailer`, `LogMailer`, `spyMailer`, isi teks email, dan setiap pemanggil `Send` **tidak disentuh**.

## SMTP justru yang membuat keputusan provider bisa ditunda

Resend, Postmark, dan SES ketiganya menyediakan endpoint SMTP — memilih di antaranya nanti berarti mengganti `SMTP_HOST`/kredensial, bukan menulis adapter. Barisnya di *Keputusan Belum Diambil* diperbarui jadi **"tidak lagi memblokir"**.

Yang **tetap** memblokir email produksi yang bisa dipercaya: **domain + SPF/DKIM/DMARC**. Bagian *Punya Lead Time* diperbarui supaya phase ini tidak terbaca sebagai "email selesai" — ia membuat email **terkirim**, bukan membuatnya **sampai inbox alih-alih spam**.

## Lima keputusan ditutup di muka (E1–E5)

| # | Keputusan | Inti alasan |
|---|---|---|
| **E1** | `net/smtp` stdlib, percakapan dibangun manual | Aturan #27. Manual karena `smtp.SendMail` **tidak punya batas waktu sama sekali**, dan `Send` dipanggil sinkron di jalur request — server menggantung = request menggantung |
| **E2** | `MAIL_PROVIDER=log` di produksi → boot gagal | Produksi yang tidak pernah kirim email **tidak menghasilkan satu pun error**; plus `LogMailer` menulis token ke log |
| **E3** | STARTTLS + tanpa-TLS (dev). TLS implisit 465 **tidak** didukung | Ketiga kandidat provider mendukung 587, jadi tidak ada yang terhalang (Aturan #28) |
| **E4** | Plaintext saja | `Message` tidak punya field HTML; email campaign di luar scope produk |
| **E5** | Diuji lewat **Mailpit sungguhan** (testcontainers), membaca pesannya kembali | Pola sama seperti harness Postgres sejak #3 — mock tidak akan pernah menangkap RFC 5322 yang salah |

## Perilaku stdlib diverifikasi sebelum ditulis, bukan diasumsikan

- `mime.QEncoding.Encode` membiarkan ketiga subject produk hari ini (ASCII) **tidak berubah**, dan hanya meng-encode saat perlu (`Sudah — kami` → `=?utf-8?q?…?=`)
- `strings.ContainsAny(s, "\r\n")` menangkap ketiga bentuk injeksi header (`\r\n`, `\n`, `\r`)

## Cakupan

Dua issue, berurutan:

- **#63** — `SMTPMailer` + `buildRFC5322`, config `SMTP_*` + validasi boot, composition root. Test unit (bebas jaringan) + integrasi Mailpit
- **#64** — Mailpit di `docker-compose.yml`, `.env.example`, 5 berkas `docs/testing/flow/`, `authentication.md`. **Penutup phase**

**Di luar cakupan secara eksplisit**: memilih provider produksi, domain/SPF/DKIM/DMARC, email HTML, retry/outbox (freeze bagian 6 sudah memutuskan tidak, dan alasannya masih berlaku).

## Kenapa "4.6"

Mengikuti preseden 4.5 — `freeze.md` 🔒 FROZEN dan sudah memakai 5–9, jadi nomor pecahan menandai penyelaan tak terencana tanpa menggeser apa pun. **`freeze.md` tidak disentuh**: keputusan bagian 6 (kirim setelah commit, tanpa tabel `jobs`) justru ditegaskan di sini, bukan direvisi.

Refs #63
Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)