### PR TITLE
feat(dev): add Mailpit, close Phase 4.6 — Email Delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,23 @@ DB_MAX_CONNS=10
 
 LOG_LEVEL=debug
 
+# --- Email (issue #63/#64, docs/phases/04.6-email-delivery/td.md §2) ---
+# "log" (LogMailer, no real send) or "smtp". Rejected outright at boot
+# when APP_ENV=production — a production process that never sends email
+# fails completely silently, and LogMailer also writes the verification
+# token itself to the log (Rule #26).
+MAIL_PROVIDER=smtp
+MAIL_FROM=no-reply@jualin.local
+# `make dev` runs Mailpit (docker-compose.yml) with its SMTP port mapped
+# to localhost:1025 — these values talk to that container from the host.
+# Open http://localhost:8025 to read whatever gets sent.
+SMTP_HOST=localhost
+SMTP_PORT=1025
+# starttls (default) or none. Mailpit takes no TLS locally — "none" is
+# rejected at boot when APP_ENV=production (Rule #36).
+SMTP_TLS=none
+SMTP_TIMEOUT=10s
+
 # --- auth (issue #10, docs/phases/01-auth-organization/td.md §2) ---
 # Required, min 32 bytes — generate your own, never reuse this one.
 JWT_SECRET=development-only-secret-do-not-use-in-production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,18 @@ services:
       timeout: 3s
       retries: 15
 
+  # SMTP + web UI for local email — no real provider needed to develop
+  # against (issue #64). api does NOT depend_on this: SMTP is only
+  # touched when an email is actually sent, never at boot, so a
+  # slow/unhealthy mailpit must never block `docker compose up` from
+  # serving traffic (same reasoning as api having no depends_on for
+  # anything beyond postgres's own readiness).
+  mailpit:
+    image: axllent/mailpit:latest
+    ports:
+      - "1025:1025" # SMTP
+      - "8025:8025" # web UI — http://localhost:8025
+
   api:
     build:
       context: ./crm_be
@@ -37,6 +49,15 @@ services:
       # (no default) so a missing secret fails boot loudly instead of
       # silently invalidating tokens on restart (Rule #36).
       JWT_SECRET: development-only-secret-do-not-use-in-production
+      # Real SMTP send, to the mailpit service above — not LogMailer
+      # (issue #63, #64). "mailpit" resolves via Docker's default compose
+      # network; SMTP_TLS=none because Mailpit takes no TLS locally
+      # (config.Validate rejects "none" outright when APP_ENV=production).
+      MAIL_PROVIDER: smtp
+      MAIL_FROM: no-reply@jualin.local
+      SMTP_HOST: mailpit
+      SMTP_PORT: 1025
+      SMTP_TLS: none
     ports:
       - "8080:8080"
     depends_on:

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 29 Agustus 2026 — **Phase 4.6 — Email Delivery dibuka** (#63, #64), prasyarat demo ke calon pengguna.
-**Phase sekarang:** Phase 4.6 — Email Delivery. Phase 4.5 selesai; Phase 5 menunggu, lihat *Berikutnya*.
+**Last updated:** 29 Agustus 2026 — Issue #64 selesai. **Phase 4.6 — Email Delivery selesai.**
+**Phase sekarang:** Phase 4.6 selesai — phase berikutnya (5) belum dibuka, lihat *Berikutnya*.
 
 ---
 
@@ -48,6 +48,7 @@
 | **Issue #57 — Trusted proxy: tegakkan Aturan #34** | — | 4.5 | Ditemukan saat meninjau `docs/issues/047` sebelum Phase 5 dibuka — bukan direncanakan. `cmd/api/main.go`'s `newRouter` memakai `gin.New()` tanpa `SetTrustedProxies`; default Gin 1.12 mempercayai setiap peer sebagai proxy, sehingga `c.ClientIP()` bisa dipalsukan lewat `X-Forwarded-For` — **dibuktikan langsung** sebelum implementasi (satu peer asli, tiga header palsu, tiga IP berbeda dilaporkan). Akibatnya **Aturan #34 secara faktual tidak ditegakkan sejak Phase 1** — seluruh limit per-IP (`register`, `resend`, `forgot`, `login`) bisa dilewati satu header. `TRUSTED_PROXIES` baru (`internal/shared/config`) — daftar IP/CIDR atau literal `none`, wajib diisi saat `APP_ENV=production` (Aturan #36, pola sama seperti `CORS_ALLOWED_ORIGINS`). `SetTrustedProxies` dipasang di `newRouter` sebelum middleware apa pun. **6 test baru di `cmd/api/trusted_proxy_test.go`** terhadap router produksi sungguhan, mencakup keempat titik panggil `ClientIP()` (bukan satu endpoint wakil) — **terbukti bisa gagal**: `SetTrustedProxies` dilepas sementara → 5 dari 6 test merah (satu test positif tetap hijau, sebagaimana mestinya) → dikembalikan, tidak pernah ter-commit. Test lama (`TestHandler_Register_RateLimited` dari #9) **tidak diubah asersinya** — hanya komentarnya diperbarui untuk jujur bahwa router tiruan `internal/auth` tidak pernah memanggil `SetTrustedProxies` sama sekali, sehingga bukti anti-spoofing yang sebenarnya sekarang hidup di `cmd/api`. 7 test baru di `internal/shared/config`. `authentication.md` mendapat bagian baru *Model kepercayaan jaringan* (diagram alur, tabel dua kesalahan konfigurasi dan gejala berlawanannya); `api.md` menunjuk ke sana. **Belum menutup phase** — eviction map (#58) belum disentuh; map masih tumbuh, hanya lebih lambat karena laju pertumbuhannya kini terikat pada IP nyata penyerang. |
 | **Issue #58 — Eviction map ber-key penyerang, penutup Phase 4.5** | — | 4.5 | Eviction **dua generasi** (`current`/`previous`, ditukar tiap ~1 window) di `ratelimit.FixedWindow` dan `auth.LoginLimiter` — bukan sweep berkala (memindai map besar sambil memegang lock justru mengubah pertahanan jadi bagian serangan, dan freeze melarang worker tanpa kebutuhan async nyata). **Carry-forward lewat lookup, bukan filter saat swap**: bucket/backoff yang masih hidup dipindahkan dari `previous` ke `current` hanya saat diakses lagi, disalin apa adanya (`windowStart`/`count` atau `failures`/`nextAllowedAt`) — sehingga key manapun yang masih aktif berperilaku **identik** dengan sebelum eviction ada, dan seluruh test lama lulus tanpa perubahan asersi. Field `now func() time.Time` unexported ditambahkan ke kedua tipe untuk kontrol waktu deterministik di test, di-set hanya dari file test internal paket yang sama (`limiter_internal_test.go`, `login_limiter_internal_test.go` — deviasi `package ratelimit`/`package auth`, pola sama seperti `internal/apikey/entity_test.go`). **4 test baru membuktikan batas memori lewat pengukuran**: 20 generasi × 50 key unik (1000 total) tetap terlacak ≤100 di kedua tipe. **Terbukti bisa gagal** — empat run adversarial terpisah (roll dimatikan, carry-forward dimatikan, di kedua tipe), semuanya merah persis seperti diprediksi, dikembalikan, tidak pernah ter-commit. Dua map ber-key entity bisnis (`apikey.lastUsedThrottle`, `lead.idempotencyCleanupThrottle`) **sengaja tetap tanpa eviction** (keputusan H3) — komentarnya diperbarui untuk berhenti menyamakan diri dengan `ratelimit.FixedWindow` dan menjelaskan alasan sebenarnya. **Seluruh 10 acceptance criteria PRD Phase 4.5 dicek satu per satu dan terpenuhi. Phase 4.5 — Hardening selesai.** |
 | **Issue #63 — `SMTPMailer`, tutup `MAIL_FROM` yang tidak pernah dipakai** | — | 4.6 | `mailer.Mailer` sudah interface sejak Phase 1 — komentarnya sendiri menyebut implementasi kedua akan datang. `SMTPMailer` mengisinya, **tanpa** abstraksi baru. Percakapan SMTP dibangun **manual** (bukan `smtp.SendMail`, yang tidak punya batas waktu sama sekali) — `Send` dipanggil sinkron di jalur request, jadi server menggantung = request menggantung; satu `conn.SetDeadline` menutup seluruh percakapan sejak dial sampai `QUIT`. **`MAIL_FROM` akhirnya dipakai** — sejak Phase 1 ada di config tapi tidak dibaca siapa pun. `MAIL_PROVIDER=log` di `APP_ENV=production` **menghentikan boot** (keputusan E2) — produksi yang tidak pernah kirim email gagal diam-diam, dan `LogMailer` menulis token verifikasi ke log. `SMTP_TLS=none` juga ditolak di produksi (E3). **Dua perilaku stdlib diverifikasi sebelum ditulis**: `mime.QEncoding.Encode` membiarkan subject ASCII produk hari ini apa adanya; `strings.ContainsAny(s, "\r\n")` menangkap ketiga bentuk injeksi header. **10 test baru** — 6 unit tanpa jaringan (`message_internal_test.go`, deviasi `package mailer` mengikuti preseden `apikey`/`ratelimit`) + **4 integrasi terhadap Mailpit sungguhan lewat testcontainers**, membaca pesan kembali lewat API Mailpit alih-alih memeriksa `Send` mengembalikan `nil`. **Terbukti bisa gagal** — defense injeksi header dan `SetDeadline` masing-masing dirusak sementara, keduanya merah persis seperti diprediksi (yang kedua digantung sampai dipotong paksa `-timeout=15s`, membuktikan tanpa deadline `Send` benar-benar tidak pernah berhenti sendiri), dikembalikan, tidak pernah ter-commit. Test produksi lama (`TestLoad_ProductionMode` dkk.) ditambahi setup `MAIL_PROVIDER=smtp`+`SMTP_HOST` — bukan perubahan asersi. **Belum menutup phase** — Mailpit belum menyala di `make dev`, `docs/testing/flow/` masih menyuruh menggali log. |
+| **Issue #64 — Mailpit di dev environment, penutup Phase 4.6** | — | 4.6 | `docker-compose.yml` bertambah service `mailpit` — **tanpa** `depends_on` di `api` (SMTP hanya disentuh saat email benar-benar dikirim, bukan saat boot; diverifikasi langsung: registrasi 0,3 detik setelah `docker compose up` tetap `201`, Mailpit tanpa healthcheck sudah siap jauh lebih cepat dari Postgres). `.env.example`'s `SMTP_HOST=localhost` sengaja **beda** dari `docker-compose.yml`'s `SMTP_HOST=mailpit` — dua sudut pandang jaringan berbeda (host vs container Docker), bukan inkonsistensi. Enam tempat di lima berkas `docs/testing/flow/` diperbarui — instruksi `docker compose logs | grep` diganti "buka `http://localhost:8025`, klik email terbaru"; §8 lama (cara menyalin tautan dari log tanpa ikut membawa `\n\n` literal) **dihapus seluruhnya**, bukan disunting, karena masalahnya sudah tidak ada. Satu baris troubleshooting baru **awalnya salah**: draf pertama mengklaim race condition boot `api`/`mailpit` sebagai penyebab utama email tidak muncul — **diverifikasi langsung sebelum ditulis final, klaimnya tidak terbukti** (urutan langkah di panduan sendiri sudah memberi Mailpit cukup waktu naik); ditulis ulang lebih berhati-hati, menyebut kemungkinan itu jarang. `authentication.md` mendapat bagian baru *Pengiriman email* (dua provider, kenapa `SMTPMailer` bukan `smtp.SendMail`, kenapa kegagalan kirim tidak membatalkan apa pun yang commit, Mailpit di dev, batas untuk produksi). **Verifikasi manual end-to-end dari nol**: `docker compose down -v` → `up --build` → `migrate-up` → registrasi → email verifikasi muncul di Mailpit (`From: no-reply@jualin.local`, subjek benar) → token diekstrak dari body → `200 verified`; diulang untuk reset password. **Seluruh 12 acceptance criteria PRD Phase 4.6 dicek satu per satu dan terpenuhi. Phase 4.6 — Email Delivery selesai.** |
 
 ---
 
@@ -59,49 +60,29 @@ _(kosong)_
 
 ## Berikutnya
 
-**Phase 4.5 — Hardening selesai** (#57, #58) — tidak direncanakan, lahir dari pemeriksaan ulang
-`docs/issues/046` & `047` sebelum Phase 5 dibuka. Ringkasan lengkap ada di baris Selesai #57/#58 dan
-`docs/phases/04.5-hardening/notes.md`; intinya: Aturan #34 tidak pernah benar-benar ditegakkan sejak
-Phase 1 (`c.ClientIP()` bisa dipalsukan lewat header karena `SetTrustedProxies` tidak pernah dipanggil)
-— sekarang ditegakkan dan dua map yang ber-key input penyerang (`ratelimit.FixedWindow`,
-`auth.LoginLimiter`) punya batas memori yang terbukti lewat pengukuran, bukan cuma dibaca dari kode.
+**Phase 4.6 — Email Delivery selesai** (#63, #64) — diminta pemilik produk sebagai prasyarat demo ke
+calon pengguna. Ringkasan lengkap di baris Selesai #63/#64 dan
+`docs/phases/04.6-email-delivery/notes.md`; intinya: `mailer.Mailer` (interface sejak Phase 1)
+akhirnya punya implementasi SMTP sungguhan, `MAIL_FROM` yang sejak Phase 1 tidak pernah dibaca
+siapa pun akhirnya dipakai, dan `MAIL_PROVIDER=log`/`SMTP_TLS=none` keduanya ditolak boot saat
+`APP_ENV=production`. `docs/testing/flow/` diperbarui — tidak ada lagi langkah "gali log", email
+verifikasi/reset/undangan sekarang muncul di Mailpit (`http://localhost:8025`) saat `make dev`.
 
-### Phase 4.6 — Email Delivery (#63, #64) — sedang dibuka
-
-**Prasyarat demo ke calon pengguna** (poin 1 di bawah), diminta pemilik produk. Dokumen:
-`docs/phases/04.6-email-delivery/`.
-
-Sejak Phase 1, `MAIL_PROVIDER` hanya punya satu nilai sah (`log`) — **tidak ada satu email pun yang
-pernah benar-benar terkirim**. Verifikasi email menggerbangi login (keputusan B3), jadi calon pengguna
-yang mencoba produk ini tidak akan bisa masuk kecuali ada yang membacakan tautan dari log server.
-Dua hal ikut ketahuan saat menyiapkan phase ini:
-
-- **`MAIL_FROM` tidak pernah dibaca siapa pun** sejak Phase 1 — `LogMailer` mengabaikan `From`
-  sepenuhnya. Konfigurasi mati sejak awal.
-- **`LogMailer` menulis token verifikasi ke log** — wajar untuk dev, tapi berarti `MAIL_PROVIDER=log`
-  di produksi menaruh kredensial sekali-pakai ke berkas log. Kombinasi itu ditolak boot mulai phase ini.
-
-`mailer.Mailer` **sudah** interface sejak Phase 1 dan komentarnya sendiri menyebut implementasi kedua
-akan datang — phase ini mengisinya, bukan membuat abstraksi baru. SMTP dipilih (bukan SDK provider)
-justru supaya **pemilihan provider produksi bisa ditunda tanpa biaya**: Resend, Postmark, dan SES
-ketiganya berbicara SMTP, jadi menggantinya nanti = mengganti env, bukan menulis adapter.
-
-### Setelah itu
-
-Dua hal menunggu keputusan manusia — bukan sesuatu yang bisa diputuskan sepihak dalam sesi agent,
+Satu hal menunggu keputusan manusia — bukan sesuatu yang bisa diputuskan sepihak dalam sesi agent,
 pola yang sama seperti saat Phase 3 tutup:
 
-1. **Demo ke calon pengguna** (freeze bagian 4) — tujuan Phase 3, **masih belum dilakukan** setelah
-   tiga penutupan phase. Dua hambatan praktisnya sedang/sudah ditutup: panduan langkah-demi-langkah
-   sekarang ada (`docs/testing/flow/`), dan email sungguhan sedang dikerjakan (Phase 4.6 di atas —
-   tanpanya calon pengguna berhenti di layar "cek email Anda"). Setelah #64 merge, tidak ada lagi
-   penghalang teknis.
-2. **Pilih phase berikutnya**: Phase 5 (Employee Mobile) adalah satu-satunya phase MVP yang tersisa dan
+1. **Pilih phase berikutnya**: Phase 5 (Employee Mobile) adalah satu-satunya phase MVP yang tersisa dan
    ada di jalur utama freeze (`Phase 3 → Phase 5 → GATE`) — tapi **cek dulu status Apple Developer
    Program & Firebase** di bagian *Punya Lead Time* di bawah. Kalau keduanya masih belum diurus, Phase 5
    akan berhenti tepat di bagian build iOS dan push notification, persis alasan Phase 4 dikerjakan lebih
    dulu sebelumnya. Bila keduanya sudah beres, Phase 5 bisa langsung dibuka (PRD + TD, pola yang sama
    seperti Phase 2→3→4).
+
+**Demo ke calon pengguna** (freeze bagian 4, tujuan Phase 3) — kedua hambatan teknis yang tercatat di
+sini sejak Phase 3 tutup sekarang **sudah ditutup**: panduan langkah-demi-langkah ada
+(`docs/testing/flow/`), dan email sungguhan terkirim (Phase 4.6). Tidak ada lagi penghalang teknis
+yang tercatat di dokumen ini — sisanya jadwal dan keputusan pemilik produk, di luar yang bisa dicatat
+sebagai item kerja di sini.
 
 ### Kewajiban yang diwarisi phase-phase berikutnya (TD phase 4 §19)
 
@@ -232,7 +213,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 3 | Owner Dashboard | ✅ | ✅ | ✅ #30–#35, #40 | ✅ |
 | 4 | Public API | ✅ | ✅ | ✅ #46–#49 | ✅ |
 | 4.5 | Hardening | ✅ | ✅ | ✅ #57–#58 | ✅ |
-| 4.6 | Email Delivery | ✅ | ✅ | ✅ #63–#64 | ⬜ |
+| 4.6 | Email Delivery | ✅ | ✅ | ✅ #63–#64 | ✅ |
 | 5 | Employee Mobile | ⬜ | ⬜ | ⬜ | ⬜ |
 
 Pekerjaan yang sedang berjalan: `gh issue list --state open`

--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -183,6 +183,59 @@ Client memanggil ulang dengan organization_id terisi
 
 ---
 
+## Pengiriman email (Phase 4.6)
+
+Verifikasi email, reset password, dan undangan tim (`internal/invitation`) semuanya lewat satu
+interface, `mailer.Mailer` — sudah ada sejak Phase 1, sengaja dibuat lebih awal karena implementasi
+kedua (provider sungguhan) sudah diketahui akan datang.
+
+| Provider | `MAIL_PROVIDER` | Dipakai untuk | Catatan |
+|---|---|---|---|
+| `LogMailer` | `log` | Test otomatis saja | Mencatat pesan ke logger, **tidak pernah dikirim**. **Ditolak boot saat `APP_ENV=production`** — proses yang tidak pernah mengirim email gagal sepenuhnya diam-diam (tidak ada crash, tidak ada error, hanya funnel registrasi yang berhenti bekerja), dan `LogMailer` juga menulis token verifikasi — kredensial sekali-pakai — ke log (Aturan #26) |
+| `SMTPMailer` | `smtp` | Development (→ Mailpit) dan produksi | Satu-satunya provider yang benar-benar mengirim |
+
+### `SMTPMailer` — kenapa bukan `smtp.SendMail`
+
+`smtp.SendMail` (stdlib) memakai `net.Dial` telanjang — **tidak ada batas waktu sama sekali**. Setiap
+pemanggil `mailer.Send` (`auth.Usecase.sendVerificationEmail`, `…sendPasswordResetEmail`,
+`invitation.Usecase.sendInvitationEmail`) memanggilnya **sinkron di jalur request**, sesudah commit
+(Aturan #32) tapi masih di dalam handler HTTP yang sama. Server SMTP yang menggantung berarti request
+HTTP ikut menggantung.
+
+`SMTPMailer` karena itu membangun percakapannya sendiri: `net.Dialer{Timeout: ...}.DialContext` untuk
+dial, lalu satu `conn.SetDeadline` yang menutup **seluruh** sisa percakapan (STARTTLS, AUTH, MAIL
+FROM, RCPT TO, DATA, QUIT) — bukan batas waktu per operasi. Server yang menjawab satu byte per detik
+tetap terputus tepat waktu, bukan lolos operasi demi operasi.
+
+### Kenapa kegagalan kirim tidak membatalkan apa pun
+
+Freeze bagian 6 (Aturan #32) sudah memutuskan ini sebelum Phase 1: kirim email **selalu setelah**
+commit, tidak pernah di dalam transaksi yang sama. Konsekuensinya, kegagalan `Send` **tidak pernah**
+membatalkan pendaftaran/undangan yang sudah tersimpan — ia dicatat sebagai error terstruktur
+(`u.logger.Error("failed to send ...", "err", err, "to", email)`) dan pemulihannya adalah tombol
+**kirim ulang**, yang sudah ada sejak Phase 1 untuk verifikasi email dan sejak awal untuk undangan.
+Password SMTP tidak pernah muncul di pesan error ini — kegagalan `AUTH` dikembalikan sebagai pesan
+polos (`"mailer: smtp authentication failed"`), bukan error asli dari `net/smtp`, yang bisa
+meng-echo detail dari respons server.
+
+### Development — Mailpit
+
+`docker-compose.yml`'s service `mailpit` menangkap setiap email `make dev` kirim, tanpa benar-benar
+mengirimkannya ke internet — dibaca lewat UI web-nya di `http://localhost:8025`. `api` **tidak**
+menunggu `mailpit` sehat sebelum boot (tidak ada `depends_on`) — SMTP hanya disentuh saat ada email
+yang benar-benar dikirim, bukan saat boot, jadi container yang lambat naik tidak pernah memblokir
+`docker compose up` menyajikan traffic.
+
+### Produksi
+
+Domain pengirim, SPF/DKIM/DMARC **tidak** disentuh oleh `SMTPMailer` — itu pekerjaan DNS di luar
+repository, tercatat sebagai item *Punya Lead Time* di `docs/STATUS.md`. Tanpanya, email yang
+terkirim secara teknis benar bisa tetap berakhir di folder spam. `SMTP_TLS=none` ditolak saat
+`APP_ENV=production` (Aturan #36) — kredensial dan token verifikasi tidak boleh melintasi jaringan
+produksi tanpa enkripsi.
+
+---
+
 ## Rate limiting
 
 | Endpoint | Batas | Implementasi |

--- a/docs/phases/04.6-email-delivery/notes.md
+++ b/docs/phases/04.6-email-delivery/notes.md
@@ -113,3 +113,109 @@ setelah setiap pengembalian.
 Issue ini membuat SMTP **bisa** dipakai dan **terbukti** mengirim ke Mailpit sungguhan di test. Tapi
 `make dev` **belum** menyalakan Mailpit, dan `docs/testing/flow/` masih menyuruh penguji menggali
 tautan dari log `api`. Itu #64, penutup phase.
+
+---
+
+## #64 — Mailpit di dev environment + perbarui alur testing, penutup Phase 4.6
+
+### Keputusan implementasi
+
+- **Tanpa `depends_on: mailpit` di service `api`** — persis seperti TD §8 memutuskan. SMTP hanya
+  disentuh saat ada email yang benar-benar dikirim, bukan saat boot; menunggu Mailpit sehat sebelum
+  `api` boleh menyajikan traffic hanya memperlambat `docker compose up` tanpa manfaat nyata. Diverifikasi
+  langsung: registrasi segera setelah `docker compose up --build -d` (tanpa jeda) tetap `201` — Mailpit
+  yang tanpa healthcheck sudah siap menerima koneksi jauh lebih cepat daripada Postgres yang punya
+  healthcheck `interval: 2s, retries: 15`.
+- **`.env.example`'s `SMTP_HOST=localhost`, bukan `mailpit`** — berbeda sengaja dari nilai
+  `docker-compose.yml`'s `SMTP_HOST=mailpit`. `.env.example` dipakai proses yang jalan **di host**
+  (`cmd/migrate` lewat `make migrate-up`, dan siapa pun yang menjalankan `cmd/api` secara native tanpa
+  Docker) — dari situ, container `mailpit` hanya terlihat lewat port yang dipetakan ke `localhost:1025`,
+  bukan lewat nama service Docker. Dua nilai berbeda untuk dua sudut pandang jaringan yang berbeda,
+  bukan inkonsistensi.
+- **`MAIL_FROM=no-reply@jualin.local`** dipakai di kedua tempat (compose dan `.env.example`) — domain
+  `.local` sengaja dipilih supaya tidak ada yang salah kira ini alamat produksi sungguhan; nilainya
+  hanya perlu valid secara sintaks untuk Mailpit, yang tidak memvalidasi domain penerima sama sekali.
+
+### `docs/testing/flow/` — pola perubahan yang konsisten
+
+Setiap tempat yang sebelumnya menyuruh `docker compose logs api | grep -o '...' | tail -1` diganti
+dua langkah yang sama: **"Buka `http://localhost:8025`, klik email terbaru — subjeknya '...'"**.
+Enam tempat di lima berkas: `README.md` (bagian *Soal email*, judulnya sendiri diganti dari
+"LogMailer" ke "Mailpit"), `00-menjalankan-aplikasi.md` (§7 bertambah langkah buka Mailpit; §8 lama —
+"cara mengambil tautan dari log" — **dihapus seluruhnya**, bukan disunting, karena masalah yang
+dipecahkannya, `\n\n` literal yang ikut tersalin dari baris log, tidak ada lagi begitu tidak ada lagi
+yang perlu disalin dari log), `01-registrasi-dan-autentikasi.md` (§1.2 verifikasi, §1.6 reset
+password), `02-tim-dan-undangan.md` (§2.1 undangan pertama, §2.3 undangan kedua ke organization
+lain), `06-checklist-akhir.md` (tiga baris checklist + satu baris baru "Mailpit bisa dibuka" di
+bagian 0).
+
+**Satu baris troubleshooting baru ditambahkan, bukan dihapus** — `00-menjalankan-aplikasi.md`'s
+tabel *Kalau ada yang tidak beres* bertambah baris untuk kasus email terkirim (`201`/`202`) tapi
+tidak muncul di Mailpit. Draf pertama baris ini mengklaim race condition boot antara `api` dan
+`mailpit` sebagai penyebab utama — **diverifikasi langsung sebelum ditulis final, dan klaimnya
+tidak terbukti** (percobaan registrasi 0.3 detik setelah `docker compose up` tetap `201`, bukan
+karena race itu tidak mungkin terjadi sama sekali, tapi karena urutan langkah di berkas ini sendiri
+— `make migrate-up` berjalan sebelum aksi manapun yang mengirim email — sudah memberi Mailpit banyak
+waktu). Baris troubleshooting final ditulis lebih berhati-hati: menyebut kemungkinan itu **jarang**
+dan mengarahkan ke `grep "failed to send"` (frasa log yang sungguhan dipakai `internal/auth` dan
+`internal/invitation` sejak Phase 1) alih-alih mengklaim penyebab pasti yang belum tentu benar.
+
+### Verifikasi manual end-to-end — dari nol, mengikuti `docs/testing/flow/00` persis
+
+```
+docker compose down -v && rm .env && cp .env.example .env
+docker compose up --build -d        → postgres, mailpit, api ketiganya naik
+make migrate-up                     → goose: successfully migrated database to version: 5
+curl /health, /health/ready         → 200, 200
+curl -o /dev/null http://localhost:8025 → 200
+
+POST /v1/auth/register              → 201
+GET Mailpit /api/v1/messages        → Subject "Verifikasi email Jualin CRM Anda",
+                                       From no-reply@jualin.local, To (email yang didaftarkan)
+                                     → token diekstrak dari body, POST /v1/auth/verify-email → 200 verified
+
+POST /v1/auth/password/forgot       → 202
+GET Mailpit /api/v1/messages        → Subject "Reset password Jualin CRM Anda" muncul sebagai pesan terbaru
+```
+
+Ketiga jenis email (verifikasi, reset password — di atas; undangan diverifikasi terpisah lewat
+langkah manual `docs/testing/flow/02` §2.1) dikonfirmasi benar-benar terkirim, bukan diasumsikan dari
+membaca kode `internal/auth`/`internal/invitation` yang tidak berubah sejak Phase 1.
+
+### `authentication.md` — bagian baru *Pengiriman email*
+
+Ditambahkan setelah bagian *Reset password* (tempat paling dekat pemakainya) — bukan menggantikan
+bagian manapun yang sudah ada. Isinya: tabel dua provider (`log`/`smtp`) dan kapan masing-masing
+ditolak boot, kenapa `SMTPMailer` tidak memakai `smtp.SendMail`, kenapa kegagalan kirim tidak pernah
+membatalkan apa pun yang sudah commit (menegaskan kembali Aturan #32, bukan mengubahnya), Mailpit di
+development, dan batas yang jelas untuk produksi (SPF/DKIM/DMARC tetap di luar cakupan, dicatat lagi
+supaya phase ini tidak terbaca sebagai "email selesai").
+
+### Verifikasi
+
+- `docker compose config` — valid.
+- Seluruh langkah `docs/testing/flow/00-menjalankan-aplikasi.md` dijalankan ulang dari nol setelah
+  setiap perubahan berkas, bukan hanya sekali di awal — memastikan urutan baru (termasuk §7 yang
+  bertambah langkah Mailpit) benar-benar bisa diikuti apa adanya oleh pembaca, bukan cuma masuk akal
+  di atas kertas.
+- Tidak ada perubahan kode Go di issue ini — `go test -race ./...` tidak dijalankan ulang karena tidak
+  ada yang bisa berubah hasilnya; `gofmt -l .` dicek tetap bersih sebagai sanity check murah.
+
+### Seluruh 12 acceptance criteria PRD Phase 4.6
+
+| # | Kriteria | Bukti |
+|---|---|---|
+| 1 | SMTP mengirim sungguhan, dibuktikan pesan sampai & terbaca | `TestSMTPMailer_MessageActuallyArrives` (#63) + verifikasi manual end-to-end (#64) |
+| 2 | `make dev` menyalakan Mailpit, email terlihat tanpa konfigurasi tambahan | Service `mailpit` di `docker-compose.yml`, dikonfirmasi lewat verifikasi manual (#64) |
+| 3 | Ganti SMTP lain tidak menyentuh kode | `SMTPConfig` seluruhnya dari env (#63); `.env.example`/`docker-compose.yml` dua nilai `SMTP_HOST` berbeda untuk dua sudut pandang jaringan tanpa menyentuh kode (#64) |
+| 4 | `MAIL_FROM` benar-benar dipakai | `TestSMTPMailer_UsesMailFromAsSender` (#63) + verifikasi manual: `From: no-reply@jualin.local` (#64) |
+| 5 | `MAIL_PROVIDER=log` + produksi → boot gagal | `TestLoad_ProductionRejectsLogMailProvider` (#63) |
+| 6 | `smtp` tanpa host sah → boot gagal | `TestLoad_SMTPRequiresHost` (#63) |
+| 7 | Server menggantung tidak menggantung request | `TestSMTPMailer_UnreachableServerFailsWithinTimeout` + adversarial proof (#63) |
+| 8 | Karakter kontrol tidak bisa menyuntik header | `TestBuildRFC5322_RejectsHeaderInjection*` + adversarial proof (#63) |
+| 9 | Password SMTP tidak pernah di log | `smtp.go`'s `c.Auth` error tidak pernah dibungkus (#63, verifikasi kode) |
+| 10 | Subject/body non-ASCII sampai utuh | `TestBuildRFC5322_NonASCIISubjectEncoded` + `TestSMTPMailer_NonASCIISubjectArrivesIntact` (#63) |
+| 11 | Test lama lulus tanpa perubahan asersi | `go test -race ./...` bersih di #63, nol asersi diubah |
+| 12 | `docs/testing/flow/` diperbarui | 5 berkas, 6 tempat, pola konsisten (#64) |
+
+**Seluruh 12 kriteria terpenuhi. Phase 4.6 — Email Delivery selesai.**

--- a/docs/testing/flow/00-menjalankan-aplikasi.md
+++ b/docs/testing/flow/00-menjalankan-aplikasi.md
@@ -24,8 +24,9 @@ baris mirip:
 api-1  | time=2026-08-29T15:23:53.922Z level=INFO msg="server starting" port=8080 env=development
 ```
 
-**Biarkan terminal ini terbuka** — inilah tempat mencari "email" (LogMailer) di langkah-langkah
-berikutnya. Buka **terminal baru** untuk langkah selanjutnya.
+Perhatikan juga bahwa `mailpit` ikut menyala di sini — server SMTP lokal yang menangkap setiap email
+yang akan dikirim aplikasi ini, tanpa benar-benar mengirimnya ke internet (lihat §7). Buka **terminal
+baru** untuk langkah selanjutnya.
 
 ## 3. Jalankan migration
 
@@ -96,44 +97,12 @@ Buka **http://localhost:3000**.
 memanggil `GET /v1/me`, dapat `401`, redirect). Ini **bukan** bug — memang begitu perilakunya untuk
 siapa pun yang belum login.
 
-Kalau langkah ini lolos, lanjut ke [`01-registrasi-dan-autentikasi.md`](./01-registrasi-dan-autentikasi.md).
+Buka juga **http://localhost:8025** — UI web Mailpit. Kosong sekarang; ini tempat setiap email
+aplikasi (verifikasi, reset password, undangan) akan muncul mulai berkas berikutnya, lengkap dengan
+tautan yang bisa langsung diklik. Tidak ada langkah tambahan untuk menyalakannya — sudah ikut naik
+bersama `make dev` di langkah 2.
 
----
-
-## 8. Cara mengambil tautan "email" dari log
-
-Dipakai berulang di berkas-berkas berikutnya (verifikasi email, reset password, undangan) — belum ada
-penyedia email sungguhan, jadi setiap tautan hanya tercatat di log `api`
-(`internal/shared/mailer.LogMailer`).
-
-Baris log-nya berbentuk seperti ini:
-
-```
-api-1  | time=... level=INFO msg="email (not sent — LogMailer)" to=owner@test.local subject="Verifikasi email Jualin CRM Anda" body="Klik tautan berikut untuk memverifikasi email Anda: http://localhost:3000/verify-email?token=WrnunLAJuz8v...\n\nTautan berlaku 24 jam."
-```
-
-⚠️ **Jangan salin manual dengan mata.** Di dalam `body=`, URL diikuti langsung oleh `\n\n` (dua
-karakter literal, bukan baris baru) — ikut tersalin dan token jadi tidak valid. Pakai perintah ini,
-yang sudah memotong tepat di ujung token:
-
-```bash
-docker compose logs api | grep -o 'http://localhost:3000/[^\\"]*' | tail -1
-```
-
-Hasilnya satu baris bersih siap tempel ke browser, misalnya:
-
-```
-http://localhost:3000/verify-email?token=WrnunLAJuz8vTf6wQtVpAx5MKRKostypB2g4SHRAXtE
-```
-
-`tail -1` mengambil **tautan terbaru**. Kalau sedang menguji beberapa email sekaligus (mis. beberapa
-undangan berturut-turut), saring dulu per jenis:
-
-```bash
-docker compose logs api | grep -o 'http://localhost:3000/verify-email[^\\"]*'      | tail -1
-docker compose logs api | grep -o 'http://localhost:3000/reset-password[^\\"]*'    | tail -1
-docker compose logs api | grep -o 'http://localhost:3000/invitations/accept[^\\"]*' | tail -1
-```
+Kalau kedua langkah ini lolos, lanjut ke [`01-registrasi-dan-autentikasi.md`](./01-registrasi-dan-autentikasi.md).
 
 ---
 
@@ -146,6 +115,7 @@ docker compose logs api | grep -o 'http://localhost:3000/invitations/accept[^\\"
 | `make migrate-up` → `DATABASE_URL required` | Lupa `source .env` di terminal yang sama sebelum `make migrate-up` — env var ini **tidak** otomatis terbaca dari file `.env`. |
 | Dashboard menampilkan error jaringan terus-menerus | `crm_dashboard/.env.local` belum ada, atau `next dev` dinyalakan **sebelum** file itu dibuat — restart `npm run dev` setelah membuat/mengubah `.env.local` (Next.js hanya membaca env saat start). |
 | `curl http://localhost:8080/health` → connection refused | `api` container belum selesai boot, atau gagal boot — cek log di terminal langkah 2 untuk pesan `failed to connect to database` atau error validasi config. |
+| Registrasi/undangan/reset berhasil (`201`/`202`) tapi email tidak muncul di `http://localhost:8025` | `docker compose logs api \| grep "failed to send"` — kalau ada baris `mailer: dial mailpit:1025: ...`, container `mailpit` belum sehat saat itu (jarang terjadi mengikuti urutan langkah di berkas ini, karena `make migrate-up` sendiri sudah memberi Mailpit cukup waktu naik). Kirim ulang aksinya (tombol kirim ulang verifikasi/undangan yang sudah ada sejak Phase 1). |
 
 ## Mematikan semuanya
 

--- a/docs/testing/flow/01-registrasi-dan-autentikasi.md
+++ b/docs/testing/flow/01-registrasi-dan-autentikasi.md
@@ -3,9 +3,10 @@
 Prasyarat: [`00-menjalankan-aplikasi.md`](./00-menjalankan-aplikasi.md) selesai — backend dan
 dashboard menyala, `http://localhost:3000` mengarahkan ke `/login`.
 
-Menguji: registrasi organization baru, verifikasi email (lewat log — belum ada email sungguhan),
-login, logout, lupa password, reset password. Ini membangun **akun Owner** yang dipakai di seluruh
-berkas berikutnya — jangan hapus datanya sampai seluruh urutan panduan ini selesai.
+Menguji: registrasi organization baru, verifikasi email (lewat Mailpit — email sungguhan terkirim,
+lihat [`00-menjalankan-aplikasi.md`](./00-menjalankan-aplikasi.md) §7), login, logout, lupa password,
+reset password. Ini membangun **akun Owner** yang dipakai di seluruh berkas berikutnya — jangan hapus
+datanya sampai seluruh urutan panduan ini selesai.
 
 ## 1.1 Registrasi organization baru
 
@@ -22,27 +23,19 @@ berkas berikutnya — jangan hapus datanya sampai seluruh urutan panduan ini sel
 owner@test.local..."* — **bukan** langsung masuk ke dashboard. Ini sengaja (keputusan B3: verifikasi
 email menggerbangi login).
 
-## 1.2 Cari tautan verifikasi di log
+## 1.2 Buka email verifikasi di Mailpit
 
-Belum ada email sungguhan — tautannya ada di log `api`. Dari akar repo:
+1. Buka **http://localhost:8025**.
+2. Klik email terbaru — subjeknya **"Verifikasi email Jualin CRM Anda"**, ditujukan ke
+   `owner@test.local`.
 
-```bash
-docker compose logs api | grep -o 'http://localhost:3000/verify-email[^\\"]*' | tail -1
-```
-
-**Hasil yang diharapkan:** satu baris bersih siap tempel, mis.
-
-```
-http://localhost:3000/verify-email?token=WrnunLAJuz8vTf6wQtVpAx5MKRKostypB2g4SHRAXtE
-```
-
-> ⚠️ Jangan menyalin URL-nya manual dari baris log mentah — di sana ia diikuti `\n\n` literal yang
-> ikut tersalin dan membuat token tidak valid. Penjelasan lengkap:
-> [`00-menjalankan-aplikasi.md`](./00-menjalankan-aplikasi.md) §8.
+**Hasil yang diharapkan:** isi email berbentuk kalimat lengkap Bahasa Indonesia dengan satu tautan
+`http://localhost:3000/verify-email?token=...` — utuh, tidak terpotong.
 
 ## 1.3 Verifikasi email
 
-1. Tempel URL yang disalin ke address bar browser, buka.
+1. Klik tautannya (kalau tampil sebagai tautan yang bisa diklik di tampilan Mailpit), atau sorot dan
+   salin teksnya lalu tempel ke address bar browser.
 
 **Hasil yang diharapkan:** halaman menampilkan status berhasil terverifikasi, dengan tautan/tombol
 menuju `/login`.
@@ -89,12 +82,9 @@ diarahkan balik ke `/login`, **tidak** menampilkan Beranda sesaat (tidak ada ses
 email yang **tidak pernah didaftarkan** (mis. `tidak-ada@test.local`) — pesannya harus identik,
 supaya orang luar tidak bisa menebak email mana yang punya akun.
 
-3. Ambil tautannya dari log (pola sama seperti §1.2):
-
-```bash
-docker compose logs api | grep -o 'http://localhost:3000/reset-password[^\\"]*' | tail -1
-```
-4. Buka tautan tersebut. Isi **Password baru** + **Konfirmasi password**, submit.
+3. Buka **http://localhost:8025**, klik email terbaru — subjeknya **"Reset password Jualin CRM
+   Anda"** (pola sama seperti §1.2).
+4. Buka tautannya. Isi **Password baru** + **Konfirmasi password**, submit.
 
 **Hasil yang diharapkan:** berhasil, diarahkan ke `/login`.
 

--- a/docs/testing/flow/02-tim-dan-undangan.md
+++ b/docs/testing/flow/02-tim-dan-undangan.md
@@ -16,12 +16,9 @@ ganti role, nonaktifkan anggota (tiga cabang), notifikasi.
 dropdown — harus ada **Admin, Manager, Employee** (bukan Owner — Owner tidak bisa diundang langsung,
 hanya dipromosikan belakangan).
 
-4. Ambil tautan undangan dari log (pola sama seperti
-   [`01-registrasi-dan-autentikasi.md`](./01-registrasi-dan-autentikasi.md) §1.2):
-
-```bash
-docker compose logs api | grep -o 'http://localhost:3000/invitations/accept[^\\"]*' | tail -1
-```
+4. Buka **http://localhost:8025**, klik email terbaru — subjeknya **"Anda diundang bergabung di
+   Jualin CRM"** (pola sama seperti [`01-registrasi-dan-autentikasi.md`](./01-registrasi-dan-autentikasi.md)
+   §1.2). Tautannya berbentuk `http://localhost:3000/invitations/accept?token=...`.
 
 ## 2.2 Terima undangan — cabang "user baru"
 
@@ -64,11 +61,11 @@ daftarkan dulu akun mandiri di organization **lain**, baru undang emailnya ke `T
 
 1. **Logout.** Daftar organization **baru** (ulangi [`01-registrasi-dan-autentikasi.md`](./01-registrasi-dan-autentikasi.md)
    §1.1–§1.3): **Nama organization** `Toko Lain`, **Nama lengkap** `Rina Sudah Terdaftar`, **Email**
-   `manager1@test.local`, password bebas. Verifikasi emailnya lewat tautan di log seperti biasa.
+   `manager1@test.local`, password bebas. Verifikasi emailnya lewat Mailpit seperti biasa.
 2. **Logout** dari `manager1@test.local`, login kembali sebagai `owner@test.local`.
 3. Di `/team` milik `Toko Testing`, klik **+ Undang anggota** dengan **Email**: `manager1@test.local`,
    **Role**: `Manager`.
-4. Cari tautan undangannya di log (§2.1 langkah 4), lalu **logout** dan login sebagai
+4. Buka tautan undangannya dari Mailpit (§2.1 langkah 4), lalu **logout** dan login sebagai
    `manager1@test.local` (pakai password dari langkah 1).
 
 **Hasil yang diharapkan saat login:** karena `manager1@test.local` sekarang anggota **dua**

--- a/docs/testing/flow/06-checklist-akhir.md
+++ b/docs/testing/flow/06-checklist-akhir.md
@@ -7,7 +7,7 @@ dari membaca kode. Kalau ada yang gagal, jangan dicentang; catat sebagai issue b
 ## Kalimat inti MVP — dari nol sampai selesai
 
 - [ ] Owner mendaftar
-- [ ] Verifikasi email (lewat tautan di log — LogMailer)
+- [ ] Verifikasi email (email sungguhan terkirim ke Mailpit)
 - [ ] Login
 - [ ] Undang employee
 - [ ] Employee menerima undangan & login
@@ -22,23 +22,24 @@ dari membaca kode. Kalau ada yang gagal, jangan dicentang; catat sebagai issue b
 
 ## 0 — Menjalankan aplikasi
 
-- [ ] `docker compose` (postgres + api) menyala tanpa error
+- [ ] `docker compose` (postgres + mailpit + api) menyala tanpa error
 - [ ] Migration berhasil sampai versi terbaru
 - [ ] `GET /health` dan `/health/ready` keduanya `200`
 - [ ] Dashboard (`npm run dev`) menyala, `http://localhost:3000` bisa dibuka
 - [ ] Belum login → otomatis diarahkan ke `/login`
+- [ ] `http://localhost:8025` (Mailpit) bisa dibuka
 
 ## 1 — Registrasi & Autentikasi
 
 - [ ] Registrasi organization baru berhasil, **tidak** langsung login
-- [ ] Tautan verifikasi ditemukan di log, berhasil memverifikasi
+- [ ] Email verifikasi muncul di Mailpit, tautannya berhasil memverifikasi
 - [ ] Membuka tautan verifikasi **kedua kalinya** tidak error/500
 - [ ] Login berhasil setelah verifikasi
 - [ ] Password salah → pesan generik, bukan detail teknis
 - [ ] Login berulang gagal → mulai diblokir (backoff)
 - [ ] Logout mengembalikan ke `/login`, sesi benar-benar hilang
 - [ ] Lupa password: pesan sama persis untuk email terdaftar maupun tidak
-- [ ] Reset password via tautan di log berhasil
+- [ ] Reset password via tautan di Mailpit berhasil
 - [ ] Password lama tidak lagi berlaku setelah reset
 
 ## 2 — Tim & Undangan

--- a/docs/testing/flow/README.md
+++ b/docs/testing/flow/README.md
@@ -16,7 +16,7 @@ Mengikuti kalimat inti MVP (`architecture/freeze.md` bagian 3, `product/decision
 
 Bagian yang **bisa** diuji manual sekarang: semuanya kecuali "follow-up dari HP" — **Phase 5 (mobile)
 belum dibangun**, jadi employee follow-up di panduan ini dilakukan lewat dashboard, bukan HP.
-Phase 0–4.5 sudah selesai (`docs/STATUS.md`); panduan ini menguji hasilnya.
+Phase 0–4.6 sudah selesai (`docs/STATUS.md`); panduan ini menguji hasilnya.
 
 ## Urutan berkas
 
@@ -40,23 +40,16 @@ lead yang sama, dst).
 - Terminal yang bisa dibuka beberapa tab/jendela sekaligus (untuk mengawasi log sambil mengklik di browser)
 - Browser apa saja
 
-## Soal email — LogMailer
+## Soal email — Mailpit
 
-Belum ada penyedia email sungguhan (`docs/STATUS.md`'s *Punya Lead Time* — domain & email provider
-belum diurus). Setiap "email" (verifikasi, reset password, undangan) hanya **dicatat ke log**, tidak
-benar-benar dikirim (`internal/shared/mailer.LogMailer`). Sepanjang panduan ini, tautan yang biasanya
-ada di badan email harus **dicari di log `api`**, bukan di kotak masuk. Caranya dijelaskan di
-`00-menjalankan-aplikasi.md` dan dipakai berulang di berkas-berkas berikutnya.
-
-Baris log-nya selalu berbentuk:
-
-```
-api-1  | time=... level=INFO msg="email (not sent — LogMailer)" to=... subject="..." body="Klik tautan berikut ...: http://localhost:3000/...?token=...\n\nTautan berlaku ..."
-```
-
-Cara mengambilnya tanpa salah salin (URL diikuti `\n\n` literal di dalam `body=`) ada di
-[`00-menjalankan-aplikasi.md`](./00-menjalankan-aplikasi.md) §8 — perintahnya satu baris, dipakai
-berulang di sepanjang panduan ini.
+Belum ada penyedia email produksi (`docs/STATUS.md`'s *Punya Lead Time* — domain & SPF/DKIM/DMARC
+belum diurus), tapi sejak Phase 4.6 **email sungguhan benar-benar terkirim** saat mengembangkan —
+lewat SMTP ke [Mailpit](https://mailpit.axllent.org/), server SMTP lokal yang ditangkap
+`docker-compose.yml`, bukan dikirim ke internet. Setiap email (verifikasi, reset password, undangan)
+muncul di **UI web Mailpit** (`http://localhost:8025`), lengkap dengan tautan yang bisa langsung
+diklik — tidak perlu lagi menggali log server. Caranya dijelaskan di
+[`00-menjalankan-aplikasi.md`](./00-menjalankan-aplikasi.md) §7 dan dipakai berulang di
+berkas-berkas berikutnya.
 
 ## Kalau sesuatu gagal
 


### PR DESCRIPTION
## Ringkasan

`docker-compose.yml` bertambah service `mailpit` — SMTP + UI web lokal yang menangkap setiap email `make dev` kirim tanpa benar-benar mengirimkannya ke internet, dibaca di `http://localhost:8025`. **Tanpa `depends_on`** di `api` — SMTP hanya disentuh saat email benar-benar dikirim, bukan saat boot.

**Diverifikasi langsung, bukan diasumsikan**: registrasi 0,3 detik setelah `docker compose up` tetap `201` — Mailpit (tanpa healthcheck) sudah siap jauh lebih cepat daripada Postgres (healthcheck `interval: 2s, retries: 15`).

## `.env.example`

`SMTP_HOST=localhost`, **sengaja beda** dari `docker-compose.yml`'s `SMTP_HOST=mailpit` — dua sudut pandang jaringan berbeda. `.env.example` dipakai proses yang jalan di **host** (`cmd/migrate` lewat `make migrate-up`), yang melihat container `mailpit` lewat port yang dipetakan ke `localhost`, bukan lewat nama service Docker.

## `docs/testing/flow/` — 5 berkas diperbarui

Setiap tempat yang sebelumnya `docker compose logs api | grep -o '...' | tail -1` diganti: **"Buka `http://localhost:8025`, klik email terbaru — subjeknya '...'"**. `00-menjalankan-aplikasi.md`'s §8 lama (cara menyalin tautan dari log tanpa ikut membawa `\n\n` literal) **dihapus seluruhnya** — masalahnya sudah tidak ada begitu tidak ada lagi yang perlu disalin dari log.

**Satu baris troubleshooting awalnya salah, dan saya perbaiki sebelum commit**: draf pertama mengklaim race condition boot `api`/`mailpit` sebagai penyebab utama. Saya cek dulu sebelum menulisnya final — klaimnya tidak terbukti (urutan langkah panduan sendiri, `make migrate-up` sebelum aksi apa pun yang kirim email, sudah memberi Mailpit cukup waktu). Baris final menyebut kemungkinan itu **jarang**, bukan penyebab pasti.

## `authentication.md`

Bagian baru **Pengiriman email** — dua provider dan kapan masing-masing ditolak boot, kenapa `SMTPMailer` bukan `smtp.SendMail`, kenapa kegagalan kirim tidak membatalkan apa pun yang sudah commit (Aturan #32 ditegaskan, bukan diubah), Mailpit di dev, dan batas eksplisit untuk produksi — SPF/DKIM/DMARC tetap di luar cakupan supaya phase ini tidak terbaca sebagai "email selesai".

## Verifikasi manual end-to-end

Mengikuti persis langkah `docs/testing/flow/00` dari nol:

```
docker compose down -v && cp .env.example .env
docker compose up --build -d    → postgres, mailpit, api ketiganya naik
make migrate-up                 → goose: successfully migrated database to version: 5
POST /v1/auth/register          → 201
GET Mailpit /api/v1/messages    → Subject "Verifikasi email Jualin CRM Anda",
                                   From no-reply@jualin.local
                                 → token diekstrak dari body → verify-email → 200 verified
POST /v1/auth/password/forgot   → 202 → email "Reset password Jualin CRM Anda" muncul di Mailpit
```

Tidak ada perubahan kode Go di issue ini.

## Penutup Phase 4.6

Seluruh 12 acceptance criteria PRD Phase 4.6 dicek satu per satu terhadap bukti nyata di `docs/phases/04.6-email-delivery/notes.md`'s `## #64`. `docs/STATUS.md` diperbarui: Phase 4.6 selesai, Progress-per-Phase → ✅, *Berikutnya* ditulis ulang — kedua hambatan teknis demo ke calon pengguna (panduan testing + email sungguhan) sekarang tertutup.

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)