### PR TITLE
docs: open Phase 5 — Employee Mobile (PRD, TD, issues, design brief)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 29 Agustus 2026 — Issue #64 selesai. **Phase 4.6 — Email Delivery selesai.**
-**Phase sekarang:** Phase 4.6 selesai — phase berikutnya (5) belum dibuka, lihat *Berikutnya*.
+**Last updated:** 29 Agustus 2026 — **Phase 5 — Employee Mobile dibuka** (#68–#73), Android dulu, iOS ditunda.
+**Phase sekarang:** Phase 5 — Employee Mobile. Phase 4.6 selesai; ini phase MVP terakhir sebelum GATE.
 
 ---
 
@@ -60,29 +60,34 @@ _(kosong)_
 
 ## Berikutnya
 
-**Phase 4.6 — Email Delivery selesai** (#63, #64) — diminta pemilik produk sebagai prasyarat demo ke
-calon pengguna. Ringkasan lengkap di baris Selesai #63/#64 dan
-`docs/phases/04.6-email-delivery/notes.md`; intinya: `mailer.Mailer` (interface sejak Phase 1)
-akhirnya punya implementasi SMTP sungguhan, `MAIL_FROM` yang sejak Phase 1 tidak pernah dibaca
-siapa pun akhirnya dipakai, dan `MAIL_PROVIDER=log`/`SMTP_TLS=none` keduanya ditolak boot saat
-`APP_ENV=production`. `docs/testing/flow/` diperbarui — tidak ada lagi langkah "gali log", email
-verifikasi/reset/undangan sekarang muncul di Mailpit (`http://localhost:8025`) saat `make dev`.
+### Phase 5 — Employee Mobile (#68–#73) — sedang dibuka
 
-Satu hal menunggu keputusan manusia — bukan sesuatu yang bisa diputuskan sepihak dalam sesi agent,
-pola yang sama seperti saat Phase 3 tutup:
+**Phase MVP terakhir.** Setelah ini GATE freeze terbuka: cari 3–5 pengguna nyata sebelum Phase 6.
+Dokumen: `docs/phases/05-employee-mobile/`.
 
-1. **Pilih phase berikutnya**: Phase 5 (Employee Mobile) adalah satu-satunya phase MVP yang tersisa dan
-   ada di jalur utama freeze (`Phase 3 → Phase 5 → GATE`) — tapi **cek dulu status Apple Developer
-   Program & Firebase** di bagian *Punya Lead Time* di bawah. Kalau keduanya masih belum diurus, Phase 5
-   akan berhenti tepat di bagian build iOS dan push notification, persis alasan Phase 4 dikerjakan lebih
-   dulu sebelumnya. Bila keduanya sudah beres, Phase 5 bisa langsung dibuka (PRD + TD, pola yang sama
-   seperti Phase 2→3→4).
+**Android dulu, iOS ditunda** (keputusan M1) — Apple Developer Program berbayar dan belum ada. Ini
+**tidak** mengorbankan satu pun kriteria selesai phase: freeze menulis *"siklus penuh berjalan di HP
+nyata"* tanpa menyebut platform, dan push Android tidak melibatkan Apple sama sekali.
+
+Riset saat membuka phase menemukan **backend hampir seluruhnya sudah siap** — jalur auth mobile,
+visibilitas Employee, permission, activity `call_logged`/`whatsapp_opened`, `version`, tabel
+`notifications` semuanya ada sejak Phase 1–2. `authz.go` bahkan sudah menuliskan komentarnya:
+*"Employee gets mobile in Phase 5"*. **`device_tokens` + FCM adalah satu-satunya pekerjaan backend**;
+sisanya Flutter, dan `crm_employee/` masih berisi satu berkas `README.md`.
+
+**Kontradiksi freeze dilaporkan, bukan diputuskan diam-diam** (Aturan #30): bagian 4 menulis cakupan
+*"cache **baca** offline"* dan kriteria selesai *"daftar lead tetap **terbaca**"*, sementara bagian
+2.3 menyebut *"antrian aksi offline di Phase 5"*. Interpretasi yang diambil — **cache baca saja**,
+antrian tulis di luar cakupan — beserta alasannya ada di `prd.md`. Ini mengubah ukuran phase secara
+mendasar, jadi **katakan sebelum implementasi dimulai** bila maksud Anda berbeda.
+
+Yang dibutuhkan dari pemilik produk: **project Firebase** (gratis, hitungan menit) — hanya memblokir
+issue penutup #73, bukan phase-nya. Langkah persisnya di `td.md` §14.
 
 **Demo ke calon pengguna** (freeze bagian 4, tujuan Phase 3) — kedua hambatan teknis yang tercatat di
 sini sejak Phase 3 tutup sekarang **sudah ditutup**: panduan langkah-demi-langkah ada
 (`docs/testing/flow/`), dan email sungguhan terkirim (Phase 4.6). Tidak ada lagi penghalang teknis
-yang tercatat di dokumen ini — sisanya jadwal dan keputusan pemilik produk, di luar yang bisa dicatat
-sebagai item kerja di sini.
+yang tercatat di dokumen ini — sisanya jadwal dan keputusan pemilik produk.
 
 ### Kewajiban yang diwarisi phase-phase berikutnya (TD phase 4 §19)
 
@@ -169,8 +174,8 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | Hal | Kode dipakai di | Mulai diurus | Kenapa |
 |---|---|---|---|
 | **Domain + email sender** (SPF/DKIM/DMARC) | Phase 1 | **Sekarang** | Verifikasi email menggerbangi login (keputusan B3), jadi ia jalur kritis Phase 1. Propagasi DNS dan pemanasan reputasi pengirim butuh waktu — dan email verifikasi yang masuk spam akan membunuh funnel registrasi **tanpa menghasilkan satu pun error**. |
-| **Apple Developer Program** | Phase 5 | Sebelum Phase 3 | Enrollment bisa berhari-hari sampai berminggu (verifikasi identitas / D-U-N-S untuk organisasi). Tanpa ini, build iOS dan APNs tidak bisa jalan sama sekali. |
-| **Firebase project (FCM)** | Phase 5 | Bersama Apple Developer | Pembuatannya cepat, tapi konfigurasi sisi iOS bergantung pada APNs key dari akun Apple di atas. |
+| **Apple Developer Program** | Phase 5 — **iOS saja** | Saat iOS diaktifkan | Enrollment bisa berhari-hari sampai berminggu (verifikasi identitas / D-U-N-S untuk organisasi). **Tidak lagi memblokir Phase 5** sejak keputusan M1 (Android dulu) — yang terhalang hanya build iOS & push iOS, bukan satu pun kriteria selesai phase. |
+| **Firebase project (FCM)** | Phase 5 | **Sebelum issue #73** | Gratis, hitungan menit. Push **Android** tidak melibatkan Apple sama sekali. Langkah persisnya di `docs/phases/05-employee-mobile/td.md` §14. Hanya memblokir satu issue (#73), bukan phase-nya — `PUSH_PROVIDER=none` membuat sisanya bisa dikerjakan tanpa Firebase. |
 
 **Tidak ada yang memblokir Phase 0.** Dicatat di sini justru supaya tidak tersadar terlambat.
 
@@ -179,8 +184,8 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 - [ ] Domain final dipilih & dibeli
 - [ ] Email provider dipilih (Resend / Postmark / SES)
 - [ ] SPF, DKIM, DMARC terpasang & terverifikasi
-- [ ] Apple Developer Program terdaftar
-- [ ] Firebase project dibuat
+- [ ] Firebase project dibuat ← **dibutuhkan #73**, langkahnya di TD Phase 5 §14
+- [ ] Apple Developer Program terdaftar ← hanya untuk iOS, ditunda (keputusan M1)
 
 > Domain juga menentukan konfigurasi cookie (`Secure`, `SameSite`, scope), CORS, dan alamat pengirim email — semuanya disentuh di Phase 1.
 
@@ -214,6 +219,6 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 4 | Public API | ✅ | ✅ | ✅ #46–#49 | ✅ |
 | 4.5 | Hardening | ✅ | ✅ | ✅ #57–#58 | ✅ |
 | 4.6 | Email Delivery | ✅ | ✅ | ✅ #63–#64 | ✅ |
-| 5 | Employee Mobile | ⬜ | ⬜ | ⬜ | ⬜ |
+| 5 | Employee Mobile | ✅ | ✅ | ✅ #68–#73 | ⬜ |
 
 Pekerjaan yang sedang berjalan: `gh issue list --state open`

--- a/docs/phases/05-employee-mobile/design-brief.md
+++ b/docs/phases/05-employee-mobile/design-brief.md
@@ -1,0 +1,261 @@
+# Design Brief — Jualin CRM Employee Mobile
+
+> **Dokumen ini untuk desainer, bukan untuk implementor.**
+> Implementasi mengikuti [`td.md`](./td.md); apa & kenapa ada di [`prd.md`](./prd.md).
+
+---
+
+## 1. Yang diminta
+
+Desain aplikasi **Android** untuk employee lapangan (sales) sebuah CRM. Aplikasi Flutter,
+**Android saja** untuk sekarang — iOS ditunda, tapi desain sebaiknya tidak memakai pola yang mustahil
+dipindahkan ke iOS kelak.
+
+Bukan mendesain ulang produk. Backend, aturan bisnis, istilah, dan alur sudah dikunci dan **sudah
+berjalan** — dashboard web-nya sudah selesai dan dipakai. Yang diminta: bagaimana pekerjaan yang sama
+terlihat dan terasa di HP, di tangan orang yang sedang berdiri di luar.
+
+---
+
+## 2. Produk dalam satu paragraf
+
+Jualin CRM membantu UKM Indonesia mengelola calon pelanggan (**Lead**) dari masuk sampai menang.
+Owner menerima lead, menugaskannya ke sales, lalu memantau. **Aplikasi ini milik sales-nya** — bukan
+versi kecil dashboard Owner. Sales hanya melihat lead yang ditugaskan kepadanya, menelepon atau
+WhatsApp calon pelanggan, mengubah status, dan menulis catatan. Ia tidak membuat lead, tidak
+mengelola tim, tidak melihat laporan.
+
+---
+
+## 3. Pengguna & konteks pemakaian
+
+**Ini bagian paling menentukan di brief ini.** Konteksnya berbeda jauh dari dashboard.
+
+| Aspek | Kenyataan |
+|---|---|
+| Siapa | Sales lapangan UKM Indonesia. Bukan pekerja kantoran, bukan pengguna teknis |
+| Perangkat | Android kelas menengah-bawah. Layar 6"-an, bukan flagship |
+| Posisi tubuh | **Berdiri, satu tangan**, sering sambil berjalan. Ibu jari satu-satunya alat input |
+| Cahaya | **Luar ruangan, matahari Indonesia.** Kontras rendah tidak terbaca sama sekali |
+| Sinyal | **Buruk atau hilang** — basement mall, ruko pinggiran, area industri. Ini kondisi normal |
+| Durasi sesi | 10–40 detik. Dibuka **di antara percakapan**, bukan untuk ditekuni |
+| Momen pemakaian | Tepat sebelum menelepon, dan tepat sesudahnya |
+
+Konsekuensi yang mengikat desain:
+
+1. **Target sentuh besar dan di jangkauan ibu jari.** Aksi utama di paruh bawah layar, bukan pojok
+   atas.
+2. **Kontras tinggi.** Teks abu-abu tipis yang cantik di monitor tidak terbaca di parkiran jam 1 siang.
+3. **Keadaan offline bukan kasus tepi** — ia harus punya desain, bukan pesan error generik.
+4. **Sedikit langkah.** "Buka aplikasi → lihat lead → tekan telepon" harus terasa instan.
+
+---
+
+## 4. Yang sudah dikunci — jangan didesain ulang
+
+### 4.1 Identitas visual dari dashboard
+
+Dashboard sudah punya token warna yang **sudah diperbaiki kontrasnya** (semua ≥4.5:1). Mobile
+sebaiknya terasa satu keluarga, tapi **tidak** wajib identik — konteks matahari boleh menuntut kontras
+lebih tinggi.
+
+| Token | Nilai | Guna |
+|---|---|---|
+| `--primary` | `oklch(0.56 0.19 41)` | Latar tombol dengan teks putih (4.83:1) |
+| `--accent-strong` | `oklch(0.48 0.17 41)` | Warna **di atas** putih — teks/ikon beraksen (7.04:1) |
+| `--foreground` | `oklch(0.145 0 0)` | Teks utama |
+| `--muted-foreground` | `oklch(0.556 0 0)` | Teks sekunder |
+| `--border` | `oklch(0.922 0 0)` | Garis pemisah |
+
+> **Jangan pakai `--primary` untuk teks di atas putih** — di 0.56 ia gagal AA. Itu sebabnya ada dua
+> token aksen terpisah.
+
+**Setiap warna teks yang Anda usulkan harus ≥4.5:1 terhadap latarnya.** Di Phase 3, lima dari delapan
+badge status hasil desain gagal ambang ini dan harus diperbaiki implementor — pekerjaan dua kali yang
+bisa dihindari.
+
+### 4.2 Yang tidak boleh diubah
+
+- **Aturan transisi status** (§9.1) — ditegakkan backend, UI hanya boleh menawarkan yang sah
+- **Istilah** (§6) — sudah dikunci glosarium produk
+- **Bahasa Indonesia** untuk seluruh teks antarmuka
+- **Employee hanya melihat lead miliknya** — ini aturan keamanan backend, bukan pilihan tampilan
+
+---
+
+## 5. Prinsip desain untuk produk ini
+
+1. **Kecepatan mengalahkan kelengkapan.** Layar yang memuat 3 informasi penting dalam 1 detik lebih
+   berguna daripada 10 informasi dalam 4 detik.
+2. **Satu layar, satu tujuan.** Sales tidak sedang menjelajah; ia sedang mengerjakan satu hal.
+3. **Aksi utama tidak boleh disembunyikan.** Telepon dan WhatsApp adalah alasan aplikasi ini dibuka.
+4. **Keadaan basi harus jujur.** Data dari cache offline harus terlihat sebagai data cache, bukan
+   dipoles seolah baru.
+5. **Jangan meniru dashboard.** Tabel, filter bertumpuk, dan kolom padat tidak berpindah ke layar 6".
+
+---
+
+## 6. Kosakata wajib
+
+Bahasa Indonesia, kecuali dua istilah yang memang dipertahankan:
+
+| Backend | Tampil sebagai |
+|---|---|
+| Lead | **Lead** (istilah produk, tidak diterjemahkan) |
+| Customer | **Customer** (idem) |
+| Task | **Tugas** |
+| Activity | **Aktivitas** |
+| Note | **Catatan** |
+| Assigned to me | **Lead Saya** |
+
+---
+
+## 7. Inventaris layar
+
+Enam layar. Tidak lebih — setiap tambahan harus punya alasan yang menang melawan §5 prinsip 1.
+
+### 7.1 Login
+
+Email + password. Sekali saja; sesudahnya **biometric**.
+
+Butuh desain: keadaan gagal (kredensial salah), keadaan "terlalu banyak percobaan" (backend
+memberlakukan backoff), dan **layar biometric** saat aplikasi dibuka kembali — termasuk jalan keluar
+"Masuk dengan password" bila biometric gagal atau tidak terdaftar.
+
+### 7.2 Lead Saya — **layar terpenting**
+
+Daftar lead yang ditugaskan ke sales ini. Layar yang paling sering dibuka; alokasikan usaha sesuai.
+
+Tiap baris minimal perlu: nama, status, dan **kapan terakhir disentuh** (lead yang didiamkan dua jam
+sudah kalah). Nomor lead (`#1024`) dipakai saat bicara dengan Owner.
+
+Butuh desain: daftar normal · **daftar dari cache offline** (§10) · kosong · sedang memuat · filter
+status.
+
+### 7.3 Detail Lead — **layar terpenting kedua**
+
+Semua aksi tulis ada di sini: **telepon**, **WhatsApp**, **ubah status**, **tambah catatan**, plus
+timeline aktivitas.
+
+Telepon dan WhatsApp adalah alasan layar ini dibuka — keduanya harus terjangkau ibu jari tanpa
+menggulir. Timeline penting tapi sekunder.
+
+Butuh desain: susunan aksi utama · pemilih status (hanya transisi sah) · form catatan · timeline ·
+**dialog konflik** (§8.2).
+
+### 7.4 Tugas Saya
+
+Daftar task, dengan jatuh tempo. Menandai selesai **satu arah** — tidak bisa dibuka kembali.
+
+### 7.5 Notifikasi
+
+Daftar notifikasi (lead baru ditugaskan). Menekannya membuka lead terkait.
+
+### 7.6 Kerangka aplikasi
+
+Navigasi antar Lead Saya / Tugas / Notifikasi, header, dan tempat tombol keluar. **Ini dipakai
+seluruh layar** — mohon didesain eksplisit, jangan diasumsikan.
+
+---
+
+## 8. Pola yang tidak boleh disederhanakan
+
+### 8.1 Offline
+
+Bukan pesan error. Sales **memang** akan membuka aplikasi tanpa sinyal, dan daftar leadnya **harus
+tetap terbaca**. Butuh: penanda bahwa data berasal dari cache + kapan terakhir diperbarui, dan
+perlakuan berbeda untuk aksi tulis (yang memang tidak bisa dilakukan offline).
+
+### 8.2 Data sudah diubah orang lain
+
+Sales mengubah status; ternyata Owner sudah memindahkan lead itu ke orang lain. Sistem **menolak** dan
+mengembalikan keadaan terkini. **Tidak pernah menimpa diam-diam.**
+
+Butuh desain dialog yang jujur tanpa menyalahkan pengguna, dengan jalan keluar "muat ulang".
+
+### 8.3 Aksi eksternal yang mungkin dibatalkan
+
+Menekan "Telepon" membuka dialer OS. Sales bisa saja membatalkannya. Aktivitas hanya dicatat bila
+aplikasi eksternal **benar-benar** terbuka — desain tidak boleh menjanjikan "tercatat" sebelum itu
+pasti.
+
+### 8.4 Kehilangan akses mendadak
+
+Employee yang dinonaktifkan Owner akan kehilangan akses **saat token berikutnya disegarkan** — bisa
+di tengah pemakaian. Butuh desain keadaan "sesi berakhir" yang tidak terlihat seperti kerusakan
+aplikasi.
+
+---
+
+## 9. Nilai yang butuh perlakuan visual
+
+### 9.1 Status lead (8) — dan transisi yang sah
+
+`new` Baru · `contacted` Dihubungi · `qualified` Memenuhi Syarat · `proposal` Penawaran ·
+`won` Menang · `lost` Kalah · `unqualified` Tidak Memenuhi Syarat · `spam` Spam
+
+Jalur utama bergerak **satu langkah** maju/mundur:
+
+```
+Baru ⇄ Dihubungi ⇄ Memenuhi Syarat ⇄ Penawaran ⇄ Menang
+```
+
+`Kalah`, `Tidak Memenuhi Syarat`, `Spam` bisa dicapai dari status mana pun. `Kalah` **wajib** disertai
+alasan (§9.2). `Tidak Memenuhi Syarat` dan `Spam` bersifat final.
+
+Delapan status ini butuh perlakuan visual yang bisa dibedakan **sekilas, di bawah matahari**.
+
+### 9.2 Alasan kalah (6)
+
+Harga · Kompetitor · Waktu Tidak Tepat · Tidak Merespons · Tidak Tertarik · Lainnya
+
+Muncul sebagai langkah wajib saat memilih `Kalah`.
+
+### 9.3 Tipe aktivitas di timeline (10)
+
+Dibuat · Ditugaskan · Dilepas · Status berubah · Dikonversi · Catatan · **Telepon** · **WhatsApp** ·
+Tugas dibuat · Tugas selesai
+
+Yang ditebalkan berasal dari aplikasi ini sendiri — layak dibedakan dari yang datang dari dashboard.
+
+---
+
+## 10. Keadaan yang wajib punya desain
+
+Bukan hanya keadaan "semuanya baik":
+
+| Keadaan | Di mana |
+|---|---|
+| Sedang memuat | Semua daftar |
+| Kosong (belum ada lead ditugaskan) | Lead Saya, Tugas |
+| **Dari cache, tanpa sinyal** | Lead Saya, Detail Lead |
+| Aksi tulis gagal karena offline | Detail Lead |
+| Konflik data (§8.2) | Detail Lead |
+| Sesi berakhir (§8.4) | Global |
+| Gagal biometric | Login |
+| Kesalahan validasi per field | Login, form catatan |
+
+---
+
+## 11. Di luar cakupan desain
+
+- **iOS** — ditunda; jangan mendesain pola iOS-spesifik
+- Membuat lead baru, konversi ke Customer, kelola tim, laporan/metrik — **bukan** milik employee
+- Chat in-app, VoIP, peta/geolokasi
+- Mode gelap — belum diputuskan; kalau ingin diusulkan, sampaikan sebagai catatan, bukan set kedua
+- Onboarding/tur, splash screen bermerek
+- Ikon aplikasi & branding (menunggu keputusan branding produk)
+
+---
+
+## 12. Bentuk keluaran yang diharapkan
+
+1. **Token**: warna, tipografi, spacing — dengan **rasio kontras tertulis** untuk tiap pasangan
+   teks/latar
+2. **Enam layar** (§7) dalam keadaan normalnya
+3. **Keadaan di §10** — ini yang paling sering terlewat, dan yang paling mahal ditemukan saat
+   implementasi
+4. **Kerangka navigasi** (§7.6)
+5. Catatan singkat untuk keputusan yang tidak terlihat dari gambar
+
+Ukuran acuan: **Android 6", 360×800 dp**. Bila satu layar hanya bekerja di layar besar, katakan.

--- a/docs/phases/05-employee-mobile/issues.md
+++ b/docs/phases/05-employee-mobile/issues.md
@@ -1,0 +1,75 @@
+# Phase 5 — Employee Mobile · Issues
+
+> Indeks pekerjaan. **Tanpa kolom status** — status hidup di GitHub ([ADR-008](../../decisions/ADR-008-delivery-workflow.md)).
+>
+> Status terkini: `gh issue list --milestone "Phase 5 — Employee Mobile"`
+
+**Milestone:** [Phase 5 — Employee Mobile](https://github.com/Pravasta/jualin-crm/milestone/6)
+
+---
+
+## Daftar
+
+| # | Judul | Aplikasi | Cakupan | TD |
+|---|---|---|---|---|
+| [68](https://github.com/Pravasta/jualin-crm/issues/68) | Backend mobile: `device_tokens`, pengiriman FCM, hook setelah commit | `crm_be` | Migration `0006`, `internal/device`, `internal/shared/push`, config `PUSH_*`, kasus isolasi tenant baru. **Tanpa UI** | §8, §9, §13 |
+| [69](https://github.com/Pravasta/jualin-crm/issues/69) | Fondasi Flutter: FVM, scaffold, `ApiClient` single-flight, secure storage, login + biometric | `crm_employee` | Pin 3.44.0, struktur `lib/`, klien API, sesi, login, biometric, CI | §2–§6, §13 |
+| [70](https://github.com/Pravasta/jualin-crm/issues/70) | Fondasi desain mobile: tema, token, labels, kerangka navigasi | `crm_employee` | Token dari hasil Claude Design (dicek WCAG AA), `labels.dart`, navigasi, login ditata ulang | §3, §11 |
+| [71](https://github.com/Pravasta/jualin-crm/issues/71) | My Leads + cache baca offline | `crm_employee` | Layar terpenting. Mekanisme cache lahir di sini bersama pemakai pertamanya | §7 |
+| [72](https://github.com/Pravasta/jualin-crm/issues/72) | Detail lead: timeline, telepon/WhatsApp auto-Activity, ubah status, catatan | `crm_employee` | Seluruh aksi tulis mobile | §11 |
+| [73](https://github.com/Pravasta/jualin-crm/issues/73) | My Tasks, FCM klien, deeplink | `crm_employee`, `crm_be`, docs | Push sisi klien, tiga keadaan deeplink, dokumentasi. **Penutup phase** | §10, §12.1, §15 |
+
+---
+
+## Urutan
+
+```
+#68 backend (tanpa UI) ─────────────────────────────────┐
+                                                        ├──► #71 My Leads ──► #72 Detail ──► #73 penutup
+#69 fondasi Flutter ──► #70 fondasi desain ─────────────┘
+        ▲                        ▲
+        │                        └── menunggu hasil Claude Design
+        └── tidak menunggu desain
+```
+
+| Dependensi | Sifat |
+|---|---|
+| #69 → #68 | **Bukan prasyarat.** Keduanya boleh paralel — #68 murni Go, #69 murni Flutter, tidak bersinggungan |
+| #70 → #69 | **Keras.** Tema butuh aplikasi yang sudah ada |
+| #70 → hasil desain | **Keras.** Ini satu-satunya issue yang benar-benar diblokir `design-brief.md` |
+| #71 → #70 | **Keras.** Membangun layar sebelum temanya ada berarti menatanya dua kali |
+| #72 → #71 | **Keras.** Detail dibuka dari daftar |
+| #73 → #68, #72 | **Keras.** Push klien butuh backend-nya (#68) dan layar tujuan deeplink (#72) |
+
+**#68 dan #69 boleh dikerjakan paralel** — dan sebaiknya begitu: keduanya tidak menunggu desain, jadi
+pekerjaan tetap jalan sementara Claude Design berjalan.
+
+---
+
+## Batas per issue
+
+| Issue | Berhenti di |
+|---|---|
+| #68 | Backend siap menerima token & mengirim push. **Belum ada aplikasi** yang mendaftarkannya — diuji `curl` + token dummy |
+| #69 | Aplikasi bisa login + biometric. **Tanpa** tema, navigasi, atau daftar lead. Tampilan sengaja seadanya |
+| #70 | Tema, navigasi, dan istilah siap dipakai. **Belum ada** layar isi — hanya placeholder bertanggal |
+| #71 | Daftar lead jalan, termasuk offline. Menekan lead **belum** membuka detail |
+| #72 | Seluruh aksi tulis jalan. **Belum ada** push maupun My Tasks |
+| #73 | Phase 5 tutup, GATE terbuka. **Tidak** rilis Play Store, **tidak** mengaktifkan iOS |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Kenapa enam issue, dan kenapa fondasi desain punya issue sendiri
+
+Phase ini yang terbesar sejauh ini — `crm_employee/` mulai dari satu berkas `README.md`. Enam issue
+membuat tiap PR tetap sebesar satu sesi.
+
+**Issue fondasi desain (#70) sengaja ada sejak phase dibuka.** Di Phase 3 kebutuhan yang sama —
+token, label, kerangka aplikasi — tidak dimiliki issue manapun, sehingga muncul sebagai **#40 di luar
+rencana** begitu hasil desain masuk. Pelajaran itu diterapkan langsung di sini, bukan diulang.
+
+**#68 sengaja tidak menunggu apa pun.** Ia murni Go dan tanpa UI, jadi ia bisa jalan sejak hari
+pertama sementara `design-brief.md` dikerjakan desainer. Pola yang sama seperti #30 membuka Phase 3
+dan #46 membuka Phase 4.

--- a/docs/phases/05-employee-mobile/prd.md
+++ b/docs/phases/05-employee-mobile/prd.md
@@ -1,0 +1,182 @@
+# Phase 5 — Employee Mobile · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md). Arahan untuk desainer di [`design-brief.md`](./design-brief.md).
+> Sumber: [`architecture/freeze.md`](../../architecture/freeze.md) bagian 4 (Phase 5), A3 (notification: penyimpanan vs pengiriman), 2.3 (`version` & antrian offline), 3.3 (wajib — Mobile), 5.1 (Aturan #24) · [ADR-003](../../decisions/ADR-003-employee-as-membership.md) · [`architecture/authentication.md`](../../architecture/authentication.md) bagian *Dashboard (cookie) vs Mobile (bearer)*
+
+---
+
+## Tujuan
+
+**Produk menjadi nyata.** Freeze menyebut phase ini pembeda utama produk — dan ia benar: sampai
+sekarang Jualin CRM adalah alat untuk **Owner**. Employee punya akun, punya lead yang ditugaskan
+kepadanya, punya task, dan punya notifikasi yang menumpuk di tabel — tapi **tidak punya cara
+memakainya**. Dashboard bukan alatnya (Phase 3 TD §2.4 sudah menyatakan itu; `authz.go` bahkan
+menuliskan komentarnya: *"Employee gets mobile in Phase 5"*).
+
+Kalimat inti MVP menyebut satu langkah yang belum pernah dijalankan siapa pun:
+
+> Owner mendaftar → … → owner meng-assign → employee menerima notifikasi →
+> **follow-up dari HP** → update → konversi ke Customer
+
+Phase ini menutupnya, dan dengan itu melengkapi seluruh siklus produk — yang membuka GATE
+(freeze: cari 3–5 pengguna nyata sebelum Phase 6).
+
+## Yang sudah siap, dan yang belum
+
+Riset sebelum menulis PRD ini menemukan backend **hampir seluruhnya sudah siap** — Phase 5 lebih
+banyak pekerjaan Flutter daripada Go:
+
+| Kebutuhan mobile | Status |
+|---|---|
+| Login jalur mobile (`client: "mobile"`, refresh token di body, TTL 2160h) | ✅ Phase 1 (#10) |
+| Rotasi refresh token + deteksi penggunaan ulang | ✅ Phase 1 (#10) |
+| Visibilitas Employee: hanya lead yang di-assign kepadanya | ✅ Phase 1 (#11) + Phase 2, ditegakkan di repository |
+| Permission Employee (`lead.read/update`, `task.*`, `activity.*`, `customer.read`) | ✅ Phase 1 (#11) |
+| Activity `call_logged`, `whatsapp_opened`, `note_added` sebagai tipe yang boleh dikirim klien | ✅ Phase 2 (#21) |
+| Transisi status + optimistic locking `version` → `409` | ✅ Phase 2 (#20) |
+| Tabel `notifications` + endpoint daftar/mark-read | ✅ Phase 2 (#22) |
+| Pencabutan refresh token saat membership dinonaktifkan | ✅ Phase 2 (#22) |
+| **`device_tokens` + pengiriman push FCM** | ❌ **belum ada — satu-satunya pekerjaan backend phase ini** |
+
+Artinya: yang membuat phase ini besar bukan backend-nya, melainkan bahwa `crm_employee/` masih
+berisi satu berkas `README.md`.
+
+---
+
+## Android dulu — iOS ditunda
+
+**Keputusan pemilik produk:** Phase 5 menargetkan **Android saja**. iOS ditunda sampai Apple
+Developer Program tersedia (berbayar ~$99/tahun, dan enrollment badan usaha butuh D-U-N-S yang
+memakan waktu).
+
+Ini **tidak** mengorbankan kriteria selesai phase. Freeze menulis *"Siklus penuh berjalan di HP
+nyata"* — tanpa menyebut platform. Yang benar-benar terhalang tanpa akun Apple hanya dua hal, dan
+keduanya iOS-spesifik:
+
+| Terhalang | Kenapa |
+|---|---|
+| Build & distribusi iOS | Provisioning gratis hanya berlaku 7 hari dan tidak bisa dibagikan. Tidak ada TestFlight |
+| Push iOS | FCM untuk iOS mengantar lewat **APNs**; APNs key hanya bisa dibuat dari akun Apple berbayar |
+
+Push **Android** tidak terhalang sama sekali — FCM mengantar langsung ke perangkat Android tanpa
+melibatkan Apple. Firebase project gratis dan dibuat dalam hitungan menit.
+
+> **Yang dijaga sepanjang phase ini:** tidak ada kode yang ditulis dengan asumsi "hanya Android
+> selamanya". Flutter lintas platform secara bawaan; penundaan ini soal **build, uji, dan rilis**,
+> bukan soal menulis kode Android-only. Detail apa yang boleh dan tidak boleh: TD §2.
+
+---
+
+## Kontradiksi di dalam freeze — dilaporkan, bukan diputuskan diam-diam
+
+Freeze menyebut cakupan offline **dua kali dengan makna berbeda**:
+
+| Lokasi | Bunyi |
+|---|---|
+| Bagian 4, tabel Phase 5, baris *Cakupan* | "**cache baca offline**" |
+| Bagian 4, tabel Phase 5, baris *Selesai bila* | "daftar lead tetap **terbaca** saat mode pesawat" |
+| Bagian 2.3, penjelasan kolom `version` | "Konsekuensi langsung dari **antrian aksi offline di Phase 5**" |
+
+Dua yang pertama menyebut **baca**; yang ketiga menyebut **antrian aksi** (yaitu tulis offline yang
+disinkronkan belakangan). Keduanya tidak bisa benar bersamaan sebagai cakupan phase — antrian tulis
+offline adalah pekerjaan berkali lipat lebih besar (penyimpanan antrian, urutan, retry, UI konflik).
+
+**Interpretasi yang diambil: cache baca saja.** Alasannya:
+
+1. **Baris *Selesai bila* adalah kriteria yang mengikat**, dan ia menyebut *terbaca* — bukan
+   "perubahan tersinkron".
+2. Baris *Cakupan* di tabel yang sama juga menulis "cache **baca** offline" secara eksplisit.
+3. Bagian 2.3 sedang menjelaskan **kenapa kolom `version` dibangun di Phase 2**, bukan menetapkan
+   cakupan Phase 5. Kalimat lengkapnya justru menegaskan kehati-hatian: *"yang mahal adalah membangun
+   antrian offline dengan asumsi last-write-wins lalu menyadari datanya sudah hilang"* — nadanya
+   memperingatkan, bukan memerintahkan membangunnya sekarang.
+
+`version` **tetap dipakai** phase ini (setiap tulis dari mobile mengirimnya, `409` ditampilkan ke
+pengguna) — jadi fondasi untuk antrian offline tetap utuh bila kelak dibangun. Yang ditunda hanya
+antriannya.
+
+**Ini dilaporkan sesuai Aturan #30, tidak diperbaiki diam-diam.** Freeze tidak diubah oleh phase ini.
+Bila pemilik produk membaca bagian 2.3 dengan maksud berbeda, katakan sebelum implementasi dimulai —
+itu mengubah ukuran phase ini secara mendasar.
+
+---
+
+## Kebutuhan
+
+| # | Sebagai… | Saya butuh… | Supaya… |
+|---|---|---|---|
+| 1 | Employee lapangan | Membuka daftar lead saya di HP, bukan di laptop | Saya bekerja sambil berdiri di depan toko calon pelanggan, bukan di meja |
+| 2 | Employee lapangan | Daftar lead saya tetap terbaca saat sinyal hilang | Basement mall dan pinggiran kota adalah kondisi kerja normal, bukan kasus tepi |
+| 3 | Employee lapangan | Menelepon / WhatsApp calon pelanggan langsung dari aplikasi | Saya tidak perlu menyalin nomor ke aplikasi lain, dan riwayatnya tercatat sendiri |
+| 4 | Employee lapangan | Mengubah status dan menambah catatan segera setelah bicara | Kalau harus menunggu sampai di kantor, saya tidak akan pernah melakukannya |
+| 5 | Employee lapangan | Tahu ada lead baru untuk saya tanpa membuka aplikasi | Lead yang didiamkan dua jam sudah kalah oleh kompetitor |
+| 6 | Employee lapangan | Masuk kembali tanpa mengetik password tiap kali | Aplikasi yang minta password 5×/hari akan ditinggalkan |
+| 7 | Owner | Yakin employee yang sudah keluar tidak bisa lagi membuka daftar lead dari HP-nya | HP pribadi tidak bisa ditarik saat orangnya resign |
+| 8 | Pemilik sistem | Kegagalan push tidak pernah menghilangkan notifikasi | Push adalah pengantar; catatannya yang jadi sumber kebenaran (freeze A3) |
+
+---
+
+## Acceptance Criteria
+
+Phase 5 selesai bila **semuanya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | Siklus penuh berjalan di **HP Android sungguhan** (bukan hanya emulator): login → lihat lead yang ditugaskan → telepon/WhatsApp → ubah status → tambah catatan |
+| 2 | Daftar lead **tetap terbaca dalam mode pesawat** setelah pernah dibuka sekali — kriteria *Selesai bila* freeze, diverifikasi dengan benar-benar mematikan koneksi |
+| 3 | Employee **hanya** melihat lead yang ditugaskan kepadanya — dibuktikan dengan dua akun employee di organization yang sama |
+| 4 | Login memakai **user session (JWT + refresh opaque)**, bukan API key — dan tidak ada satu pun jalur di aplikasi yang menyentuh API key (Aturan #24) |
+| 5 | Refresh token disimpan di **secure storage** OS, bukan `SharedPreferences` — dan rotasinya bekerja (token lama ditolak setelah dipakai) |
+| 6 | Membuka kembali aplikasi meminta **biometric**, bukan password — dan menolak masuk bila biometric gagal |
+| 7 | Menonaktifkan employee dari dashboard membuat aplikasi di HP-nya **kehilangan akses pada refresh berikutnya** — diverifikasi langsung, bukan diasumsikan dari kode Phase 2 |
+| 8 | Menelepon dan membuka WhatsApp masing-masing mencatat activity (`call_logged`, `whatsapp_opened`) yang muncul di timeline dashboard |
+| 9 | Ubah status yang bentrok (data sudah diubah orang lain) menampilkan **konflik kepada pengguna**, tidak pernah menimpa diam-diam (`version` → `409`) |
+| 10 | Assign lead dari dashboard memunculkan **push notification di HP Android** dalam hitungan detik, dan menekannya membuka lead itu (deeplink) |
+| 11 | Kegagalan kirim push **tidak** membatalkan pembuatan record notification, dan tidak menggagalkan request assignment (Aturan #32) |
+| 12 | Token perangkat yang sudah tidak valid (aplikasi di-uninstall) **dibersihkan**, tidak menumpuk selamanya |
+| 13 | `flutter analyze` bersih dan test unit lolos di CI, memakai versi Flutter yang **dipin** — bukan versi apa pun yang kebetulan terpasang di mesin |
+| 14 | Tidak ada rahasia (refresh token, service account FCM) yang ter-commit ke repository |
+
+---
+
+## Keputusan yang ditutup di phase ini
+
+| # | Pertanyaan | Keputusan | Alasan |
+|---|---|---|---|
+| **M1** | Platform target Phase 5? | **Android saja.** iOS digenerate Flutter tapi tidak pernah dibangun, diuji, atau dikonfigurasi Firebase. | Apple Developer Program berbayar dan belum ada; enrollment badan usaha punya lead time berminggu. Yang terhalang hanya build & push iOS — bukan satu pun kriteria selesai phase ini. Kode tetap ditulis lintas platform (Flutter bawaan), jadi mengaktifkan iOS kelak = konfigurasi + build, bukan menulis ulang. |
+| **M2** | Versi Flutter dipin atau ikut mesin? | **Dipin lewat FVM**, `3.44.0`, `.fvmrc` di-commit. | Mesin ini sudah punya dua versi berbeda (`flutter` sistem 3.38.9 vs FVM 3.44.0) — tanpa pin, dua mesin sudah tidak sepakat hari ini, apalagi CI. Pola yang sama seperti `go.mod` mengunci versi Go. |
+| **M3** | Cakupan offline: baca saja atau antrian tulis? | **Cache baca saja.** Antrian aksi offline **di luar cakupan**. | Kontradiksi freeze di atas — kriteria *Selesai bila* menyebut *terbaca*. `version` tetap dikirim di setiap tulis sehingga fondasi antrian tetap utuh bila kelak dibangun. |
+| **M4** | Pengiriman FCM: Firebase Admin SDK atau HTTP v1 langsung? | **HTTP v1 langsung**, token OAuth2 dari service account lewat `golang.org/x/oauth2/google`. | Admin SDK membawa Firestore, Auth, dan Storage yang tidak satu pun dipakai. Aturan #27 — pola yang sama seperti memilih `net/smtp` ketimbang pustaka mail di Phase 4.6. Satu dependency baru (`x/oauth2`), bukan satu pohon dependency. |
+| **M5** | Kapan push dikirim relatif transaksi? | **Setelah commit**, tidak pernah di dalamnya. Kegagalan kirim hanya dicatat. | Aturan #32, sama persis seperti email sejak Phase 1. Freeze A3 sudah menetapkan record notification adalah **source of truth** dan push hanya pengantar *best-effort* — jadi push yang gagal memang tidak boleh punya konsekuensi apa pun terhadap data. |
+| **M6** | Desain: brief dulu atau langsung bangun? | **Design brief ditulis lebih dulu**, hasil Claude Design ditunggu sebelum issue layar. Issue **fondasi desain dibuat sejak awal**, bukan menyusul. | Pola Phase 3, dengan satu koreksi dari pengalamannya: di sana token/kerangka aplikasi tidak dimiliki issue manapun sehingga #40 muncul di luar rencana di tengah phase. Kali ini fondasi punya issue sendiri sejak hari pertama. |
+
+---
+
+## Di luar cakupan
+
+| Tidak dikerjakan | Ke |
+|---|---|
+| **iOS**: build, TestFlight, App Store, APNs | Menunggu Apple Developer Program (M1) |
+| **Antrian aksi offline** (ubah status/catatan saat pesawat, disinkronkan belakangan) | Belum dijadwalkan (M3) — `version` sudah siap menerimanya |
+| Dashboard Owner di mobile | Bukan alat Employee. Owner memakai `crm_dashboard` |
+| Membuat lead baru dari mobile | Employee tidak punya `ActionLeadCreate` (Phase 1 #11). Lead lahir dari Owner atau API publik |
+| Konversi ke Customer dari mobile | `ActionLeadConvert` sengaja tidak dimiliki Employee |
+| Mengelola tim / API key dari mobile | Owner/Admin saja, dan itu pekerjaan dashboard |
+| Chat in-app, panggilan VoIP | Di luar scope produk (`CLAUDE.md`) — aplikasi hanya **membuka** dialer & WhatsApp milik OS |
+| Peta / geolokasi kunjungan | Belum pernah diminta. Aturan #28 |
+| Play Store release, signing key produksi | Phase ini selesai di **APK/AAB debug di HP nyata**. Rilis publik butuh keputusan branding & akun Play yang belum ada |
+| Notifikasi selain `lead_assigned` & `task_assigned` | Hanya dua tipe itu yang ada di `ck_notifications_type` |
+
+---
+
+## Dependensi
+
+| Bergantung pada | Sifat |
+|---|---|
+| Phase 1 (#10, #11) | **Keras.** Seluruh jalur auth mobile dan visibilitas Employee lahir di sana |
+| Phase 2 (#19–#23) | **Keras.** Lead, task, activity, notification, `version` — tidak ada yang perlu ditambah |
+| Phase 3 | **Praktis.** Owner butuh jalan untuk assign lead supaya ada yang muncul di aplikasi |
+| Phase 4 | **Bukan prasyarat** (freeze) — mobile tidak menyentuh API key sama sekali |
+| Firebase project | **Memblokir issue push saja**, bukan phase-nya. Yang dibutuhkan pemilik produk ada di TD §9 |
+| Apple Developer Program | **Tidak memblokir apa pun di phase ini** (M1) |
+| Hasil Claude Design | **Memblokir issue layar**, bukan issue backend & fondasi Flutter (M6) |

--- a/docs/phases/05-employee-mobile/td.md
+++ b/docs/phases/05-employee-mobile/td.md
@@ -1,0 +1,512 @@
+# Phase 5 — Employee Mobile · Technical Design
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+> Hanya **delta** untuk phase ini — aturan yang sudah ada di [`freeze.md`](../../architecture/freeze.md) dirujuk, tidak diulang.
+> Sumber: freeze bagian 4 (Phase 5), A3, 2.3, 5.1 (Aturan #24) · Aturan #1–#7, #12, #13, #16, #18, #26, #32, #36 · [ADR-011](../../decisions/ADR-011-layered-packages-and-unit-of-work.md) · [`architecture/authentication.md`](../../architecture/authentication.md)
+
+---
+
+## 1. Batas platform — apa arti "Android dulu" secara konkret
+
+Keputusan M1 adalah soal **build, uji, dan rilis** — bukan soal menulis kode Android-only.
+
+| Boleh | Tidak boleh |
+|---|---|
+| `crm_employee/ios/` digenerate `flutter create` dan dibiarkan apa adanya | Menghapus folder `ios/`, atau menambahkan `platforms:` yang mengecualikannya |
+| Paket dipilih yang mendukung Android **dan** iOS | Memilih paket Android-only saat ada alternatif lintas platform setara |
+| `flutter build apk` diuji; `flutter build ipa` tidak pernah dijalankan | Menulis `if (Platform.isAndroid)` untuk hal yang sebenarnya lintas platform |
+| Firebase dikonfigurasi untuk Android saja (`google-services.json`) | Menulis kode push yang mengasumsikan hanya FCM-langsung (iOS lewat APNs punya bentuk yang sama di sisi Dart) |
+| `device_tokens.platform` menerima `'android'` dan `'ios'` sejak awal | Membuat kolomnya `CHECK (platform = 'android')` |
+
+Mengaktifkan iOS kelak harus menjadi pekerjaan **konfigurasi + build**, bukan penulisan ulang.
+Setiap keputusan di bawah dinilai terhadap batasan itu.
+
+---
+
+## 2. Toolchain — FVM, versi dipin
+
+```
+.fvmrc                     { "flutter": "3.44.0" }        ← di-commit
+crm_employee/.fvmrc        idem (FVM membaca dari akar proyek Flutter)
+```
+
+Flutter **3.44.0** (Dart 3.12.0, stable, rilis 2026-05-15) — diverifikasi jalan lewat
+`fvm spawn 3.44.0 --version` sebelum ditulis di sini.
+
+**Kenapa dipin.** Mesin pengembangan ini sudah punya dua Flutter berbeda hari ini: `flutter` di
+`PATH` adalah **3.38.9**, sementara FVM menyimpan **3.44.0** dan **3.44.3**. Tanpa pin, dua mesin
+sudah tidak sepakat sekarang — apalagi CI. Ini alasan yang sama kenapa `go.mod` mengunci versi Go.
+
+Seluruh perintah Flutter di phase ini dijalankan lewat `fvm flutter …` / `fvm dart …`.
+`Makefile` di akar mendapat target `mobile-*` yang membungkusnya (§13), sehingga tidak ada yang perlu
+mengingat prefix `fvm`.
+
+> `fvm list` menandai 3.44.0 sebagai *Need setup*. `fvm spawn`/`fvm use` pertama akan menyiapkannya
+> sendiri — bukan langkah manual terpisah.
+
+---
+
+## 3. Struktur `crm_employee/`
+
+Mengikuti bentuk yang sudah terbukti di `crm_dashboard`: **logika murni dipisah dari widget**, supaya
+bisa diuji tanpa merender apa pun (pola `lib/nav.ts`, `lib/lead-filters.ts`, `lib/api-key-rows.ts`).
+
+```
+crm_employee/
+  .fvmrc
+  pubspec.yaml
+  analysis_options.yaml          flutter_lints, dinaikkan (§12)
+  lib/
+    main.dart
+    app.dart                     MaterialApp, router, theme
+    core/
+      api_client.dart            HTTP + refresh single-flight (§5)
+      api_error.dart             bentuk error envelope {code,message,details}
+      session.dart               ChangeNotifier — status login, membership, role
+      secure_store.dart          pembungkus flutter_secure_storage
+      cache.dart                 cache baca offline (§7)
+      config.dart                base URL per flavor
+    features/
+      auth/                      login, biometric gate
+      leads/                     My Leads, detail, aksi
+      tasks/                     My Tasks
+      notifications/             daftar notifikasi + FCM handler
+    shared/
+      labels.dart                status/alasan/sumber → Bahasa Indonesia (§11)
+      theme.dart                 token warna & tipografi dari design output
+      widgets/                   komponen dipakai >1 layar
+  test/                          unit test — logika murni, tanpa widget
+  android/
+  ios/                           digenerate, tidak pernah dibangun (§1)
+```
+
+**`labels.dart` menyalin nilai dari `crm_dashboard/src/lib/labels.ts`, bukan mengimpornya.** Tidak ada
+mekanisme berbagi kode Dart↔TypeScript, dan membangunnya (codegen dari satu sumber) adalah abstraksi
+untuk masalah yang belum ada (Aturan #27). Yang dijaga: `glossary.md` tetap satu-satunya sumber
+istilah, dan test mengunci daftar nilainya sama panjang dengan enum backend.
+
+---
+
+## 4. Autentikasi & penyimpanan token
+
+Jalur mobile **sudah ada sejak Phase 1** — tidak ada perubahan backend di sini.
+
+| Aspek | Ketentuan |
+|---|---|
+| Login | `POST /v1/auth/login` dengan `{"client": "mobile"}` → refresh token di **body**, bukan cookie |
+| Access token | JWT, TTL 15 menit, dikirim `Authorization: Bearer` |
+| Refresh token | Opaque, TTL 2160h (90 hari), **rotasi** setiap refresh |
+| Penyimpanan | **`flutter_secure_storage`** — Android Keystore / EncryptedSharedPreferences. **Tidak pernah** `SharedPreferences` biasa (kriteria #5) |
+| CSRF | **Tidak berlaku** — token dikirim eksplisit di header, tidak pernah otomatis oleh browser (`authentication.md`) |
+| API key | **Tidak pernah disentuh** (Aturan #24). Tidak ada satu baris pun di `crm_employee/` yang mengenal format `jln_*` |
+
+### 4.1 Biometric
+
+`local_auth`. Gerbang **saat aplikasi dibuka kembali**, bukan pengganti login pertama:
+
+```
+Buka aplikasi
+  └─ ada refresh token di secure storage?
+       ├─ tidak → layar login (email + password)
+       └─ ya   → minta biometric
+                  ├─ sukses → refresh access token → masuk
+                  └─ gagal/batal → TIDAK masuk; tawarkan "Masuk dengan password"
+```
+
+Kriteria #6 menuntut biometric gagal **menolak masuk** — jadi kegagalannya tidak boleh diam-diam
+jatuh ke sesi yang sudah ada. Perangkat tanpa biometric terdaftar jatuh ke password, bukan dilewati.
+
+### 4.2 Kehilangan akses saat membership dinonaktifkan
+
+Phase 2 (#22) sudah mencabut seluruh `refresh_tokens` milik membership dalam transaksi penonaktifan.
+Konsekuensinya di mobile: access token yang masih hidup tetap bekerja **sampai 15 menit**, lalu
+refresh berikutnya gagal `401` dan aplikasi keluar ke layar login. Kriteria #7 menuntut ini
+**diverifikasi langsung**, bukan disimpulkan dari kode Phase 2 — jendela 15 menit itu perilaku nyata
+yang harus dilihat, bukan ditebak.
+
+---
+
+## 5. `ApiClient` — menyalin bentuk `crm_dashboard`, termasuk single-flight
+
+`crm_dashboard/src/lib/api-client.ts` sudah memecahkan masalah yang sama dan **diuji konkurensinya
+secara genuine** (#31: 6 panggilan paralel yang 401 bersamaan → tepat 1 refresh). Bentuknya disalin,
+bukan ditemukan ulang:
+
+```dart
+Future<T> send<T>(...) async {
+  var res = await _raw(...);
+  if (res.statusCode != 401) return _decode(res);
+
+  // Satu Future refresh dipakai bersama — ditetapkan SEBELUM await apa pun,
+  // supaya request paralel yang 401 bersamaan tidak memicu refresh masing-masing.
+  _refreshFuture ??= _doRefresh();
+  final ok = await _refreshFuture;
+  ...
+}
+```
+
+Yang berbeda dari dashboard: refresh token dibaca dari secure storage dan dikirim di **body**, bukan
+diambil dari cookie. Kegagalan refresh → hapus token dari secure storage, `Session` pindah ke
+keadaan keluar.
+
+**Test wajib** (§12): satu test yang menahan refresh lewat `Completer` sampai beberapa panggilan
+paralel mencapai titik single-flight, membuktikan `/v1/auth/refresh` dipanggil **tepat sekali** —
+pola yang sama seperti `api-client.test.ts`.
+
+---
+
+## 6. State — `provider`, bukan hand-rolled
+
+`ChangeNotifier` + `provider`. Satu paket kecil, stabil, dan luas dipakai.
+
+**Kenapa bukan tanpa paket sama sekali** (yang lebih sesuai refleks Aturan #27): `InheritedWidget`
+buatan tangan untuk state sesi menghasilkan **lebih banyak** kode boilerplate untuk hasil yang sama,
+dan boilerplate itu justru tempat bug muncul. Aturan #27 melarang abstraksi *sebelum kebutuhannya
+nyata* — state sesi lintas layar adalah kebutuhan hari pertama, bukan antisipasi.
+
+**Kenapa bukan Riverpod/Bloc**: keduanya membawa konsep baru (provider scope, event/state stream)
+untuk aplikasi berlayar sedikit. Bisa ditinjau ulang bila jumlah layar tumbuh — itu pemicunya.
+
+---
+
+## 7. Cache baca offline
+
+Kriteria #2 — *"daftar lead tetap terbaca saat mode pesawat"*.
+
+**Bentuk: satu tabel key-value di SQLite** (`sqflite`), berisi **respons sukses terakhir** per
+permintaan:
+
+```sql
+CREATE TABLE response_cache (
+  key        TEXT PRIMARY KEY,   -- mis. "GET /v1/leads?status=new&page=1"
+  body       TEXT NOT NULL,      -- JSON mentah, apa adanya
+  fetched_at INTEGER NOT NULL    -- epoch ms, untuk ditampilkan "data per <waktu>"
+);
+```
+
+Alur baca: coba jaringan → sukses → simpan & tampilkan; gagal jaringan → baca cache → tampilkan
+dengan penanda **"Data terakhir diperbarui <waktu>"**.
+
+**Kenapa key-value JSON mentah, bukan tabel domain lokal.** Yang dibutuhkan kriteria #2 adalah
+*menampilkan kembali apa yang terakhir terlihat* — bukan query lokal, bukan join, bukan filter
+offline. Tabel domain lokal (drift/ORM) berarti menjaga skema kedua yang harus ikut berubah setiap
+kali backend berubah — biaya nyata untuk kemampuan yang tidak diminta (Aturan #27, #28).
+
+**Yang di-cache:** `GET /v1/leads`, `GET /v1/tasks`, `GET /v1/leads/{id}`,
+`GET /v1/leads/{id}/activities`. **Yang tidak:** apa pun yang bukan `GET`, dan `GET /v1/me`
+(sesi ditentukan token, bukan cache).
+
+**Dihapus saat logout** — cache berisi data lead satu organization; perangkat yang berpindah pengguna
+tidak boleh menampilkan sisa data pengguna sebelumnya.
+
+> **Bukan** antrian tulis offline (keputusan M3). Aksi tulis saat offline **gagal dengan pesan jelas**,
+> tidak diantre diam-diam.
+
+---
+
+## 8. Backend — migration `0006_device_tokens`
+
+Satu-satunya perubahan schema phase ini.
+
+```sql
+CREATE TABLE device_tokens (
+    id              uuid PRIMARY KEY,
+    organization_id uuid NOT NULL REFERENCES organizations (id),
+    membership_id   uuid NOT NULL,
+    token           text NOT NULL,
+    platform        text NOT NULL,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    last_seen_at    timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT ck_device_tokens_platform CHECK (platform IN ('android','ios')),
+    CONSTRAINT uq_device_tokens_id_org   UNIQUE (id, organization_id),
+    CONSTRAINT uq_device_tokens_token    UNIQUE (token),
+    CONSTRAINT fk_device_tokens_membership
+        FOREIGN KEY (membership_id, organization_id)
+        REFERENCES memberships (id, organization_id)
+);
+
+CREATE INDEX idx_device_tokens_org_membership
+    ON device_tokens (organization_id, membership_id);
+```
+
+| Aturan | Pemenuhan |
+|---|---|
+| #1 `organization_id` di setiap tabel bisnis | ✅ |
+| #2 `UNIQUE (id, organization_id)` | ✅ `uq_device_tokens_id_org` |
+| #3 FK ke tabel tenant-scoped selalu composite | ✅ `(membership_id, organization_id)` |
+| #12 PK UUIDv7 dari aplikasi, tanpa `DEFAULT` | ✅ |
+| #13 `timestamptz` | ✅ |
+| #16 index tenant-aware berawalan `organization_id` | ✅ |
+| #18 soft delete untuk entity bisnis | ❌ **sengaja tidak** — lihat di bawah |
+
+**`uq_device_tokens_token` unik lintas organization**, bukan composite. Ini pengecualian **ketiga**
+di codebase ini, sekelas dengan `api_keys.key_id` (#46) dan `refresh_tokens.token_hash` (#10): token
+FCM mengidentifikasi **satu instalasi aplikasi di satu perangkat**, dan perangkat itu bisa berpindah
+pengguna (employee resign, HP dipakai orang lain, employee pindah organization). Unik global +
+upsert membuat pendaftaran ulang **memindahkan baris** ke membership yang sekarang login — tepat
+perilaku yang benar. Composite akan membiarkan satu perangkat fisik menerima push milik dua
+organization sekaligus. Alasannya ditulis sebagai komentar di migration.
+
+**Tanpa `deleted_at`** (deviasi sadar dari Aturan #18): `device_tokens` bukan entity bisnis — tidak
+punya nilai audit, tidak pernah dirujuk laporan, dan kriteria #12 justru **menuntut** token mati
+benar-benar hilang. Soft delete di sini berarti menyimpan sampah selamanya sambil harus mengingat
+memfilternya di setiap query.
+
+---
+
+## 9. Backend — pengiriman FCM
+
+### 9.1 Paket `internal/device`
+
+Bentuk lima berkas ADR-011 (`entity/port/usecase/repository_postgres/handler_http`).
+
+| Endpoint | Principal | Guna |
+|---|---|---|
+| `POST /v1/device-tokens` | user (Employee dkk.) | Daftarkan/segarkan token perangkat. Upsert pada `token`; memperbarui `membership_id` + `last_seen_at` |
+| `DELETE /v1/device-tokens` | user | Hapus token milik perangkat ini saat logout |
+
+Action `authz` baru: `device_token.register`, `device_token.delete` — dimiliki **seluruh role**
+(Owner sampai Employee). Owner memakai dashboard hari ini, tapi tidak ada alasan menutup pintu bagi
+Owner yang kelak memasang aplikasi.
+
+### 9.2 Pengirim — HTTP v1 langsung (keputusan M4)
+
+`internal/shared/push`, sepola `internal/shared/mailer`:
+
+```go
+type Message struct {
+    Token string
+    Title string
+    Body  string
+    Data  map[string]string  // {"type":"lead_assigned","lead_id":"…"} → deeplink
+}
+
+type Sender interface {
+    Send(ctx context.Context, msg Message) error
+}
+```
+
+Dua implementasi, dipilih `PUSH_PROVIDER` — **bentuk yang sama persis seperti `MAIL_PROVIDER`**
+(Phase 4.6):
+
+| `PUSH_PROVIDER` | Implementasi | Catatan |
+|---|---|---|
+| `none` | `NoopSender` | Mencatat ke log, tidak mengirim. **Ditolak boot saat `APP_ENV=production`** (Aturan #36) |
+| `fcm` | `FCMSender` | `POST https://fcm.googleapis.com/v1/projects/{id}/messages:send` |
+
+Token OAuth2 dari service account lewat `golang.org/x/oauth2/google` (`JWTConfigFromJSON` →
+`TokenSource`, yang menyegarkan sendiri). **Satu dependency baru** — bukan pohon dependency Firebase
+Admin SDK, yang membawa Firestore/Auth/Storage yang tidak satu pun dipakai (Aturan #27, alasan yang
+sama seperti memilih `net/smtp` di Phase 4.6).
+
+Batas waktu HTTP eksplisit (`PUSH_TIMEOUT`, default `10s`) — **pelajaran langsung dari #63**: di sana
+`smtp.SendMail` ternyata tidak punya batas waktu sama sekali, dan `Send` dipanggil sinkron di jalur
+request. Di sini jalurnya sama, jadi batas waktunya dipasang sejak awal, bukan ditemukan belakangan.
+
+### 9.3 Kapan dikirim (keputusan M5)
+
+```go
+// internal/lead/usecase.go — UpdateAssignment
+txErr := u.store.InTx(ctx, func(r Repos) error {
+    …
+    return r.Notification.Notify(ctx, t, newAssignee, "lead_assigned", &id, nil, title, &updated.Name)
+})
+if txErr != nil { … }
+
+// SETELAH commit — Aturan #32. Kegagalan hanya dicatat, tidak pernah
+// membatalkan assignment atau record notification yang sudah tersimpan.
+u.pushAssignmentNotification(ctx, t, newAssignee, updated)
+```
+
+Persis pola `sendVerificationEmail` sejak Phase 1. Freeze A3 sudah menetapkan record notification
+adalah **source of truth** dan push hanya pengantar *best-effort* — jadi push yang gagal memang tidak
+boleh punya konsekuensi apa pun terhadap data (kriteria #11).
+
+`lead` mendeklarasikan interface konsumennya sendiri (`PushSender`, satu method) sesuai ADR-011,
+dijembatani di composition root — pola yang sama seperti `NotificationSender` dan
+`ActivityRecorder`.
+
+### 9.4 Token mati dibersihkan (kriteria #12)
+
+FCM v1 mengembalikan `404 UNREGISTERED` atau `400 INVALID_ARGUMENT` untuk token yang aplikasinya
+sudah di-uninstall. Respons itu **dipakai**: token tersebut dihapus dari `device_tokens`. Tanpa ini
+tabelnya hanya bertambah selamanya — kelas masalah yang sama seperti peta tanpa eviction di Phase 4.5.
+
+### 9.5 Rahasia (Aturan #26)
+
+| Aturan |
+|---|
+| Service account JSON **tidak pernah** di-commit. `FCM_CREDENTIALS_FILE` menunjuk path di luar repo; `.gitignore` menutup polanya |
+| Isi token FCM perangkat **tidak pernah** masuk log — hanya `membership_id` dan hasil kirim |
+| Body notifikasi boleh dicatat (judul lead), token tidak — sepola `mailer` yang mencatat `to` tapi bukan isi |
+
+---
+
+## 10. Deeplink dari push
+
+`firebase_messaging` menyediakan tiga jalur, ketiganya harus ditangani:
+
+| Keadaan aplikasi | Jalur |
+|---|---|
+| Terbuka (foreground) | `onMessage` → tampilkan in-app banner, jangan pindah layar paksa |
+| Latar belakang, ditekan | `onMessageOpenedApp` → navigasi ke lead |
+| Mati, dibuka dari notifikasi | `getInitialMessage` → navigasi ke lead **setelah** sesi siap |
+
+`data.lead_id` yang menentukan tujuan. Kasus yang wajib benar: notifikasi ditekan saat **belum
+login** → simpan tujuan, buka setelah login berhasil, bukan hilang diam-diam.
+
+**Tanpa paket deeplink eksternal** — tidak ada tautan `https://` dari luar aplikasi yang perlu
+ditangani di phase ini (itu Phase 6+ bila pernah ada).
+
+---
+
+## 11. Bahasa & istilah
+
+Aturan #12 `CLAUDE.md`: seluruh teks antarmuka **Bahasa Indonesia**. `shared/labels.dart` menyalin
+peta dari `crm_dashboard/src/lib/labels.ts` — 8 status, 6 alasan kalah, 4 sumber, 4 role.
+"Lead" dan "Customer" **tetap** sebagaimana di dashboard: keduanya istilah `glossary.md`.
+
+---
+
+## 12. Rencana test
+
+Aplikasi Flutter tidak punya harness sekelas testcontainers, dan **memaksakannya bukan tujuan phase
+ini**. Yang diuji adalah bagian yang paling mungkin salah diam-diam:
+
+| Berkas | Menguji |
+|---|---|
+| `test/api_client_test.dart` | Refresh **single-flight** — beberapa 401 paralel → tepat 1 refresh (pola `api-client.test.ts` #31). `MockClient` dari `package:http` |
+| `test/api_client_test.dart` | Refresh gagal → token dihapus dari secure storage, sesi keluar |
+| `test/cache_test.dart` | Simpan→baca respons; jaringan gagal → cache dipakai; logout → cache kosong |
+| `test/labels_test.dart` | Jumlah & nilai enum cocok dengan backend — 8/6/4/4, mengunci drift dari `labels.ts` |
+| `test/lead_status_test.dart` | Transisi status yang ditawarkan UI ⊆ yang backend izinkan (pola `lead-status.ts` #33) |
+| `crm_be/internal/device/*_test.go` | Repository (Postgres asli), handler, upsert token pindah membership |
+| `crm_be/internal/shared/push/*_test.go` | Bentuk payload FCM v1, penanganan `UNREGISTERED` → hapus token |
+| `crm_be/cmd/api/tenant_isolation_test.go` | **Kasus baru** `DELETE /v1/device-tokens` — dan **tetap terbukti bisa gagal** |
+
+**Widget test tidak diwajibkan** phase ini. Yang mengikat adalah kriteria #1/#2 — diverifikasi di HP
+Android sungguhan, bukan lewat widget test yang lulus di CI sambil aplikasinya tidak jalan.
+
+### 12.1 Verifikasi manual wajib (di HP nyata)
+
+Kriteria #1, #2, #6, #7, #10 **hanya** bisa dibuktikan di perangkat. Prosedurnya ditulis ke
+`docs/testing/flow/` sebagai berkas baru saat issue penutup, mengikuti bentuk yang sudah ada.
+
+---
+
+## 13. Konfigurasi & `Makefile`
+
+Env baru di `internal/shared/config` (pola `MAIL_PROVIDER` Phase 4.6):
+
+```
+PUSH_PROVIDER=none|fcm          # none ditolak saat APP_ENV=production
+FCM_PROJECT_ID=…                # wajib bila PUSH_PROVIDER=fcm
+FCM_CREDENTIALS_FILE=…          # path service account JSON, wajib bila fcm
+PUSH_TIMEOUT=10s
+```
+
+`Makefile` akar bertambah:
+
+```make
+mobile-get:      cd $(MOBILE) && fvm flutter pub get
+mobile-analyze:  cd $(MOBILE) && fvm flutter analyze
+mobile-test:     cd $(MOBILE) && fvm flutter test
+mobile-run:      cd $(MOBILE) && fvm flutter run
+mobile-apk:      cd $(MOBILE) && fvm flutter build apk --debug
+```
+
+CI: `.github/workflows/ci-employee.yml` dengan `paths: crm_employee/**`, Flutter dipin **3.44.0**,
+menjalankan `analyze` + `test`. Tidak membangun APK di CI — build Android butuh
+`google-services.json` yang sengaja tidak di-commit (§14).
+
+---
+
+## 14. Yang harus disiapkan pemilik produk — Firebase
+
+Diblokir sampai ini ada: **hanya issue push**, bukan phase-nya.
+
+### Langkah
+
+1. **Buat project Firebase** — [console.firebase.google.com](https://console.firebase.google.com) →
+   *Add project*. Google Analytics boleh dilewati (tidak dipakai).
+2. **Daftarkan aplikasi Android** — *Add app* → Android:
+   - **Package name**: `com.jualin.crm.employee` ← harus sama persis dengan `applicationId` di
+     `android/app/build.gradle`
+   - SHA-1 **tidak perlu** (itu untuk Google Sign-In/Dynamic Links, keduanya tidak dipakai)
+   - Unduh **`google-services.json`** → taruh di `crm_employee/android/app/google-services.json`
+3. **Buat service account untuk backend** — *Project settings* → *Service accounts* → *Generate new
+   private key* → JSON. Simpan **di luar repository**, arahkan `FCM_CREDENTIALS_FILE` ke sana.
+4. **Catat Project ID** (ada di *Project settings* → *General*) → `FCM_PROJECT_ID`.
+
+### Alternatif: FlutterFire CLI
+
+Belum terpasang di mesin ini (`flutterfire not found`, `~/.pub-cache/bin` kosong). Memasangnya:
+
+```bash
+fvm dart pub global activate flutterfire_cli
+export PATH="$PATH":"$HOME/.pub-cache/bin"
+cd crm_employee && flutterfire configure --platforms=android
+```
+
+Ia melakukan langkah 2 secara otomatis **dan** menghasilkan `lib/firebase_options.dart`. **Langkah 3
+tetap manual** — service account untuk backend tidak disentuh FlutterFire CLI sama sekali.
+
+### Yang tidak boleh di-commit
+
+`.gitignore` `crm_employee/` menutup:
+
+```
+android/app/google-services.json
+lib/firebase_options.dart
+**/*serviceAccount*.json
+```
+
+`google-services.json` bukan rahasia dalam arti ketat (ia ikut terkirim di dalam APK), tapi
+di-*ignore* supaya repository tidak terikat pada satu project Firebase, dan supaya tidak ada
+kebiasaan menaruh berkas Firebase apa pun di repo — service account JSON yang **benar-benar** rahasia
+kelihatan seperti berkas serupa (kriteria #14). Disediakan `.example` untuk keduanya.
+
+---
+
+## 15. Yang berubah pada dokumentasi
+
+| Berkas | Perubahan |
+|---|---|
+| `architecture/authentication.md` | Bagian *Dashboard (cookie) vs Mobile (bearer)* — kolom mobile dari rencana jadi kenyataan; biometric & secure storage |
+| `architecture/api.md` | Dua endpoint `device-tokens` di daftar endpoint |
+| `architecture/authorization.md` | Matriks Phase 5 — dua action `device_token.*` |
+| `architecture/multi-tenancy.md` | Pengecualian **ketiga** unik-lintas-organization (`device_tokens.token`); kasus isolasi baru di lapis 4 |
+| `docs/testing/flow/` | Berkas baru: alur testing manual mobile di HP Android |
+| `crm_employee/README.md` | Dari "belum dibuat" jadi cara menjalankan |
+| `.env.example`, `docker-compose.yml` | `PUSH_PROVIDER` dkk. |
+| `STATUS.md` | Baris Selesai; Phase 5 di *Progress per Phase*; *Punya Lead Time* — Apple/Firebase diperbarui |
+
+`freeze.md` **tidak disentuh**. Kontradiksi cakupan offline (PRD) **dilaporkan**, bukan diperbaiki —
+Aturan #30.
+
+---
+
+## 16. Risiko teknis
+
+| Risiko | Penanganan |
+|---|---|
+| Phase ini jauh lebih besar dari phase manapun sebelumnya | 6 issue dengan batas tegas (`issues.md`). Backend & fondasi Flutter **tidak** menunggu desain |
+| Hasil desain datang di tengah phase, seperti Phase 3 | Issue fondasi desain dibuat **sejak awal** (M6) — persis pelajaran dari #40 |
+| Test Flutter jauh lebih tipis dari backend | Disadari & disengaja (§12). Yang mengikat kriteria #1/#2 adalah verifikasi di HP nyata |
+| FCM tidak terkonfigurasi menghambat pengembangan | `PUSH_PROVIDER=none` membuat seluruh phase bisa dikerjakan tanpa Firebase sama sekali, kecuali satu issue push |
+| Menulis kode yang mengunci ke Android | §1 menetapkan batasnya secara eksplisit dan bisa diperiksa saat review |
+| `flutter_secure_storage` bermasalah di sebagian perangkat Android | Diketahui punya kasus tepi pada Android lama. Verifikasi kriteria #1 di HP nyata akan menangkapnya; bila muncul, dicatat sebagai temuan `docs/issues/`, bukan diakali diam-diam |
+
+---
+
+## 17. Kewajiban yang diteruskan ke phase berikutnya
+
+- **Saat Apple Developer Program ada**: aktifkan iOS — `google-services.json` versi iOS, APNs key di
+  Firebase, `flutter build ipa`. Tidak ada kode Dart yang perlu ditulis ulang bila §1 dipatuhi.
+- **GATE setelah Phase 5** (freeze): cari 3–5 pengguna nyata sebelum Phase 6. Urutan Phase 6–9
+  ditentukan apa yang mereka minta, bukan tebakan.
+- **Antrian aksi offline** (M3): `version` sudah siap menerimanya. Membangunnya butuh keputusan
+  eksplisit soal UI konflik — dan freeze bagian 2.3 sudah memperingatkan biayanya.
+- **Bila jumlah layar tumbuh banyak**: tinjau ulang pilihan `provider` (§6). Itu pemicunya, bukan
+  sebelum.


### PR DESCRIPTION
## Ringkasan

**Phase MVP terakhir.** Setelah ini GATE freeze terbuka: cari 3–5 pengguna nyata sebelum Phase 6.

PR ini hanya membuka phase: `prd.md`, `td.md`, `issues.md`, `design-brief.md`, plus `STATUS.md`. **Tidak ada kode yang berubah.**

## Android dulu, iOS ditunda (M1)

Apple Developer Program berbayar dan belum ada. Ini **tidak mengorbankan satu pun kriteria selesai phase** — freeze menulis *"siklus penuh berjalan di HP nyata"* tanpa menyebut platform, dan push Android tidak melibatkan Apple sama sekali.

TD §1 memasang **batas yang eksplisit dan bisa diperiksa saat review**, supaya "Android dulu" tetap keputusan *build/uji/rilis* dan tidak diam-diam jadi *kode Android-only*.

## Temuan riset: backend hampir seluruhnya sudah siap

| Kebutuhan mobile | Status |
|---|---|
| Auth mobile (`client: "mobile"`, refresh di body, TTL 2160h) | ✅ Phase 1 |
| Visibilitas Employee (hanya lead miliknya, ditegakkan di repository) | ✅ Phase 1 |
| Permission Employee | ✅ Phase 1 |
| Activity `call_logged`, `whatsapp_opened`, `note_added` | ✅ Phase 2 |
| `version` → `409` | ✅ Phase 2 |
| `notifications` + mark-read | ✅ Phase 2 |
| **`device_tokens` + FCM** | ❌ **satu-satunya pekerjaan backend** |

`authz.go` bahkan sudah menuliskan komentarnya sejak Phase 1: *"Employee gets mobile in Phase 5"*.

## ⚠️ Kontradiksi di dalam freeze — dilaporkan, bukan diputuskan diam-diam

| Lokasi | Bunyi |
|---|---|
| Bagian 4, *Cakupan* | "cache **baca** offline" |
| Bagian 4, *Selesai bila* | "daftar lead tetap **terbaca** saat mode pesawat" |
| Bagian 2.3 | "Konsekuensi langsung dari **antrian aksi offline di Phase 5**" |

Antrian tulis offline adalah pekerjaan berkali lipat lebih besar. PRD mengambil bacaan **cache baca saja** dengan tiga alasan, dan `version` tetap dikirim di setiap tulis sehingga fondasi antrian tetap utuh bila kelak dibangun.

**Ini mengubah ukuran phase secara mendasar — mohon dikoreksi sebelum implementasi dimulai bila maksud Anda berbeda** (Aturan #30).

## Enam issue — dua pilihan struktural yang disengaja

```
#68 backend (tanpa UI) ─────────────────────────────────┐
                                                        ├──► #71 ──► #72 ──► #73
#69 fondasi Flutter ──► #70 fondasi desain ─────────────┘
        ▲                        ▲
        └── tidak menunggu       └── menunggu Claude Design
```

- **#68 tidak menunggu apa pun** — murni Go, tanpa UI, jadi pekerjaan tetap jalan sementara desain dikerjakan. Pola #30 (Phase 3) dan #46 (Phase 4).
- **#70 (fondasi desain) ada sejak hari pertama**, bukan menyusul. Di Phase 3 kebutuhan yang sama (token, label, app shell) tidak dimiliki issue manapun dan muncul sebagai **#40 di luar rencana**. Pelajaran itu diterapkan, bukan diulang.

## Keputusan yang ditutup (M1–M6)

| # | Keputusan | Inti alasan |
|---|---|---|
| **M1** | Android saja; `ios/` digenerate tapi tak pernah dibangun | Tidak memblokir kriteria selesai manapun |
| **M2** | Flutter **3.44.0** dipin lewat FVM | **Diverifikasi jalan** (`fvm spawn`). Mesin ini sudah punya dua versi berbeda — `flutter` di PATH 3.38.9 vs FVM 3.44.0 |
| **M3** | Cache **baca** saja | Kontradiksi freeze di atas |
| **M4** | FCM HTTP v1 langsung + `x/oauth2/google` | Admin SDK membawa Firestore/Auth/Storage yang tak satu pun dipakai (Aturan #27, alasan sama seperti `net/smtp` di Phase 4.6) |
| **M5** | Push dikirim **setelah** commit | Aturan #32; freeze A3 sudah menetapkan record adalah source of truth, push best-effort |
| **M6** | Design brief dulu, issue fondasi sejak awal | Pola Phase 3 + koreksi dari #40 |

## `design-brief.md`

Ditulis untuk desainer. Bagian terpanjangnya **konteks pemakaian** — karena itu yang benar-benar beda dari dashboard: berdiri, satu tangan, di bawah matahari Indonesia, HP Android kelas menengah, sinyal hilang. Juga menyatakan di muka bahwa **setiap warna teks harus ≥4.5:1** — di Phase 3, lima dari delapan badge status gagal ambang itu dan harus diperbaiki saat implementasi.

## Yang dibutuhkan dari Anda

**Project Firebase** — gratis, hitungan menit. Langkah persisnya di `td.md` §14 (manual **dan** via FlutterFire CLI, yang belum terpasang di mesin ini). Hanya memblokir issue penutup **#73**; `PUSH_PROVIDER=none` membuat lima issue lainnya bisa dikerjakan tanpa Firebase sama sekali.

Refs #68 #69 #70 #71 #72 #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)