### PR TITLE
feat(mobile): add device_tokens, FCM push, post-commit hook

### DIFF
--- a/crm_be/cmd/api/device_store.go
+++ b/crm_be/cmd/api/device_store.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/device"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+)
+
+// deviceStore is the composition root's implementation of device.Store —
+// same wiring pattern as apikeyStore/invitationStore.
+type deviceStore struct {
+	pool *pgxpool.Pool
+}
+
+func newDeviceStore(pool *pgxpool.Pool) device.Store {
+	return &deviceStore{pool: pool}
+}
+
+func (s *deviceStore) InTx(ctx context.Context, fn func(device.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(deviceReposFor(tx))
+	})
+}
+
+func (s *deviceStore) Repos() device.Repos {
+	return deviceReposFor(s.pool)
+}
+
+func deviceReposFor(q db.Querier) device.Repos {
+	return device.Repos{
+		DeviceToken: device.New(q),
+	}
+}

--- a/crm_be/cmd/api/lead_store.go
+++ b/crm_be/cmd/api/lead_store.go
@@ -15,32 +15,48 @@ import (
 // leadStore is the composition root's implementation of lead.Store —
 // same wiring pattern as auth_store.go/membership_store.go/
 // invitation_store.go. Its Activity repository comes from
-// activity.NewRecorder (#21) and its Notification sender from
-// notification.NewNotifier (#22) — internal/lead never imports either
-// package's domain types, only this file (and those packages
-// themselves) know all three exist (ADR-011).
+// activity.NewRecorder (#21), its Notification sender from
+// notification.NewNotifier (#22), and its Push sender from
+// deviceUsecase (Phase 5 #68) — internal/lead never imports any of
+// those three packages' domain types, only this file (and those
+// packages themselves) know all three exist (ADR-011).
 type leadStore struct {
 	pool *pgxpool.Pool
+	push lead.PushSender
 }
 
-func newLeadStore(pool *pgxpool.Pool) lead.Store {
-	return &leadStore{pool: pool}
+// newLeadStore takes push as a parameter, not a package-level default,
+// because push genuinely can be nil in tests that construct a leadStore
+// directly without caring about push at all — lead.Usecase already
+// guards Repos().Push being nil (Phase 5 TD §9.3's doc comment on
+// pushAssignmentNotification), so passing nil here is a legitimate,
+// supported call, not an oversight.
+func newLeadStore(pool *pgxpool.Pool, push lead.PushSender) lead.Store {
+	return &leadStore{pool: pool, push: push}
 }
 
 func (s *leadStore) InTx(ctx context.Context, fn func(lead.Repos) error) error {
 	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
-		return fn(leadReposFor(tx))
+		return fn(leadReposFor(tx, s.push))
 	})
 }
 
 func (s *leadStore) Repos() lead.Repos {
-	return leadReposFor(s.pool)
+	return leadReposFor(s.pool, s.push)
 }
 
-func leadReposFor(q db.Querier) lead.Repos {
+// leadReposFor's push parameter is deliberately NOT built from q the
+// way Lead/Activity/Notification are — push (deviceUsecase) always
+// reads/writes through its OWN store, backed by the pool, regardless of
+// which querier lead's own transaction is using. That's correct: the
+// one caller of Repos().Push (Usecase.pushAssignmentNotification) only
+// ever calls it AFTER InTx has already committed (Rule #32), so it
+// never needs to participate in lead's transaction at all.
+func leadReposFor(q db.Querier, push lead.PushSender) lead.Repos {
 	return lead.Repos{
 		Lead:         lead.New(q),
 		Activity:     activity.NewRecorder(q),
 		Notification: notification.NewNotifier(q),
+		Push:         push,
 	}
 }

--- a/crm_be/cmd/api/main.go
+++ b/crm_be/cmd/api/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Pravasta/jualin-crm/crm_be/internal/apikey"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/auth"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/customer"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/device"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/invitation"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/lead"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/membership"
@@ -30,6 +31,7 @@ import (
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/logger"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/mailer"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/push"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/ratelimit"
 	"github.com/Pravasta/jualin-crm/crm_be/internal/task"
 )
@@ -136,7 +138,15 @@ func newRouter(log *slog.Logger, pool *pgxpool.Pool, cfg *config.Config) *gin.En
 	apikeyUsecase := apikey.NewUsecase(newAPIKeyStore(pool))
 	publicLeadCreateMW := authn.MiddlewareWithAPIKey(authUsecase, apikeyUsecase)
 
-	leadUsecase := lead.NewUsecase(newLeadStore(pool))
+	// device is wired here, ahead of lead, for the same reason apikey is
+	// above it: lead.PushSender (bridged below) needs deviceUsecase to
+	// already exist. deviceUsecase.PushToMembership structurally
+	// satisfies lead.PushSender (Phase 5 #68, TD §9.3) — internal/lead
+	// never imports this package, same bridging pattern as
+	// NotificationSender/ActivityRecorder.
+	deviceUsecase := device.NewUsecase(newDeviceStore(pool), newPushSender(cfg, log), log)
+
+	leadUsecase := lead.NewUsecase(newLeadStore(pool, deviceUsecase))
 	leadRateLimiter := ratelimit.NewFixedWindow(cfg.PublicAPIRateLimit, time.Minute)
 	lead.NewHandler(leadUsecase, leadRateLimiter).RegisterRoutes(r, authMW, publicLeadCreateMW)
 
@@ -156,6 +166,11 @@ func newRouter(log *slog.Logger, pool *pgxpool.Pool, cfg *config.Config) *gin.En
 	// user) — apikeyUsecase itself was built earlier, alongside lead's
 	// wiring, which is the only thing that needed it ahead of this point.
 	apikey.NewHandler(apikeyUsecase).RegisterRoutes(r, authMW)
+
+	// device's own management routes (register/unregister as principal
+	// user) — deviceUsecase itself was built earlier, alongside lead's
+	// wiring, which is the only thing that needed it ahead of this point.
+	device.NewHandler(deviceUsecase).RegisterRoutes(r, authMW)
 
 	// metrics is read-only (no Store/InTx, TD phase 3 §2) — its
 	// Repository is built directly from pool, no _store.go wrapper needed.
@@ -216,6 +231,35 @@ func newMailer(cfg *config.Config, log *slog.Logger) mailer.Mailer {
 		})
 	default:
 		panic(fmt.Sprintf("unreachable: unknown MAIL_PROVIDER %q passed config validation", cfg.MailProvider))
+	}
+}
+
+// newPushSender picks the push implementation for cfg.PushProvider — same
+// shape as newMailer (Phase 5 #68). Unlike newMailer's two branches,
+// push.NewFCMSender can genuinely fail (a missing or malformed
+// credentials file is a real, reachable misconfiguration, not a code
+// invariant) — panicking here rather than threading an error through
+// newRouter's signature still satisfies ADR-010: this runs synchronously
+// during router construction, before ListenAndServe is ever called and
+// before httpx.Recovery's request-scoped middleware exists to catch
+// anything, so the process exits nonzero before it could serve a single
+// request half-configured.
+func newPushSender(cfg *config.Config, log *slog.Logger) push.Sender {
+	switch cfg.PushProvider {
+	case "none":
+		return push.NewNoopSender(log)
+	case "fcm":
+		sender, err := push.NewFCMSender(push.FCMConfig{
+			ProjectID:       cfg.FCMProjectID,
+			CredentialsFile: cfg.FCMCredentialsFile,
+			Timeout:         cfg.PushTimeout,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("push: failed to construct FCM sender from FCM_CREDENTIALS_FILE=%q: %v", cfg.FCMCredentialsFile, err))
+		}
+		return sender
+	default:
+		panic(fmt.Sprintf("unreachable: unknown PUSH_PROVIDER %q passed config validation", cfg.PushProvider))
 	}
 }
 

--- a/crm_be/cmd/api/router_test.go
+++ b/crm_be/cmd/api/router_test.go
@@ -27,7 +27,8 @@ func testConfig() *config.Config {
 		AppEnv:             "development",
 		MailProvider:       "log",
 		AppBaseURL:         "http://localhost:3000",
-		PublicAPIRateLimit: 100, // see isolationTestConfig's comment (Phase 4 #47)
+		PublicAPIRateLimit: 100,    // see isolationTestConfig's comment (Phase 4 #47)
+		PushProvider:       "none", // see isolationTestConfig's comment (Phase 5 #68) — a zero-value "" here would hit newPushSender's unreachable default and panic
 	}
 }
 

--- a/crm_be/cmd/api/tenant_isolation_test.go
+++ b/crm_be/cmd/api/tenant_isolation_test.go
@@ -60,6 +60,12 @@ func isolationTestConfig() *config.Config {
 		// config.Load() would itself reject as invalid (config.go's
 		// validate() requires > 0).
 		PublicAPIRateLimit: 100,
+		// Zero value "" (not env.Parse's "none" default — this struct is
+		// built directly, bypassing envDefault entirely) would hit
+		// newPushSender's unreachable default case and panic (Phase 5
+		// #68) — every isolation test in this file goes through
+		// newRouter, so this has to be set explicitly here too.
+		PushProvider: "none",
 	}
 }
 
@@ -408,5 +414,35 @@ func TestTenantIsolation_MultiMembership_OnlySeesActiveOrgInToken(t *testing.T) 
 	}
 	if len(body.Data) != 1 {
 		t.Fatalf("expected exactly 1 member visible (org A's owner only), got %d: %s", len(body.Data), w.Body.String())
+	}
+}
+
+// TestTenantIsolation_DeviceTokenDelete_CrossOrgReturns404 is Phase 5
+// #68's device_tokens case. It doesn't fit the generic by-id table
+// above — DELETE /v1/device-tokens addresses its target by a token
+// VALUE in the request body, not a path segment — so it gets its own
+// test, same reasoning as
+// TestTenantIsolation_MetricsAggregate_ScopedToOrganization above.
+func TestTenantIsolation_DeviceTokenDelete_CrossOrgReturns404(t *testing.T) {
+	r, pool := newIsolationRouter(t)
+
+	orgA, _, ownerAMembershipID := seedOrgOwner(t, pool, "Device Org A", "device-owner-a@example.com")
+	tokenA := mintBearerToken(t, uuid.Must(uuid.NewV7()), orgA, ownerAMembershipID, tenant.RoleOwner)
+
+	orgB, _, membershipB := seedOrgOwner(t, pool, "Device Org B", "device-owner-b@example.com")
+	seedIsolationDeviceToken(t, pool, orgB, membershipB, "isolation-device-token-b")
+
+	w := doIsolationRequest(r, http.MethodDelete, "/v1/device-tokens", tokenA, map[string]string{"token": "isolation-device-token-b"})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for a cross-org device token delete, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func seedIsolationDeviceToken(t *testing.T, pool *pgxpool.Pool, org, membershipID uuid.UUID, token string) {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	const q = `INSERT INTO device_tokens (id, organization_id, membership_id, token, platform) VALUES ($1, $2, $3, $4, 'android')`
+	if _, err := pool.Exec(t.Context(), q, id, org, membershipID, token); err != nil {
+		t.Fatalf("seed isolation device token: %v", err)
 	}
 }

--- a/crm_be/go.mod
+++ b/crm_be/go.mod
@@ -12,9 +12,11 @@ require (
 	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.44.0
 	golang.org/x/crypto v0.54.0
+	golang.org/x/oauth2 v0.36.0
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/crm_be/go.sum
+++ b/crm_be/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
@@ -217,6 +219,8 @@ golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/crm_be/internal/apikey/handler_http.go
+++ b/crm_be/internal/apikey/handler_http.go
@@ -48,7 +48,7 @@ func (h *Handler) create(c *gin.Context) {
 		return
 	}
 
-	k, raw, err := h.usecase.Create(c.Request.Context(), t, CreateInput{Name: req.Name, Scopes: req.Scopes})
+	k, raw, err := h.usecase.Create(c.Request.Context(), t, CreateInput(req))
 	if err != nil {
 		httpx.WriteError(c, err)
 		return

--- a/crm_be/internal/apikey/repository_postgres.go
+++ b/crm_be/internal/apikey/repository_postgres.go
@@ -24,9 +24,7 @@ func New(q db.Querier) Repository {
 // apiKeyColumns is deliberately unaliased — every query below references
 // api_keys as its only table, so bare column names never need
 // disambiguating (same reasoning as customer.customerColumns).
-const apiKeyColumns = `
-	id, organization_id, key_id, secret_hash, key_prefix, name, scopes,
-	created_by_membership_id, created_at, last_used_at, revoked_at, expires_at`
+const apiKeyColumns = `id, organization_id, key_id, secret_hash, key_prefix, name, scopes, created_by_membership_id, created_at, last_used_at, revoked_at, expires_at` // #nosec G101 -- a SQL column list, not a credential; gosec's identifier heuristic matches "apiKeyColumns" as a name
 
 func (r *postgresRepository) Create(ctx context.Context, t tenant.Context, k *APIKey) error {
 	const q = `

--- a/crm_be/internal/apikey/usecase_unit_test.go
+++ b/crm_be/internal/apikey/usecase_unit_test.go
@@ -405,6 +405,15 @@ func TestUnit_ResolveAPIKey_EveryFailureReasonIsIdentical(t *testing.T) {
 	revoked := seedResolvableKey(store, org, []string{"leads:write"})
 	now := time.Now()
 	revoked.RevokedAt = &now
+	// seedResolvableKey always stamps KeyID=testKeyID; without giving
+	// revoked a KeyID of its own, this and valid collide in the fake
+	// repo's byID map and FindByKeyID's range over it (Go's map
+	// iteration order is randomized per call) nondeterministically
+	// returns whichever of the two it hits first — sometimes resolving
+	// the "revoked key" scenario below against the still-valid key
+	// instead, a flaky false pass/fail caught by running this test with
+	// -count=200 (fails intermittently without this line).
+	revoked.KeyID = "revokedkey01"
 
 	valid := seedResolvableKey(store, org, []string{"leads:write"})
 	_ = valid

--- a/crm_be/internal/device/entity.go
+++ b/crm_be/internal/device/entity.go
@@ -1,0 +1,38 @@
+// Package device owns device_tokens — one row per app installation per
+// physical device, registered so internal/shared/push can reach it, and
+// bridges lead's PushSender interface at the composition root (Phase 5
+// #68). See migrations/0006_device_tokens.sql for why token is unique
+// GLOBALLY rather than per organization.
+package device
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Token struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+	MembershipID   uuid.UUID
+	Token          string
+	Platform       string
+	CreatedAt      time.Time
+	LastSeenAt     time.Time
+}
+
+// validPlatforms mirrors ck_device_tokens_platform exactly — kept here
+// as the one place Go code needs to agree with the CHECK constraint,
+// same pattern as apikey.ScopeLeadsWrite mirroring ck_api_keys_scopes.
+var validPlatforms = map[string]bool{
+	"android": true,
+	"ios":     true,
+}
+
+// IsValidPlatform reports whether p is a platform value the database
+// will accept — checked in Usecase before the INSERT is even attempted,
+// so a bad value from a client is a 400 (Rule #33's validation_failed
+// shape), not a database constraint violation surfacing as a 500.
+func IsValidPlatform(p string) bool {
+	return validPlatforms[p]
+}

--- a/crm_be/internal/device/handler_http.go
+++ b/crm_be/internal/device/handler_http.go
@@ -42,7 +42,7 @@ func (h *Handler) register(c *gin.Context) {
 		return
 	}
 
-	tok, err := h.usecase.Register(c.Request.Context(), t, RegisterInput{Token: req.Token, Platform: req.Platform})
+	tok, err := h.usecase.Register(c.Request.Context(), t, RegisterInput(req))
 	if err != nil {
 		httpx.WriteError(c, err)
 		return

--- a/crm_be/internal/device/handler_http.go
+++ b/crm_be/internal/device/handler_http.go
@@ -1,0 +1,89 @@
+package device
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+)
+
+type Handler struct {
+	usecase *Usecase
+}
+
+func NewHandler(usecase *Usecase) *Handler {
+	return &Handler{usecase: usecase}
+}
+
+// RegisterRoutes mounts /v1/device-tokens, entirely behind authMW —
+// principal user only (Phase 5 TD §9.1: every role, Owner through
+// Employee, not just Employee — no reason to shut the door on an Owner
+// who eventually installs the app too).
+func (h *Handler) RegisterRoutes(r gin.IRouter, authMW gin.HandlerFunc) {
+	g := r.Group("/v1/device-tokens")
+	g.Use(authMW)
+	g.POST("", h.register)
+	g.DELETE("", h.unregister)
+}
+
+type registerRequest struct {
+	Token    string `json:"token"`
+	Platform string `json:"platform"`
+}
+
+func (h *Handler) register(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	var req registerRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	tok, err := h.usecase.Register(c.Request.Context(), t, RegisterInput{Token: req.Token, Platform: req.Platform})
+	if err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	httpx.OK(c, http.StatusCreated, deviceTokenJSON(tok))
+}
+
+// unregisterRequest — DELETE with a JSON body rather than
+// /v1/device-tokens/:token: an FCM token can legally contain characters
+// that need escaping in a path segment, and there's exactly one query
+// this endpoint ever needs, not a resource collection addressed by id.
+type unregisterRequest struct {
+	Token string `json:"token"`
+}
+
+func (h *Handler) unregister(c *gin.Context) {
+	t := authn.TenantFromContext(c)
+
+	var req unregisterRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpx.WriteError(c, httpx.NewValidationError(httpx.ErrorDetail{Field: "body", Code: "invalid_json"}))
+		return
+	}
+
+	if err := h.usecase.Unregister(c.Request.Context(), t, req.Token); err != nil {
+		httpx.WriteError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// deviceTokenJSON never includes the raw token — the client already has
+// it (it just sent it), and echoing it back in every response is a
+// second place for it to leak into a log capturing HTTP bodies (Rule
+// #26, same reasoning apiKeyJSON follows for secret_hash).
+func deviceTokenJSON(tok *Token) gin.H {
+	return gin.H{
+		"id":            tok.ID,
+		"membership_id": tok.MembershipID,
+		"platform":      tok.Platform,
+		"created_at":    tok.CreatedAt,
+		"last_seen_at":  tok.LastSeenAt,
+	}
+}

--- a/crm_be/internal/device/handler_test.go
+++ b/crm_be/internal/device/handler_test.go
@@ -1,0 +1,191 @@
+package device_test
+
+// Integration tests (real Postgres via dbtest) for issue #68's
+// device_token HTTP layer — register/unregister as principal user.
+// Nothing here exercises the push-sending side (PushToMembership); that
+// has its own coverage in usecase_unit_test.go with a fake Sender.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/device"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/accesstoken"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authn"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/push"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+const testJWTSecret = "device-handler-test-jwt-secret-32bytes" // #nosec G101 -- test-only value, not a real credential
+
+type testClaimsParser struct{}
+
+func (testClaimsParser) ParseAccessToken(raw string) (*accesstoken.Claims, error) {
+	return accesstoken.Parse([]byte(testJWTSecret), raw)
+}
+
+type testStore struct{ pool *pgxpool.Pool }
+
+func newTestStore(pool *pgxpool.Pool) device.Store { return &testStore{pool: pool} }
+
+func (s *testStore) InTx(ctx context.Context, fn func(device.Repos) error) error {
+	return db.InTx(ctx, s.pool, func(tx pgx.Tx) error {
+		return fn(device.Repos{DeviceToken: device.New(tx)})
+	})
+}
+
+func (s *testStore) Repos() device.Repos {
+	return device.Repos{DeviceToken: device.New(s.pool)}
+}
+
+func newTestRouter(t *testing.T) (*gin.Engine, *pgxpool.Pool) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pool := dbtest.NewPool(t)
+	u := device.NewUsecase(newTestStore(pool), push.NewNoopSender(testLogger()), testLogger())
+
+	r := gin.New()
+	device.NewHandler(u).RegisterRoutes(r, authn.Middleware(testClaimsParser{}))
+	return r, pool
+}
+
+func bearerToken(t *testing.T, userID, orgID, membershipID uuid.UUID, role tenant.Role) string {
+	t.Helper()
+	tok, err := accesstoken.Issue([]byte(testJWTSecret), 15*time.Minute, userID, orgID, membershipID, role)
+	if err != nil {
+		t.Fatalf("mint access token: %v", err)
+	}
+	return tok
+}
+
+func doJSON(r *gin.Engine, method, path, bearer string, body any) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(method, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// --- register ---
+
+func TestHandler_Register_EveryRoleAllowed(t *testing.T) {
+	for _, role := range []tenant.Role{tenant.RoleOwner, tenant.RoleAdmin, tenant.RoleManager, tenant.RoleEmployee} {
+		r, pool := newTestRouter(t)
+		ctx := context.Background()
+		org := seedOrganization(t, ctx, pool)
+		membershipID := seedMembership(t, ctx, pool, org, "actor-"+string(role)+"@example.com", role)
+		token := bearerToken(t, uuid.Must(uuid.NewV7()), org, membershipID, role)
+
+		w := doJSON(r, http.MethodPost, "/v1/device-tokens", token, map[string]string{
+			"token": "handler-test-token-" + string(role), "platform": "android",
+		})
+		if w.Code != http.StatusCreated {
+			t.Fatalf("role %s: expected 201, got %d: %s", role, w.Code, w.Body.String())
+		}
+
+		var body struct {
+			Data struct {
+				MembershipID string `json:"membership_id"`
+				Platform     string `json:"platform"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.Data.MembershipID != membershipID.String() {
+			t.Errorf("expected membership_id %s, got %s", membershipID, body.Data.MembershipID)
+		}
+		if body.Data.Platform != "android" {
+			t.Errorf("expected platform android, got %q", body.Data.Platform)
+		}
+		if bytes.Contains(w.Body.Bytes(), []byte("handler-test-token-"+string(role))) {
+			t.Error("expected the response to never echo the raw device token back (Rule #26)")
+		}
+	}
+}
+
+func TestHandler_Register_InvalidPlatform_Returns400(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+	membershipID := seedMembership(t, ctx, pool, org, "owner@example.com", tenant.RoleOwner)
+	token := bearerToken(t, uuid.Must(uuid.NewV7()), org, membershipID, tenant.RoleOwner)
+
+	w := doJSON(r, http.MethodPost, "/v1/device-tokens", token, map[string]string{
+		"token": "tok-1", "platform": "windows-phone",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandler_Register_Unauthenticated_Returns401(t *testing.T) {
+	r, _ := newTestRouter(t)
+	w := doJSON(r, http.MethodPost, "/v1/device-tokens", "", map[string]string{"token": "tok-1", "platform": "android"})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- unregister ---
+
+func TestHandler_Unregister_OwnToken_Returns204(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+	membershipID := seedMembership(t, ctx, pool, org, "employee@example.com", tenant.RoleEmployee)
+	token := bearerToken(t, uuid.Must(uuid.NewV7()), org, membershipID, tenant.RoleEmployee)
+
+	create := doJSON(r, http.MethodPost, "/v1/device-tokens", token, map[string]string{"token": "to-unregister", "platform": "android"})
+	if create.Code != http.StatusCreated {
+		t.Fatalf("setup: expected 201, got %d: %s", create.Code, create.Body.String())
+	}
+
+	del := doJSON(r, http.MethodDelete, "/v1/device-tokens", token, map[string]string{"token": "to-unregister"})
+	if del.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", del.Code, del.Body.String())
+	}
+}
+
+// TestHandler_Unregister_SomeoneElsesToken_Returns404 is the HTTP-level
+// proof of device.Usecase.Unregister's ownership check — same org,
+// different membership, must come back 404, never 403 (Rule #6's
+// reasoning, extended to cross-membership ownership).
+func TestHandler_Unregister_SomeoneElsesToken_Returns404(t *testing.T) {
+	r, pool := newTestRouter(t)
+	ctx := context.Background()
+	org := seedOrganization(t, ctx, pool)
+	victimMembership := seedMembership(t, ctx, pool, org, "victim@example.com", tenant.RoleEmployee)
+	victimToken := bearerToken(t, uuid.Must(uuid.NewV7()), org, victimMembership, tenant.RoleEmployee)
+	attackerMembership := seedMembership(t, ctx, pool, org, "attacker@example.com", tenant.RoleEmployee)
+	attackerToken := bearerToken(t, uuid.Must(uuid.NewV7()), org, attackerMembership, tenant.RoleEmployee)
+
+	create := doJSON(r, http.MethodPost, "/v1/device-tokens", victimToken, map[string]string{"token": "victim-device", "platform": "android"})
+	if create.Code != http.StatusCreated {
+		t.Fatalf("setup: expected 201, got %d: %s", create.Code, create.Body.String())
+	}
+
+	del := doJSON(r, http.MethodDelete, "/v1/device-tokens", attackerToken, map[string]string{"token": "victim-device"})
+	if del.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", del.Code, del.Body.String())
+	}
+}
+
+// seedOrganization/seedMembership are defined once, in repository_test.go
+// — shared by every *_test.go file in this package.

--- a/crm_be/internal/device/port.go
+++ b/crm_be/internal/device/port.go
@@ -1,0 +1,62 @@
+package device
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Repository is device_token's own table interface.
+type Repository interface {
+	// Upsert inserts tok, or — if tok.Token already identifies a row
+	// (uq_device_tokens_token is global, not per-organization) — MOVES
+	// that row to tok's organization_id/membership_id/platform and
+	// bumps last_seen_at. This is the mechanism behind "a device that
+	// changes hands gets re-registered, not duplicated" (migration
+	// 0006's comment on uq_device_tokens_token).
+	Upsert(ctx context.Context, t tenant.Context, tok *Token) error
+
+	// FindByToken is tenant-scoped by organization_id — a token
+	// registered under another organization is indistinguishable from
+	// one that doesn't exist (Rule #6), same as every other tenant-
+	// scoped FindByX in this codebase. Used by Usecase.Unregister to
+	// confirm ownership before deleting (see its doc comment).
+	FindByToken(ctx context.Context, t tenant.Context, token string) (*Token, error)
+
+	// FindByMembership returns every device currently registered for
+	// one membership — the fan-out list internal/lead's PushSender
+	// bridge sends to. Not scoped to the CALLER's own membership: the
+	// caller here is Usecase.PushToMembership, invoked with the
+	// ASSIGNING actor's tenant.Context on behalf of the RECIPIENT
+	// membership, which are frequently two different people.
+	FindByMembership(ctx context.Context, t tenant.Context, membershipID uuid.UUID) ([]*Token, error)
+
+	// DeleteByToken is tenant-scoped by organization_id only — NOT by
+	// membership_id. It has two callers with different membership
+	// contexts: Usecase.Unregister (which checks ownership itself
+	// first, in Go, because the caller's t.MembershipID and the
+	// token's owning membership must be compared as data, not baked
+	// into the WHERE clause) and Usecase.PushToMembership's cleanup
+	// path (which already knows the token belongs to the recipient
+	// membership because it was just read via FindByMembership for
+	// that exact membership — adding a second membership filter here
+	// would just repeat a check already made).
+	DeleteByToken(ctx context.Context, t tenant.Context, token string) error
+}
+
+// Repos bundles what a single Usecase call needs.
+type Repos struct {
+	DeviceToken Repository
+}
+
+// Store is the Unit of Work Usecase depends on — same shape as every
+// other domain's since ADR-011. Every method here is a single
+// statement, but the pattern is kept identical to every other domain
+// rather than special-cased away, matching how apikey (issue #46) —
+// also entirely single-statement operations — still exposes Store.
+type Store interface {
+	InTx(ctx context.Context, fn func(Repos) error) error
+	Repos() Repos
+}

--- a/crm_be/internal/device/repository_postgres.go
+++ b/crm_be/internal/device/repository_postgres.go
@@ -21,8 +21,7 @@ func New(q db.Querier) Repository {
 	return &postgresRepository{q: q}
 }
 
-const deviceTokenColumns = `
-	id, organization_id, membership_id, token, platform, created_at, last_seen_at`
+const deviceTokenColumns = `id, organization_id, membership_id, token, platform, created_at, last_seen_at` // #nosec G101 -- a SQL column list, not a credential; gosec's identifier heuristic matches "deviceTokenColumns" as a name
 
 // Upsert relies on uq_device_tokens_token — the same physical device
 // registering again (app reopened, token refreshed by FCM, or the

--- a/crm_be/internal/device/repository_postgres.go
+++ b/crm_be/internal/device/repository_postgres.go
@@ -1,0 +1,127 @@
+package device
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+type postgresRepository struct {
+	q db.Querier
+}
+
+func New(q db.Querier) Repository {
+	return &postgresRepository{q: q}
+}
+
+const deviceTokenColumns = `
+	id, organization_id, membership_id, token, platform, created_at, last_seen_at`
+
+// Upsert relies on uq_device_tokens_token — the same physical device
+// registering again (app reopened, token refreshed by FCM, or the
+// device handed to a different employee) updates the existing row in
+// place rather than erroring or creating a duplicate. id is generated
+// fresh by the caller but only used on the INSERT branch; ON CONFLICT
+// keeps the existing row's id, which is correct — nothing external
+// references a device_tokens.id, so it moving would cost nothing, but
+// keeping it stable costs nothing either and is simpler to reason
+// about.
+func (r *postgresRepository) Upsert(ctx context.Context, t tenant.Context, tok *Token) error {
+	const q = `
+		INSERT INTO device_tokens (id, organization_id, membership_id, token, platform)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (token) DO UPDATE SET
+			organization_id = EXCLUDED.organization_id,
+			membership_id   = EXCLUDED.membership_id,
+			platform        = EXCLUDED.platform,
+			last_seen_at    = now()
+		RETURNING id, created_at, last_seen_at`
+
+	err := r.q.QueryRow(ctx, q,
+		tok.ID, t.OrganizationID, tok.MembershipID, tok.Token, tok.Platform,
+	).Scan(&tok.ID, &tok.CreatedAt, &tok.LastSeenAt)
+	if err != nil {
+		return fmt.Errorf("device: upsert: %w", err)
+	}
+	tok.OrganizationID = t.OrganizationID
+	return nil
+}
+
+func (r *postgresRepository) FindByToken(ctx context.Context, t tenant.Context, token string) (*Token, error) {
+	const q = `
+		SELECT ` + deviceTokenColumns + `
+		FROM device_tokens
+		WHERE token = $1 AND organization_id = $2`
+
+	tok, err := scanRow(r.q.QueryRow(ctx, q, token, t.OrganizationID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, httpx.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("device: find by token: %w", err)
+	}
+	return tok, nil
+}
+
+func (r *postgresRepository) FindByMembership(ctx context.Context, t tenant.Context, membershipID uuid.UUID) ([]*Token, error) {
+	const q = `
+		SELECT ` + deviceTokenColumns + `
+		FROM device_tokens
+		WHERE organization_id = $1 AND membership_id = $2`
+
+	rows, err := r.q.Query(ctx, q, t.OrganizationID, membershipID)
+	if err != nil {
+		return nil, fmt.Errorf("device: find by membership: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*Token
+	for rows.Next() {
+		tok, err := scanRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("device: scan: %w", err)
+		}
+		out = append(out, tok)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("device: find by membership: %w", err)
+	}
+	return out, nil
+}
+
+// DeleteByToken is deliberately NOT idempotent-by-design the way
+// apikey.Revoke is — zero rows affected is never checked here at all
+// (unlike Revoke, which distinguishes "already revoked" from "gone").
+// A device token that's already gone by the time this runs (unregistered
+// twice, or cleaned up by the push path a moment earlier) is exactly the
+// same successful outcome either way: the token doesn't exist anymore.
+func (r *postgresRepository) DeleteByToken(ctx context.Context, t tenant.Context, token string) error {
+	const q = `DELETE FROM device_tokens WHERE token = $1 AND organization_id = $2`
+	if _, err := r.q.Exec(ctx, q, token, t.OrganizationID); err != nil {
+		return fmt.Errorf("device: delete by token: %w", err)
+	}
+	return nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanRow(row rowScanner) (*Token, error) {
+	var tok Token
+	err := row.Scan(
+		&tok.ID, &tok.OrganizationID, &tok.MembershipID, &tok.Token, &tok.Platform,
+		&tok.CreatedAt, &tok.LastSeenAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &tok, nil
+}

--- a/crm_be/internal/device/repository_test.go
+++ b/crm_be/internal/device/repository_test.go
@@ -1,0 +1,233 @@
+package device_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/device"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/db/dbtest"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+func newTestToken(membershipID uuid.UUID, token string) *device.Token {
+	return &device.Token{
+		ID:           uuid.Must(uuid.NewV7()),
+		MembershipID: membershipID,
+		Token:        token,
+		Platform:     "android",
+	}
+}
+
+func TestRepository_Upsert_CreatesNewRow(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := device.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	membershipID := seedMembership(t, ctx, pool, org, "budi@example.com", tenant.RoleEmployee)
+	tc := tenant.Context{OrganizationID: org, MembershipID: &membershipID, Role: tenant.RoleEmployee}
+
+	tok := newTestToken(membershipID, "fcm-token-abc")
+	if err := repo.Upsert(ctx, tc, tok); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if tok.CreatedAt.IsZero() || tok.LastSeenAt.IsZero() {
+		t.Error("expected CreatedAt/LastSeenAt to be populated after upsert")
+	}
+
+	found, err := repo.FindByToken(ctx, tc, "fcm-token-abc")
+	if err != nil {
+		t.Fatalf("find by token: %v", err)
+	}
+	if found.MembershipID != membershipID || found.Platform != "android" {
+		t.Errorf("unexpected round-tripped token: %+v", found)
+	}
+}
+
+// TestRepository_Upsert_SameToken_MovesRowToNewOwner is migration
+// 0006's own comment, proven: a device that changes hands (employee
+// resigns, a new employee logs in on the same physical phone) gets its
+// existing row REPOINTED to the new organization/membership, not
+// duplicated — because uq_device_tokens_token is unique globally.
+func TestRepository_Upsert_SameToken_MovesRowToNewOwner(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := device.New(pool)
+
+	orgA := seedOrganization(t, ctx, pool)
+	memberA := seedMembership(t, ctx, pool, orgA, "old-employee@example.com", tenant.RoleEmployee)
+	tcA := tenant.Context{OrganizationID: orgA, MembershipID: &memberA, Role: tenant.RoleEmployee}
+
+	first := newTestToken(memberA, "shared-device-token")
+	if err := repo.Upsert(ctx, tcA, first); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	firstID := first.ID
+
+	orgB := seedOrganization(t, ctx, pool)
+	memberB := seedMembership(t, ctx, pool, orgB, "new-employee@example.com", tenant.RoleEmployee)
+	tcB := tenant.Context{OrganizationID: orgB, MembershipID: &memberB, Role: tenant.RoleEmployee}
+
+	second := newTestToken(memberB, "shared-device-token") // same token value
+	if err := repo.Upsert(ctx, tcB, second); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	// Old organization must no longer see this token at all — Rule #6,
+	// and the whole point of the move.
+	if _, err := repo.FindByToken(ctx, tcA, "shared-device-token"); err != httpx.ErrNotFound {
+		t.Errorf("expected old organization to no longer find the moved token, got err=%v", err)
+	}
+
+	found, err := repo.FindByToken(ctx, tcB, "shared-device-token")
+	if err != nil {
+		t.Fatalf("find by token (new owner): %v", err)
+	}
+	if found.MembershipID != memberB {
+		t.Errorf("expected token to belong to new membership %s, got %s", memberB, found.MembershipID)
+	}
+	if found.ID != firstID {
+		t.Errorf("expected the SAME row (id unchanged) to be repointed, got a different id — this means a duplicate row exists")
+	}
+
+	rows, err := pool.Query(ctx, `SELECT count(*) FROM device_tokens WHERE token = $1`, "shared-device-token")
+	if err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	defer rows.Close()
+	var count int
+	if rows.Next() {
+		_ = rows.Scan(&count)
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 row for this token globally, got %d — upsert produced a duplicate", count)
+	}
+}
+
+func TestRepository_FindByToken_CrossOrg_ReturnsNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := device.New(pool)
+
+	orgA := seedOrganization(t, ctx, pool)
+	memberA := seedMembership(t, ctx, pool, orgA, "a@example.com", tenant.RoleEmployee)
+	tcA := tenant.Context{OrganizationID: orgA, MembershipID: &memberA, Role: tenant.RoleEmployee}
+	if err := repo.Upsert(ctx, tcA, newTestToken(memberA, "cross-org-token")); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	orgB := seedOrganization(t, ctx, pool)
+	tcB := tenant.Context{OrganizationID: orgB, Role: tenant.RoleOwner}
+
+	if _, err := repo.FindByToken(ctx, tcB, "cross-org-token"); err != httpx.ErrNotFound {
+		t.Errorf("expected httpx.ErrNotFound for a token belonging to another organization, got %v", err)
+	}
+}
+
+func TestRepository_FindByMembership_ReturnsOnlyThatMembersTokens(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := device.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	memberA := seedMembership(t, ctx, pool, org, "member-a@example.com", tenant.RoleEmployee)
+	memberB := seedMembership(t, ctx, pool, org, "member-b@example.com", tenant.RoleEmployee)
+	tc := tenant.Context{OrganizationID: org, Role: tenant.RoleOwner}
+
+	if err := repo.Upsert(ctx, tc, newTestToken(memberA, "token-a-1")); err != nil {
+		t.Fatalf("upsert a1: %v", err)
+	}
+	if err := repo.Upsert(ctx, tc, newTestToken(memberA, "token-a-2")); err != nil {
+		t.Fatalf("upsert a2: %v", err)
+	}
+	if err := repo.Upsert(ctx, tc, newTestToken(memberB, "token-b-1")); err != nil {
+		t.Fatalf("upsert b1: %v", err)
+	}
+
+	found, err := repo.FindByMembership(ctx, tc, memberA)
+	if err != nil {
+		t.Fatalf("find by membership: %v", err)
+	}
+	if len(found) != 2 {
+		t.Fatalf("expected 2 tokens for memberA, got %d", len(found))
+	}
+	for _, tok := range found {
+		if tok.MembershipID != memberA {
+			t.Errorf("expected every result to belong to memberA, got %s", tok.MembershipID)
+		}
+	}
+}
+
+func TestRepository_DeleteByToken_RemovesRow(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := device.New(pool)
+
+	org := seedOrganization(t, ctx, pool)
+	memberID := seedMembership(t, ctx, pool, org, "d@example.com", tenant.RoleEmployee)
+	tc := tenant.Context{OrganizationID: org, MembershipID: &memberID, Role: tenant.RoleEmployee}
+
+	if err := repo.Upsert(ctx, tc, newTestToken(memberID, "to-delete")); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := repo.DeleteByToken(ctx, tc, "to-delete"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := repo.FindByToken(ctx, tc, "to-delete"); err != httpx.ErrNotFound {
+		t.Errorf("expected token to be gone after delete, got err=%v", err)
+	}
+}
+
+// TestRepository_DeleteByToken_CrossOrg_DoesNotDelete is the repository-
+// level half of the tenant isolation this issue's harness case also
+// proves at the HTTP layer (cmd/api/tenant_isolation_test.go) — a
+// delete scoped to the WRONG organization must affect zero rows, not
+// the real one belonging to someone else.
+func TestRepository_DeleteByToken_CrossOrg_DoesNotDelete(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.NewPool(t)
+	repo := device.New(pool)
+
+	orgA := seedOrganization(t, ctx, pool)
+	memberA := seedMembership(t, ctx, pool, orgA, "victim@example.com", tenant.RoleEmployee)
+	tcA := tenant.Context{OrganizationID: orgA, MembershipID: &memberA, Role: tenant.RoleEmployee}
+	if err := repo.Upsert(ctx, tcA, newTestToken(memberA, "victim-token")); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	orgB := seedOrganization(t, ctx, pool)
+	tcB := tenant.Context{OrganizationID: orgB, Role: tenant.RoleOwner}
+	if err := repo.DeleteByToken(ctx, tcB, "victim-token"); err != nil {
+		t.Fatalf("delete (should be a no-op, not an error): %v", err)
+	}
+
+	if _, err := repo.FindByToken(ctx, tcA, "victim-token"); err != nil {
+		t.Errorf("expected victim's token to still exist after a cross-org delete attempt, got err=%v", err)
+	}
+}
+
+func seedOrganization(t *testing.T, ctx context.Context, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	id := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name) VALUES ($1, 'Test Org')`, id); err != nil {
+		t.Fatalf("failed to seed organization: %v", err)
+	}
+	return id
+}
+
+func seedMembership(t *testing.T, ctx context.Context, pool *pgxpool.Pool, org uuid.UUID, email string, role tenant.Role) uuid.UUID {
+	t.Helper()
+	userID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, password_hash, full_name) VALUES ($1, $2, 'x', 'Test User')`, userID, email); err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+	membershipID := uuid.Must(uuid.NewV7())
+	if _, err := pool.Exec(ctx, `INSERT INTO memberships (id, organization_id, user_id, role) VALUES ($1, $2, $3, $4)`, membershipID, org, userID, role); err != nil {
+		t.Fatalf("failed to seed membership: %v", err)
+	}
+	return membershipID
+}

--- a/crm_be/internal/device/usecase.go
+++ b/crm_be/internal/device/usecase.go
@@ -1,0 +1,127 @@
+package device
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/authz"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/push"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// Usecase depends only on Store (port.go) and push.Sender — never on
+// *pgxpool.Pool or pgx.Tx directly (ADR-011).
+type Usecase struct {
+	store  Store
+	sender push.Sender
+	logger *slog.Logger
+}
+
+func NewUsecase(store Store, sender push.Sender, logger *slog.Logger) *Usecase {
+	return &Usecase{store: store, sender: sender, logger: logger}
+}
+
+type RegisterInput struct {
+	Token    string
+	Platform string
+}
+
+// Register upserts the calling device's token (see Repository.Upsert's
+// doc comment for what "upsert" means here — a re-registration MOVES
+// the row to the caller's current organization/membership rather than
+// erroring).
+func (u *Usecase) Register(ctx context.Context, t tenant.Context, in RegisterInput) (*Token, error) {
+	if err := authz.Require(t, authz.ActionDeviceTokenRegister); err != nil {
+		return nil, err
+	}
+	if in.Token == "" {
+		return nil, httpx.NewValidationError(httpx.ErrorDetail{Field: "token", Code: "required"})
+	}
+	if !IsValidPlatform(in.Platform) {
+		return nil, httpx.NewValidationError(httpx.ErrorDetail{Field: "platform", Code: "invalid_value"})
+	}
+
+	tok := &Token{
+		ID:           uuid.Must(uuid.NewV7()),
+		MembershipID: *t.MembershipID,
+		Token:        in.Token,
+		Platform:     in.Platform,
+	}
+	if err := u.store.Repos().DeviceToken.Upsert(ctx, t, tok); err != nil {
+		return nil, fmt.Errorf("device: register: %w", err)
+	}
+	return tok, nil
+}
+
+// Unregister removes the caller's own device token — called on logout
+// (Phase 5 TD §9.1). Ownership is checked here, in Go, rather than
+// folded into DeleteByToken's SQL: FindByToken is scoped to the caller's
+// organization only (Rule #6), and a token that DOES exist in this
+// organization but belongs to a DIFFERENT membership is treated
+// identically to one that doesn't exist at all — 404, never 403 — so a
+// client can't learn anything about who else has a device registered.
+func (u *Usecase) Unregister(ctx context.Context, t tenant.Context, token string) error {
+	if err := authz.Require(t, authz.ActionDeviceTokenDelete); err != nil {
+		return err
+	}
+	found, err := u.store.Repos().DeviceToken.FindByToken(ctx, t, token)
+	if err != nil {
+		return err // httpx.ErrNotFound for cross-org or missing
+	}
+	if t.MembershipID == nil || found.MembershipID != *t.MembershipID {
+		return httpx.ErrNotFound
+	}
+	if err := u.store.Repos().DeviceToken.DeleteByToken(ctx, t, token); err != nil {
+		return fmt.Errorf("device: unregister: %w", err)
+	}
+	return nil
+}
+
+// PushToMembership structurally satisfies lead.PushSender (ADR-011: the
+// interface is declared by its consumer, lead, not here — lead never
+// imports this package). Called AFTER lead's own transaction has
+// already committed (Phase 5 TD §9.3, Rule #32) — every failure path
+// below is logged and swallowed, never returned in a way that could
+// look like something worth retrying at that call site.
+//
+// t carries the ASSIGNING actor's tenant.Context (Owner/Admin/Manager
+// doing the reassignment); membershipID is the RECIPIENT, almost always
+// a different person. Only t.OrganizationID is used for scoping — no
+// method here touches t.MembershipID.
+func (u *Usecase) PushToMembership(ctx context.Context, t tenant.Context, membershipID uuid.UUID, title, body string, data map[string]string) error {
+	tokens, err := u.store.Repos().DeviceToken.FindByMembership(ctx, t, membershipID)
+	if err != nil {
+		u.logger.Error("failed to look up device tokens", "err", err, "membership_id", membershipID)
+		return err
+	}
+
+	for _, tok := range tokens {
+		sendErr := u.sender.Send(ctx, push.Message{Token: tok.Token, Title: title, Body: body, Data: data})
+		if sendErr == nil {
+			continue
+		}
+
+		// Rule #26: never log tok.Token itself — only which membership
+		// and what happened, the same shape mailer.Send's own failure
+		// log uses (logs "to", never the message body).
+		u.logger.Error("failed to send push notification", "err", sendErr, "membership_id", membershipID)
+
+		if errors.Is(sendErr, push.ErrTokenInvalid) {
+			// TD §9.4, kriteria #12 — a token FCM will never accept
+			// again must actually be removed, or this table only grows
+			// (the same class of debt Phase 4.5 closed for
+			// ratelimit.FixedWindow). Deletion failure is logged but
+			// still not propagated — one token's cleanup failing must
+			// never stop the loop from reaching the rest.
+			if delErr := u.store.Repos().DeviceToken.DeleteByToken(ctx, t, tok.Token); delErr != nil {
+				u.logger.Error("failed to delete unregistered device token", "err", delErr, "membership_id", membershipID)
+			}
+		}
+	}
+	return nil
+}

--- a/crm_be/internal/device/usecase_unit_test.go
+++ b/crm_be/internal/device/usecase_unit_test.go
@@ -1,0 +1,299 @@
+package device_test
+
+// TestUnit_* tests prove Usecase is decoupled from PostgreSQL (ADR-011) —
+// fake Store, no Docker. Run in isolation with:
+//
+//	go test ./internal/device/... -run TestUnit
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/Pravasta/jualin-crm/crm_be/internal/device"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/httpx"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/push"
+	"github.com/Pravasta/jualin-crm/crm_be/internal/shared/tenant"
+)
+
+// --- fakes ---
+
+type fakeDeviceRepo struct {
+	byToken map[string]*device.Token
+	deleted []string
+}
+
+func newFakeDeviceRepo() *fakeDeviceRepo {
+	return &fakeDeviceRepo{byToken: map[string]*device.Token{}}
+}
+
+func (f *fakeDeviceRepo) Upsert(_ context.Context, t tenant.Context, tok *device.Token) error {
+	tok.OrganizationID = t.OrganizationID
+	f.byToken[tok.Token] = tok
+	return nil
+}
+
+func (f *fakeDeviceRepo) FindByToken(_ context.Context, t tenant.Context, token string) (*device.Token, error) {
+	tok, ok := f.byToken[token]
+	if !ok || tok.OrganizationID != t.OrganizationID {
+		return nil, httpx.ErrNotFound
+	}
+	return tok, nil
+}
+
+func (f *fakeDeviceRepo) FindByMembership(_ context.Context, t tenant.Context, membershipID uuid.UUID) ([]*device.Token, error) {
+	var out []*device.Token
+	for _, tok := range f.byToken {
+		if tok.OrganizationID == t.OrganizationID && tok.MembershipID == membershipID {
+			out = append(out, tok)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeDeviceRepo) DeleteByToken(_ context.Context, t tenant.Context, token string) error {
+	tok, ok := f.byToken[token]
+	if !ok || tok.OrganizationID != t.OrganizationID {
+		return nil // matches postgresRepository.DeleteByToken: not-found is not an error
+	}
+	delete(f.byToken, token)
+	f.deleted = append(f.deleted, token)
+	return nil
+}
+
+type fakeStore struct {
+	repo *fakeDeviceRepo
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{repo: newFakeDeviceRepo()}
+}
+
+func (s *fakeStore) InTx(_ context.Context, fn func(device.Repos) error) error {
+	return fn(device.Repos{DeviceToken: s.repo})
+}
+func (s *fakeStore) Repos() device.Repos {
+	return device.Repos{DeviceToken: s.repo}
+}
+
+// fakeSender records every Send call and returns whatever this test
+// queued up for that token — never touches a network.
+type fakeSender struct {
+	results map[string]error // token -> error to return (nil key never set = success)
+	calls   []push.Message
+}
+
+func newFakeSender() *fakeSender {
+	return &fakeSender{results: map[string]error{}}
+}
+
+func (f *fakeSender) Send(_ context.Context, msg push.Message) error {
+	f.calls = append(f.calls, msg)
+	return f.results[msg.Token]
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func actorContext(orgID, membershipID uuid.UUID, role tenant.Role) tenant.Context {
+	return tenant.Context{OrganizationID: orgID, PrincipalType: tenant.PrincipalUser, MembershipID: &membershipID, Role: role}
+}
+
+// --- Register ---
+
+func TestUnit_Register_EveryRoleAllowed(t *testing.T) {
+	for _, role := range []tenant.Role{tenant.RoleOwner, tenant.RoleAdmin, tenant.RoleManager, tenant.RoleEmployee} {
+		t.Run(string(role), func(t *testing.T) {
+			u := device.NewUsecase(newFakeStore(), newFakeSender(), testLogger())
+			org := uuid.Must(uuid.NewV7())
+			tc := actorContext(org, uuid.Must(uuid.NewV7()), role)
+
+			tok, err := u.Register(context.Background(), tc, device.RegisterInput{Token: "tok-1", Platform: "android"})
+			if err != nil {
+				t.Fatalf("expected role %s to be allowed to register, got error: %v", role, err)
+			}
+			if tok.Platform != "android" {
+				t.Errorf("expected platform android, got %s", tok.Platform)
+			}
+		})
+	}
+}
+
+func TestUnit_Register_EmptyToken_Returns400(t *testing.T) {
+	u := device.NewUsecase(newFakeStore(), newFakeSender(), testLogger())
+	tc := actorContext(uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	_, err := u.Register(context.Background(), tc, device.RegisterInput{Token: "", Platform: "android"})
+	var ve *httpx.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected a validation error for empty token, got %v", err)
+	}
+}
+
+func TestUnit_Register_InvalidPlatform_Returns400(t *testing.T) {
+	u := device.NewUsecase(newFakeStore(), newFakeSender(), testLogger())
+	tc := actorContext(uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	_, err := u.Register(context.Background(), tc, device.RegisterInput{Token: "tok-1", Platform: "windows-phone"})
+	var ve *httpx.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected a validation error for an invalid platform, got %v", err)
+	}
+}
+
+// --- Unregister ---
+
+func TestUnit_Unregister_OwnToken_Succeeds(t *testing.T) {
+	store := newFakeStore()
+	u := device.NewUsecase(store, newFakeSender(), testLogger())
+	org := uuid.Must(uuid.NewV7())
+	membershipID := uuid.Must(uuid.NewV7())
+	tc := actorContext(org, membershipID, tenant.RoleEmployee)
+
+	if _, err := u.Register(context.Background(), tc, device.RegisterInput{Token: "own-token", Platform: "android"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := u.Unregister(context.Background(), tc, "own-token"); err != nil {
+		t.Fatalf("unregister: %v", err)
+	}
+	if len(store.repo.deleted) != 1 || store.repo.deleted[0] != "own-token" {
+		t.Errorf("expected own-token to be deleted, got deletions: %v", store.repo.deleted)
+	}
+}
+
+// TestUnit_Unregister_SomeoneElsesToken_Returns404NotForbidden is the
+// direct behavior device.Usecase.Unregister's doc comment describes:
+// a token that exists in this organization but belongs to a DIFFERENT
+// membership is treated exactly like one that doesn't exist — 404, not
+// 403 — so a client can't learn who else has a device registered
+// (Rule #6's reasoning, extended from cross-org to cross-membership
+// ownership within the same org).
+func TestUnit_Unregister_SomeoneElsesToken_Returns404NotForbidden(t *testing.T) {
+	store := newFakeStore()
+	u := device.NewUsecase(store, newFakeSender(), testLogger())
+	org := uuid.Must(uuid.NewV7())
+	victim := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+	attacker := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	if _, err := u.Register(context.Background(), victim, device.RegisterInput{Token: "victim-token", Platform: "android"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	err := u.Unregister(context.Background(), attacker, "victim-token")
+	if err != httpx.ErrNotFound {
+		t.Errorf("expected httpx.ErrNotFound, got %v", err)
+	}
+	if len(store.repo.deleted) != 0 {
+		t.Errorf("expected victim's token to survive an unregister attempt by someone else, got deletions: %v", store.repo.deleted)
+	}
+}
+
+func TestUnit_Unregister_UnknownToken_Returns404(t *testing.T) {
+	u := device.NewUsecase(newFakeStore(), newFakeSender(), testLogger())
+	tc := actorContext(uuid.Must(uuid.NewV7()), uuid.Must(uuid.NewV7()), tenant.RoleEmployee)
+
+	err := u.Unregister(context.Background(), tc, "never-registered")
+	if err != httpx.ErrNotFound {
+		t.Errorf("expected httpx.ErrNotFound, got %v", err)
+	}
+}
+
+// --- PushToMembership ---
+
+func TestUnit_PushToMembership_SendsToEveryRegisteredDevice(t *testing.T) {
+	store := newFakeStore()
+	sender := newFakeSender()
+	u := device.NewUsecase(store, sender, testLogger())
+	org := uuid.Must(uuid.NewV7())
+	recipient := uuid.Must(uuid.NewV7())
+
+	regCtx := actorContext(org, recipient, tenant.RoleEmployee)
+	if _, err := u.Register(context.Background(), regCtx, device.RegisterInput{Token: "device-1", Platform: "android"}); err != nil {
+		t.Fatalf("register device-1: %v", err)
+	}
+	if _, err := u.Register(context.Background(), regCtx, device.RegisterInput{Token: "device-2", Platform: "android"}); err != nil {
+		t.Fatalf("register device-2: %v", err)
+	}
+
+	actor := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleOwner) // a DIFFERENT person doing the assigning
+	if err := u.PushToMembership(context.Background(), actor, recipient, "title", "body", nil); err != nil {
+		t.Fatalf("PushToMembership: %v", err)
+	}
+
+	if len(sender.calls) != 2 {
+		t.Fatalf("expected 2 push sends (one per device), got %d", len(sender.calls))
+	}
+}
+
+// TestUnit_PushToMembership_UnregisteredToken_IsDeleted is Phase 5
+// TD §9.4, kriteria #12's direct proof: a token FCM says will never
+// work again must actually be removed.
+func TestUnit_PushToMembership_UnregisteredToken_IsDeleted(t *testing.T) {
+	store := newFakeStore()
+	sender := newFakeSender()
+	sender.results["dead-token"] = push.ErrTokenInvalid
+	u := device.NewUsecase(store, sender, testLogger())
+	org := uuid.Must(uuid.NewV7())
+	recipient := uuid.Must(uuid.NewV7())
+
+	regCtx := actorContext(org, recipient, tenant.RoleEmployee)
+	if _, err := u.Register(context.Background(), regCtx, device.RegisterInput{Token: "dead-token", Platform: "android"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	actor := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+	if err := u.PushToMembership(context.Background(), actor, recipient, "t", "b", nil); err != nil {
+		t.Fatalf("PushToMembership: %v", err)
+	}
+
+	if len(store.repo.deleted) != 1 || store.repo.deleted[0] != "dead-token" {
+		t.Errorf("expected dead-token to be deleted after an UNREGISTERED-class send failure, got deletions: %v", store.repo.deleted)
+	}
+}
+
+// TestUnit_PushToMembership_TransientError_TokenIsKept proves the
+// opposite of the test above: a transient send failure must NOT delete
+// anything, or a momentary FCM/network hiccup would silently and
+// permanently disable a real user's push.
+func TestUnit_PushToMembership_TransientError_TokenIsKept(t *testing.T) {
+	store := newFakeStore()
+	sender := newFakeSender()
+	sender.results["flaky-token"] = errors.New("push: fcm returned 500: internal error")
+	u := device.NewUsecase(store, sender, testLogger())
+	org := uuid.Must(uuid.NewV7())
+	recipient := uuid.Must(uuid.NewV7())
+
+	regCtx := actorContext(org, recipient, tenant.RoleEmployee)
+	if _, err := u.Register(context.Background(), regCtx, device.RegisterInput{Token: "flaky-token", Platform: "android"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	actor := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+	if err := u.PushToMembership(context.Background(), actor, recipient, "t", "b", nil); err != nil {
+		t.Fatalf("PushToMembership: %v", err)
+	}
+
+	if len(store.repo.deleted) != 0 {
+		t.Errorf("expected flaky-token to survive a transient send error, got deletions: %v", store.repo.deleted)
+	}
+}
+
+// TestUnit_PushToMembership_NoDevicesRegistered_DoesNotError covers the
+// common case: an employee who has never opened the mobile app. Freeze
+// A3 — the notification row is already the source of truth by the time
+// this runs; a recipient with zero devices must not look like a
+// failure at this call site.
+func TestUnit_PushToMembership_NoDevicesRegistered_DoesNotError(t *testing.T) {
+	u := device.NewUsecase(newFakeStore(), newFakeSender(), testLogger())
+	org := uuid.Must(uuid.NewV7())
+	actor := actorContext(org, uuid.Must(uuid.NewV7()), tenant.RoleOwner)
+
+	if err := u.PushToMembership(context.Background(), actor, uuid.Must(uuid.NewV7()), "t", "b", nil); err != nil {
+		t.Errorf("expected no error when the recipient has no registered devices, got %v", err)
+	}
+}

--- a/crm_be/internal/lead/port.go
+++ b/crm_be/internal/lead/port.go
@@ -56,13 +56,32 @@ type NotificationSender interface {
 	Notify(ctx context.Context, t tenant.Context, recipientMembershipID uuid.UUID, notifType string, leadID, taskID *uuid.UUID, title string, body *string) error
 }
 
+// PushSender is declared locally per ADR-011, bridged the same way as
+// NotificationSender — lead needs only to push to one membership's
+// registered devices, not device's full domain type. Satisfied by
+// device.NewUsecase's return value at the composition root (Phase 5
+// TD §9.3). Deliberately part of Repos, not a NewUsecase parameter: the
+// call happens AFTER InTx commits (Rule #32), reading Repos() a second
+// time outside the transaction, same as every other read-after-write
+// use of Store.Repos() in this codebase — not because it needs a
+// transaction, but so it doesn't require every existing
+// NewUsecase(store) call site (~20 across this package's tests) to
+// also supply a push dependency they never exercise.
+type PushSender interface {
+	PushToMembership(ctx context.Context, t tenant.Context, membershipID uuid.UUID, title, body string, data map[string]string) error
+}
+
 // Repos bundles what a single Usecase call needs. Activity was added in
 // #21 when lead events first needed cross-table atomicity with activity
 // rows (TD §10). Notification was added in #22 for assignment (TD §11).
+// Push was added in Phase 5 #68 — deliberately optional (nil is a valid
+// zero value here, checked by the one caller that reads it) since it's
+// consulted OUTSIDE any transaction, unlike the other three fields.
 type Repos struct {
 	Lead         Repository
 	Activity     ActivityRecorder
 	Notification NotificationSender
+	Push         PushSender
 }
 
 // Store is the Unit of Work Usecase depends on — same shape as every

--- a/crm_be/internal/lead/usecase.go
+++ b/crm_be/internal/lead/usecase.go
@@ -302,6 +302,13 @@ func (u *Usecase) UpdateAssignment(ctx context.Context, t tenant.Context, id uui
 
 	var updated *Lead
 	var conflict bool
+	// pushRecipient is set inside the closure only when a real,
+	// non-self assignment notification was recorded — the same
+	// condition Notify itself is gated on below. Read after InTx
+	// returns to fire the push OUTSIDE the transaction (Phase 5 TD §9.3,
+	// keputusan M5, Rule #32) — a push failure must never roll back an
+	// assignment that already committed.
+	var pushRecipient *uuid.UUID
 	txErr := u.store.InTx(ctx, func(r Repos) error {
 		current, err := r.Lead.FindByID(ctx, t, id)
 		if err != nil {
@@ -330,10 +337,14 @@ func (u *Usecase) UpdateAssignment(ctx context.Context, t tenant.Context, id uui
 		}
 
 		if t.MembershipID != nil && newAssignee == *t.MembershipID {
-			return nil // self-assignment — no notification
+			return nil // self-assignment — no notification, no push
 		}
 		title := fmt.Sprintf("Lead #%d ditugaskan kepada Anda", updated.LeadNumber)
-		return r.Notification.Notify(ctx, t, newAssignee, "lead_assigned", &id, nil, title, &updated.Name)
+		if err := r.Notification.Notify(ctx, t, newAssignee, "lead_assigned", &id, nil, title, &updated.Name); err != nil {
+			return err
+		}
+		pushRecipient = &newAssignee
+		return nil
 	})
 	if conflict {
 		return nil, &VersionConflictError{Current: updated}
@@ -344,7 +355,37 @@ func (u *Usecase) UpdateAssignment(ctx context.Context, t tenant.Context, id uui
 	if txErr != nil {
 		return nil, txErr
 	}
+
+	if pushRecipient != nil {
+		u.pushAssignmentNotification(ctx, t, *pushRecipient, updated)
+	}
 	return updated, nil
+}
+
+// pushAssignmentNotification sends a best-effort push AFTER the
+// notification record and activity above have already committed
+// (Rule #32; freeze A3: the notification row is the source of truth,
+// push is only a delivery attempt). Repos().Push may be nil — most
+// existing tests build a Repos literal with only Lead/Activity/
+// Notification set, and Push is deliberately not required alongside
+// them (Phase 5 TD §9.3: bridged the same way as NotificationRecorder,
+// not threaded through NewUsecase, so it never touches those call
+// sites). A missing bridge here just means no push is attempted, same
+// externally-visible effect as PUSH_PROVIDER=none.
+func (u *Usecase) pushAssignmentNotification(ctx context.Context, t tenant.Context, membershipID uuid.UUID, l *Lead) {
+	push := u.store.Repos().Push
+	if push == nil {
+		return
+	}
+	title := fmt.Sprintf("Lead #%d ditugaskan kepada Anda", l.LeadNumber)
+	data := map[string]string{"type": "lead_assigned", "lead_id": l.ID.String()}
+	// Error discarded deliberately: device.Usecase already logs the
+	// failure structurally (Phase 5 TD §9.5) — logging it again here
+	// would duplicate the entry without adding information, and lead
+	// has no logger field of its own (adding one would mean every
+	// existing NewUsecase(store) call site across ~20 test files needs
+	// updating for a dependency those tests never exercise).
+	_ = push.PushToMembership(ctx, t, membershipID, title, l.Name, data)
 }
 
 func (u *Usecase) Delete(ctx context.Context, t tenant.Context, id uuid.UUID) error {

--- a/crm_be/internal/shared/authz/authz.go
+++ b/crm_be/internal/shared/authz/authz.go
@@ -99,8 +99,8 @@ const (
 	// do" is #47's apiKeyScopeFor, which deliberately excludes all three
 	// of these (Rule #24: an API key cannot create another API key).
 	ActionAPIKeyCreate Action = "api_key.create"
-	ActionAPIKeyList   Action = "api_key.list"
-	ActionAPIKeyRevoke Action = "api_key.revoke"
+	ActionAPIKeyList   Action = "api_key.list"   // #nosec G101 -- an RBAC action name, not a credential; gosec's identifier heuristic matches "APIKey" in the const name
+	ActionAPIKeyRevoke Action = "api_key.revoke" // #nosec G101 -- same false positive as ActionAPIKeyList above
 
 	// ActionDeviceTokenRegister/Delete (Phase 5 #68) are granted to
 	// EVERY role, Owner through Employee — unlike api_key.*, which is
@@ -109,7 +109,7 @@ const (
 	// data; Owner and Admin use the dashboard today, but nothing stops
 	// either of them from installing the mobile app too, and there's no
 	// security reason to make them the exception.
-	ActionDeviceTokenRegister Action = "device_token.register"
+	ActionDeviceTokenRegister Action = "device_token.register" // #nosec G101 -- an RBAC action name, not a credential; gosec's identifier heuristic matches "Token" in the const name
 	ActionDeviceTokenDelete   Action = "device_token.delete"
 )
 

--- a/crm_be/internal/shared/authz/authz.go
+++ b/crm_be/internal/shared/authz/authz.go
@@ -101,6 +101,16 @@ const (
 	ActionAPIKeyCreate Action = "api_key.create"
 	ActionAPIKeyList   Action = "api_key.list"
 	ActionAPIKeyRevoke Action = "api_key.revoke"
+
+	// ActionDeviceTokenRegister/Delete (Phase 5 #68) are granted to
+	// EVERY role, Owner through Employee — unlike api_key.*, which is
+	// deliberately narrow. A device token is registering the CALLER'S
+	// OWN phone for push, not a capability that reaches other people's
+	// data; Owner and Admin use the dashboard today, but nothing stops
+	// either of them from installing the mobile app too, and there's no
+	// security reason to make them the exception.
+	ActionDeviceTokenRegister Action = "device_token.register"
+	ActionDeviceTokenDelete   Action = "device_token.delete"
 )
 
 // permissions mirrors docs/architecture/authorization.md's matrix
@@ -134,6 +144,8 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionAPIKeyCreate:         true,
 		ActionAPIKeyList:           true,
 		ActionAPIKeyRevoke:         true,
+		ActionDeviceTokenRegister:  true,
+		ActionDeviceTokenDelete:    true,
 	},
 	tenant.RoleAdmin: {
 		ActionMembershipList:       true,
@@ -162,6 +174,8 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionAPIKeyCreate:         true,
 		ActionAPIKeyList:           true,
 		ActionAPIKeyRevoke:         true,
+		ActionDeviceTokenRegister:  true,
+		ActionDeviceTokenDelete:    true,
 	},
 	tenant.RoleManager: {
 		ActionMembershipList: true,
@@ -182,7 +196,9 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionCustomerRead:   true,
 		// ActionCustomerUpdate/Delete deliberately absent — Owner/Admin
 		// only, narrower than Manager's lead.update/delete access.
-		ActionMetricsRead: true,
+		ActionMetricsRead:         true,
+		ActionDeviceTokenRegister: true,
+		ActionDeviceTokenDelete:   true,
 	},
 	tenant.RoleEmployee: {
 		// Read/update granted here; the repository further restricts
@@ -197,7 +213,9 @@ var permissions = map[tenant.Role]map[Action]bool{
 		ActionTaskComplete:   true,
 		// ActionTaskDelete deliberately absent — TD §9's matrix denies
 		// Employee this one, unlike every other activity/task action.
-		ActionCustomerRead: true,
+		ActionCustomerRead:        true,
+		ActionDeviceTokenRegister: true,
+		ActionDeviceTokenDelete:   true,
 		// ActionCustomerUpdate/Delete/ActionLeadConvert deliberately
 		// absent — Employee gets read-only, repo-restricted to
 		// customers converted from leads assigned to them.

--- a/crm_be/internal/shared/authz/authz_test.go
+++ b/crm_be/internal/shared/authz/authz_test.go
@@ -41,6 +41,8 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleOwner, authz.ActionAPIKeyCreate, true},
 		{tenant.RoleOwner, authz.ActionAPIKeyList, true},
 		{tenant.RoleOwner, authz.ActionAPIKeyRevoke, true},
+		{tenant.RoleOwner, authz.ActionDeviceTokenRegister, true},
+		{tenant.RoleOwner, authz.ActionDeviceTokenDelete, true},
 
 		{tenant.RoleAdmin, authz.ActionMembershipList, true},
 		{tenant.RoleAdmin, authz.ActionMembershipUpdateRole, true},
@@ -68,6 +70,8 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleAdmin, authz.ActionAPIKeyCreate, true},
 		{tenant.RoleAdmin, authz.ActionAPIKeyList, true},
 		{tenant.RoleAdmin, authz.ActionAPIKeyRevoke, true},
+		{tenant.RoleAdmin, authz.ActionDeviceTokenRegister, true},
+		{tenant.RoleAdmin, authz.ActionDeviceTokenDelete, true},
 
 		{tenant.RoleManager, authz.ActionMembershipList, true},
 		{tenant.RoleManager, authz.ActionMembershipUpdateRole, false},
@@ -95,6 +99,8 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleManager, authz.ActionAPIKeyCreate, false}, // Manager gets NO access at all, not read-only
 		{tenant.RoleManager, authz.ActionAPIKeyList, false},
 		{tenant.RoleManager, authz.ActionAPIKeyRevoke, false},
+		{tenant.RoleManager, authz.ActionDeviceTokenRegister, true}, // unlike api_key.*, every role gets this — it's the CALLER's own device
+		{tenant.RoleManager, authz.ActionDeviceTokenDelete, true},
 
 		{tenant.RoleEmployee, authz.ActionMembershipList, false},
 		{tenant.RoleEmployee, authz.ActionMembershipUpdateRole, false},
@@ -122,6 +128,8 @@ func TestRequire(t *testing.T) {
 		{tenant.RoleEmployee, authz.ActionAPIKeyCreate, false},
 		{tenant.RoleEmployee, authz.ActionAPIKeyList, false},
 		{tenant.RoleEmployee, authz.ActionAPIKeyRevoke, false},
+		{tenant.RoleEmployee, authz.ActionDeviceTokenRegister, true}, // every role, including Employee — registering a phone for push isn't a management action
+		{tenant.RoleEmployee, authz.ActionDeviceTokenDelete, true},
 	}
 
 	for _, c := range cases {
@@ -158,6 +166,7 @@ var allActions = []authz.Action{
 	authz.ActionCustomerRead, authz.ActionCustomerUpdate, authz.ActionCustomerDelete,
 	authz.ActionMetricsRead,
 	authz.ActionAPIKeyCreate, authz.ActionAPIKeyList, authz.ActionAPIKeyRevoke,
+	authz.ActionDeviceTokenRegister, authz.ActionDeviceTokenDelete,
 }
 
 // TestRequire_APIKeyPrincipal_OnlyLeadCreateAllowed is issue #47's

--- a/crm_be/internal/shared/config/config.go
+++ b/crm_be/internal/shared/config/config.go
@@ -26,6 +26,10 @@ var validMailProviders = []string{"log", "smtp"}
 
 var validSMTPTLSModes = []string{"starttls", "none"}
 
+// "none" (push.NoopSender) or "fcm" (push.FCMSender) — same shape as
+// validMailProviders (Phase 5 #68).
+var validPushProviders = []string{"none", "fcm"}
+
 // Config holds all environment-derived settings for crm_be.
 type Config struct {
 	AppEnv string `env:"APP_ENV" envDefault:"development"`
@@ -56,6 +60,17 @@ type Config struct {
 	SMTPPassword string        `env:"SMTP_PASSWORD"`
 	SMTPTLS      string        `env:"SMTP_TLS" envDefault:"starttls"`
 	SMTPTimeout  time.Duration `env:"SMTP_TIMEOUT" envDefault:"10s"`
+
+	// Push* configure push.FCMSender (Phase 5, issue #68) — read only
+	// when PushProvider is "fcm". Same shape as MailProvider/SMTP*
+	// above, deliberately: "none" (push.NoopSender) is rejected outright
+	// when APP_ENV=production, for the identical reason MAIL_PROVIDER=log
+	// is — a production process that silently never pushes fails with no
+	// error at all.
+	PushProvider       string        `env:"PUSH_PROVIDER" envDefault:"none"`
+	FCMProjectID       string        `env:"FCM_PROJECT_ID"`
+	FCMCredentialsFile string        `env:"FCM_CREDENTIALS_FILE"`
+	PushTimeout        time.Duration `env:"PUSH_TIMEOUT" envDefault:"10s"`
 
 	// JWTSecret signs and verifies access tokens (HS256, TD phase 1 §4).
 	// Required with no default — an app booting with a generated or empty
@@ -156,6 +171,26 @@ func (c *Config) validate() error {
 		}
 		if c.SMTPTimeout <= 0 {
 			return fmt.Errorf("config invalid: SMTP_TIMEOUT must be positive, got %s", c.SMTPTimeout)
+		}
+	}
+	if !slices.Contains(validPushProviders, c.PushProvider) {
+		return fmt.Errorf("config invalid: PUSH_PROVIDER must be one of %v, got %q", validPushProviders, c.PushProvider)
+	}
+	// Same reasoning as MAIL_PROVIDER=log in production (above): a
+	// process that never pushes fails with no error, no crash — just a
+	// notification that quietly never arrives on anyone's phone.
+	if c.AppEnv == "production" && c.PushProvider == "none" {
+		return fmt.Errorf(`config invalid: PUSH_PROVIDER must not be "none" when APP_ENV=production`)
+	}
+	if c.PushProvider == "fcm" {
+		if c.FCMProjectID == "" {
+			return fmt.Errorf("config invalid: FCM_PROJECT_ID must be set when PUSH_PROVIDER=fcm")
+		}
+		if c.FCMCredentialsFile == "" {
+			return fmt.Errorf("config invalid: FCM_CREDENTIALS_FILE must be set when PUSH_PROVIDER=fcm")
+		}
+		if c.PushTimeout <= 0 {
+			return fmt.Errorf("config invalid: PUSH_TIMEOUT must be positive, got %s", c.PushTimeout)
 		}
 	}
 	if len(c.JWTSecret) < minJWTSecretLength {

--- a/crm_be/internal/shared/config/config_test.go
+++ b/crm_be/internal/shared/config/config_test.go
@@ -114,6 +114,9 @@ func TestLoad_ProductionMode(t *testing.T) {
 	t.Setenv("TRUSTED_PROXIES", "10.0.0.0/8")
 	t.Setenv("MAIL_PROVIDER", "smtp")
 	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("PUSH_PROVIDER", "fcm")
+	t.Setenv("FCM_PROJECT_ID", "test-project")
+	t.Setenv("FCM_CREDENTIALS_FILE", "/tmp/fcm-creds.json")
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -163,6 +166,9 @@ func TestLoad_ProductionRequiresCookieSecure(t *testing.T) {
 	t.Setenv("TRUSTED_PROXIES", "none")
 	t.Setenv("MAIL_PROVIDER", "smtp")
 	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("PUSH_PROVIDER", "fcm")
+	t.Setenv("FCM_PROJECT_ID", "test-project")
+	t.Setenv("FCM_CREDENTIALS_FILE", "/tmp/fcm-creds.json")
 
 	_, err := config.Load()
 	if err == nil {
@@ -185,6 +191,9 @@ func TestLoad_ProductionRequiresCORSAllowedOrigins(t *testing.T) {
 	t.Setenv("TRUSTED_PROXIES", "none")
 	t.Setenv("MAIL_PROVIDER", "smtp")
 	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("PUSH_PROVIDER", "fcm")
+	t.Setenv("FCM_PROJECT_ID", "test-project")
+	t.Setenv("FCM_CREDENTIALS_FILE", "/tmp/fcm-creds.json")
 	unsetEnv(t, "CORS_ALLOWED_ORIGINS")
 
 	_, err := config.Load()
@@ -210,6 +219,9 @@ func TestLoad_ProductionRequiresTrustedProxies(t *testing.T) {
 	t.Setenv("CORS_ALLOWED_ORIGINS", "https://app.example.com")
 	t.Setenv("MAIL_PROVIDER", "smtp")
 	t.Setenv("SMTP_HOST", "smtp.example.com")
+	t.Setenv("PUSH_PROVIDER", "fcm")
+	t.Setenv("FCM_PROJECT_ID", "test-project")
+	t.Setenv("FCM_CREDENTIALS_FILE", "/tmp/fcm-creds.json")
 	unsetEnv(t, "TRUSTED_PROXIES")
 
 	_, err := config.Load()

--- a/crm_be/internal/shared/push/fcm.go
+++ b/crm_be/internal/shared/push/fcm.go
@@ -1,0 +1,174 @@
+package push
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// fcmMessagingScope is the one OAuth2 scope FCMSender ever requests —
+// narrower than the Firebase Admin SDK's default, which asks for
+// several Firebase products this codebase never touches (Phase 5 TD
+// §9.2, keputusan M4, same reasoning as choosing net/smtp over a mail
+// library in Phase 4.6).
+const fcmMessagingScope = "https://www.googleapis.com/auth/firebase.messaging"
+
+// ErrTokenInvalid is returned by FCMSender.Send when FCM itself reports
+// the token can never succeed again — UNREGISTERED (the app was
+// uninstalled) or INVALID_ARGUMENT (the token is malformed). Callers
+// check this with errors.Is to decide whether to delete the token
+// (Phase 5 TD §9.4, kriteria #12) — every other error (timeout, 5xx,
+// network) is transient and must NOT delete anything.
+var ErrTokenInvalid = errors.New("push: token invalid or unregistered")
+
+// FCMConfig holds everything FCMSender needs to reach FCM. Every field
+// maps directly to one PUSH_*/FCM_* env var (internal/shared/config).
+type FCMConfig struct {
+	ProjectID       string
+	CredentialsFile string
+	Timeout         time.Duration
+}
+
+// fcmBaseURL is overridden only from this package's own internal tests
+// (fcm_internal_test.go), pointed at an httptest.Server standing in for
+// FCM — there's no local FCM emulator equivalent to Mailpit (Phase 4.6)
+// to run this against for real, so the HTTP behavior (request shape,
+// status/error-body handling) is proven against a fake server instead,
+// and the actual send is verified manually once Firebase exists
+// (Phase 5 TD §12.1, issue #73).
+const fcmBaseURL = "https://fcm.googleapis.com"
+
+// FCMSender sends push notifications through FCM's HTTP v1 API
+// directly — POST {baseURL}/v1/projects/{id}/messages:send — rather
+// than the Firebase Admin SDK, which brings Firestore, Auth, and
+// Storage clients this codebase never uses (Rule #27).
+type FCMSender struct {
+	projectID string
+	ts        oauth2.TokenSource
+	client    *http.Client
+	baseURL   string
+}
+
+// NewFCMSender reads the service account file once at construction and
+// builds a token source that refreshes itself as needed — the same
+// long-lived object is reused across every Send call, never re-read
+// from disk per request.
+func NewFCMSender(cfg FCMConfig) (*FCMSender, error) {
+	data, err := os.ReadFile(cfg.CredentialsFile)
+	if err != nil {
+		return nil, fmt.Errorf("push: read credentials file: %w", err)
+	}
+	jwtCfg, err := google.JWTConfigFromJSON(data, fcmMessagingScope)
+	if err != nil {
+		return nil, fmt.Errorf("push: parse credentials file: %w", err)
+	}
+	return &FCMSender{
+		projectID: cfg.ProjectID,
+		ts:        jwtCfg.TokenSource(context.Background()),
+		// Timeout bounds only the message-send request below — the
+		// lesson from #63: smtp.SendMail had no timeout at all, and
+		// Send here runs in the same best-effort, post-commit position
+		// mailer.Send does. Set from the start, not discovered later.
+		client:  &http.Client{Timeout: cfg.Timeout},
+		baseURL: fcmBaseURL,
+	}, nil
+}
+
+type fcmEnvelope struct {
+	Message fcmMessage `json:"message"`
+}
+
+type fcmMessage struct {
+	Token        string            `json:"token"`
+	Notification fcmNotification   `json:"notification"`
+	Data         map[string]string `json:"data,omitempty"`
+}
+
+type fcmNotification struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+// fcmErrorBody is FCM v1's documented error shape. Only the one field
+// this package acts on is decoded — errorCode inside details, which is
+// where UNREGISTERED/INVALID_ARGUMENT actually appear (the top-level
+// status string uses gRPC status names like NOT_FOUND, not FCM's own
+// error codes).
+type fcmErrorBody struct {
+	Error struct {
+		Details []struct {
+			ErrorCode string `json:"errorCode"`
+		} `json:"details"`
+	} `json:"error"`
+}
+
+func (s *FCMSender) Send(ctx context.Context, msg Message) error {
+	tok, err := s.ts.Token()
+	if err != nil {
+		return fmt.Errorf("push: fetch oauth token: %w", err)
+	}
+
+	body, err := json.Marshal(fcmEnvelope{Message: fcmMessage{
+		Token:        msg.Token,
+		Notification: fcmNotification{Title: msg.Title, Body: msg.Body},
+		Data:         msg.Data,
+	}})
+	if err != nil {
+		return fmt.Errorf("push: marshal message: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/v1/projects/%s/messages:send", s.baseURL, s.projectID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("push: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("push: send: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if isUnregisteredError(resp.StatusCode, respBody) {
+		return ErrTokenInvalid
+	}
+	return fmt.Errorf("push: fcm returned %d: %s", resp.StatusCode, respBody)
+}
+
+// isUnregisteredError matches the two codes TD §9.4 names — 404 with
+// errorCode UNREGISTERED (app uninstalled) or 400 with INVALID_ARGUMENT
+// (malformed token). Any other status (429, 5xx, other 400s) is left
+// alone — those are transient or unrelated to the token itself, and
+// deleting a token on a transient error would be a real user's push
+// silently disabled by a momentary FCM hiccup.
+func isUnregisteredError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusNotFound && statusCode != http.StatusBadRequest {
+		return false
+	}
+	var parsed fcmErrorBody
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return false
+	}
+	for _, d := range parsed.Error.Details {
+		if d.ErrorCode == "UNREGISTERED" || d.ErrorCode == "INVALID_ARGUMENT" {
+			return true
+		}
+	}
+	return false
+}

--- a/crm_be/internal/shared/push/fcm_internal_test.go
+++ b/crm_be/internal/shared/push/fcm_internal_test.go
@@ -1,0 +1,187 @@
+package push
+
+// package push (not push_test) — FCMSender's baseURL field is
+// unexported by design (only ever overridden from here, pointed at an
+// httptest.Server standing in for FCM — Phase 5 TD §9.2's doc comment
+// on fcmBaseURL explains why there's no real FCM emulator to test
+// against the way Mailpit lets Phase 4.6 test SMTP for real). Mirrors
+// the same isolated exception mailer's message_internal_test.go and
+// ratelimit's limiter_internal_test.go already set precedent for.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func fakeTokenSource() oauth2.TokenSource {
+	return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "fake-token", Expiry: time.Now().Add(time.Hour)})
+}
+
+func newTestFCMSender(t *testing.T, serverURL string) *FCMSender {
+	t.Helper()
+	return &FCMSender{
+		projectID: "test-project",
+		ts:        fakeTokenSource(),
+		client:    &http.Client{Timeout: 5 * time.Second},
+		baseURL:   serverURL,
+	}
+}
+
+func TestFCMSender_Send_SendsCorrectRequestShape(t *testing.T) {
+	var gotAuth, gotPath, gotMethod string
+	var gotBody struct {
+		Message struct {
+			Token        string `json:"token"`
+			Notification struct{ Title, Body string }
+			Data         map[string]string `json:"data"`
+		} `json:"message"`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"projects/test-project/messages/0"}`))
+	}))
+	defer srv.Close()
+
+	s := newTestFCMSender(t, srv.URL)
+	err := s.Send(context.Background(), Message{
+		Token: "device-token-abc",
+		Title: "Lead #42 ditugaskan kepada Anda",
+		Body:  "Budi Santoso",
+		Data:  map[string]string{"type": "lead_assigned", "lead_id": "01a0"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotPath != "/v1/projects/test-project/messages:send" {
+		t.Errorf("unexpected path: %s", gotPath)
+	}
+	if gotAuth != "Bearer fake-token" {
+		t.Errorf("expected Authorization: Bearer fake-token, got %q", gotAuth)
+	}
+	if gotBody.Message.Token != "device-token-abc" {
+		t.Errorf("expected token in body, got %q", gotBody.Message.Token)
+	}
+	if gotBody.Message.Data["lead_id"] != "01a0" {
+		t.Errorf("expected data.lead_id=01a0, got %+v", gotBody.Message.Data)
+	}
+}
+
+// TestFCMSender_Send_UnregisteredTokenReturnsErrTokenInvalid is Phase 5
+// TD §9.4's direct acceptance criterion: 404 UNREGISTERED must be
+// distinguishable from every other failure so the caller (device.Usecase)
+// knows to delete the token.
+func TestFCMSender_Send_UnregisteredTokenReturnsErrTokenInvalid(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"message":"Requested entity was not found.","status":"NOT_FOUND","details":[{"@type":"type.googleapis.com/google.firebase.fcm.v1.FcmError","errorCode":"UNREGISTERED"}]}}`))
+	}))
+	defer srv.Close()
+
+	s := newTestFCMSender(t, srv.URL)
+	err := s.Send(context.Background(), Message{Token: "dead-token", Title: "t", Body: "b"})
+	if err != ErrTokenInvalid {
+		t.Errorf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
+// TestFCMSender_Send_InvalidArgumentReturnsErrTokenInvalid covers the
+// second case TD §9.4 names — a malformed token, not just an
+// uninstalled app.
+func TestFCMSender_Send_InvalidArgumentReturnsErrTokenInvalid(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":400,"message":"The registration token is not a valid FCM registration token","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.firebase.fcm.v1.FcmError","errorCode":"INVALID_ARGUMENT"}]}}`))
+	}))
+	defer srv.Close()
+
+	s := newTestFCMSender(t, srv.URL)
+	err := s.Send(context.Background(), Message{Token: "malformed-token", Title: "t", Body: "b"})
+	if err != ErrTokenInvalid {
+		t.Errorf("expected ErrTokenInvalid, got %v", err)
+	}
+}
+
+// TestFCMSender_Send_TransientErrorDoesNotReturnErrTokenInvalid proves
+// isUnregisteredError doesn't over-match — a rate limit or server error
+// must NOT look like "delete this token", or a momentary FCM hiccup
+// would silently disable a real user's push forever.
+func TestFCMSender_Send_TransientErrorDoesNotReturnErrTokenInvalid(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"429 rate limited", http.StatusTooManyRequests, `{"error":{"code":429,"status":"RESOURCE_EXHAUSTED"}}`},
+		{"500 internal", http.StatusInternalServerError, `{"error":{"code":500,"status":"INTERNAL"}}`},
+		{"400 other reason", http.StatusBadRequest, `{"error":{"code":400,"status":"INVALID_ARGUMENT","details":[{"errorCode":"THIRD_PARTY_AUTH_ERROR"}]}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			s := newTestFCMSender(t, srv.URL)
+			err := s.Send(context.Background(), Message{Token: "some-token", Title: "t", Body: "b"})
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if err == ErrTokenInvalid {
+				t.Errorf("expected a transient error, got ErrTokenInvalid — this would wrongly delete a live token")
+			}
+		})
+	}
+}
+
+// TestFCMSender_Send_RespectsTimeout is the same lesson #63 already
+// proved for SMTPMailer, applied here: a server that accepts the
+// connection and never responds must not hang Send forever.
+func TestFCMSender_Send_RespectsTimeout(t *testing.T) {
+	// A fixed sleep well past the client's 300ms timeout, not
+	// <-r.Context().Done(): whether the server notices a client giving
+	// up depends on OS/connection details that aren't reliable in a
+	// test, and httptest.Server.Close() then hangs waiting for a
+	// handler that may never see its context canceled. Sleeping
+	// guarantees the handler finishes on its own, on a schedule the
+	// client has already stopped waiting for.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	s := &FCMSender{
+		projectID: "test-project",
+		ts:        fakeTokenSource(),
+		client:    &http.Client{Timeout: 300 * time.Millisecond},
+		baseURL:   srv.URL,
+	}
+
+	start := time.Now()
+	err := s.Send(context.Background(), Message{Token: "t", Title: "t", Body: "b"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected Send to fail against a server that never responds")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("expected Send to fail within a bounded time close to the configured 300ms timeout, took %s", elapsed)
+	}
+}

--- a/crm_be/internal/shared/push/push.go
+++ b/crm_be/internal/shared/push/push.go
@@ -1,0 +1,54 @@
+// Package push defines the interface every push-sending flow in this
+// codebase uses, and a NoopSender implementation for development and
+// test — same shape as internal/shared/mailer (Phase 4.6), which itself
+// followed the reasoning an interface with one real implementation
+// normally violates Rule #27, justified here because the second
+// implementation (FCMSender) is built in the same issue, not deferred.
+//
+// Sends always happen after the triggering transaction commits (Rule
+// #32) — see internal/lead.Usecase.pushAssignmentNotification. A send
+// failure is logged structurally; it never rolls back work that already
+// committed, and freeze bagian A3 has already established the
+// notification row (not the push) as source of truth.
+package push
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Message is provider-agnostic. Data becomes the FCM "data payload" —
+// used for deeplinking on the client (Phase 5 TD §10), never rendered
+// as visible text itself.
+type Message struct {
+	Token string
+	Title string
+	Body  string
+	Data  map[string]string
+}
+
+type Sender interface {
+	Send(ctx context.Context, msg Message) error
+}
+
+// NoopSender records that a send was attempted via the request-scoped
+// logger instead of sending it. Used in development (PUSH_PROVIDER=none)
+// and in every test that doesn't specifically exercise FCMSender — no
+// test in this codebase depends on network access or a real device.
+//
+// Deliberately never logs msg.Token or msg.Data — a device token
+// identifies one physical installation and is treated as a credential
+// (Phase 5 TD §9.5, Rule #26), the same reasoning LogMailer already
+// applies to never logging a raw secret.
+type NoopSender struct {
+	Logger *slog.Logger
+}
+
+func NewNoopSender(logger *slog.Logger) *NoopSender {
+	return &NoopSender{Logger: logger}
+}
+
+func (s *NoopSender) Send(_ context.Context, msg Message) error {
+	s.Logger.Info("push (not sent — NoopSender)", "title", msg.Title)
+	return nil
+}

--- a/crm_be/migrations/0006_device_tokens.sql
+++ b/crm_be/migrations/0006_device_tokens.sql
@@ -1,0 +1,46 @@
+-- Phase 5 — Employee Mobile. First migration of the phase.
+-- Spec: docs/phases/05-employee-mobile/td.md §8. Column shapes below are
+-- copied from that spec, not re-derived.
+
+-- +goose Up
+
+-- device_tokens — token FCM per instalasi aplikasi per perangkat.
+-- Tanpa deleted_at (deviasi sadar Aturan #18): ini bukan entity bisnis —
+-- tidak punya nilai audit, tidak pernah dirujuk laporan, dan token mati
+-- memang harus benar-benar hilang (kriteria #12 phase ini), bukan
+-- disimpan sebagai sampah yang harus diingat untuk difilter di setiap
+-- query.
+CREATE TABLE device_tokens (
+    id              uuid PRIMARY KEY,
+    organization_id uuid NOT NULL REFERENCES organizations (id),
+    membership_id   uuid NOT NULL,
+
+    token           text NOT NULL,
+    platform        text NOT NULL,
+
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    last_seen_at    timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT ck_device_tokens_platform CHECK (platform IN ('android', 'ios')),
+    CONSTRAINT uq_device_tokens_id_org   UNIQUE (id, organization_id),
+    -- token unik LINTAS organization, bukan per organization — pengecualian
+    -- ketiga di codebase ini, sekelas api_keys.key_id (0005) dan
+    -- refresh_tokens.token_hash (0002). Token FCM mengidentifikasi SATU
+    -- instalasi aplikasi di SATU perangkat, dan perangkat itu bisa
+    -- berpindah pengguna (employee resign, HP dipakai orang lain, employee
+    -- pindah organization). Unik global + upsert pada kolom ini membuat
+    -- pendaftaran ulang MEMINDAHKAN baris ke membership yang sekarang
+    -- login — perilaku yang benar. Composite (token, organization_id)
+    -- akan membiarkan satu perangkat fisik menerima push milik dua
+    -- organization sekaligus.
+    CONSTRAINT uq_device_tokens_token    UNIQUE (token),
+    CONSTRAINT fk_device_tokens_membership
+        FOREIGN KEY (membership_id, organization_id)
+        REFERENCES memberships (id, organization_id)
+);
+
+CREATE INDEX idx_device_tokens_org_membership
+    ON device_tokens (organization_id, membership_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS device_tokens;

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,7 +3,7 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 29 Agustus 2026 — **Phase 5 — Employee Mobile dibuka** (#68–#73), Android dulu, iOS ditunda.
+**Last updated:** 30 Agustus 2026 — **Issue #68 selesai** (backend mobile: `device_tokens`, FCM, hook setelah commit).
 **Phase sekarang:** Phase 5 — Employee Mobile. Phase 4.6 selesai; ini phase MVP terakhir sebelum GATE.
 
 ---
@@ -49,6 +49,7 @@
 | **Issue #58 — Eviction map ber-key penyerang, penutup Phase 4.5** | — | 4.5 | Eviction **dua generasi** (`current`/`previous`, ditukar tiap ~1 window) di `ratelimit.FixedWindow` dan `auth.LoginLimiter` — bukan sweep berkala (memindai map besar sambil memegang lock justru mengubah pertahanan jadi bagian serangan, dan freeze melarang worker tanpa kebutuhan async nyata). **Carry-forward lewat lookup, bukan filter saat swap**: bucket/backoff yang masih hidup dipindahkan dari `previous` ke `current` hanya saat diakses lagi, disalin apa adanya (`windowStart`/`count` atau `failures`/`nextAllowedAt`) — sehingga key manapun yang masih aktif berperilaku **identik** dengan sebelum eviction ada, dan seluruh test lama lulus tanpa perubahan asersi. Field `now func() time.Time` unexported ditambahkan ke kedua tipe untuk kontrol waktu deterministik di test, di-set hanya dari file test internal paket yang sama (`limiter_internal_test.go`, `login_limiter_internal_test.go` — deviasi `package ratelimit`/`package auth`, pola sama seperti `internal/apikey/entity_test.go`). **4 test baru membuktikan batas memori lewat pengukuran**: 20 generasi × 50 key unik (1000 total) tetap terlacak ≤100 di kedua tipe. **Terbukti bisa gagal** — empat run adversarial terpisah (roll dimatikan, carry-forward dimatikan, di kedua tipe), semuanya merah persis seperti diprediksi, dikembalikan, tidak pernah ter-commit. Dua map ber-key entity bisnis (`apikey.lastUsedThrottle`, `lead.idempotencyCleanupThrottle`) **sengaja tetap tanpa eviction** (keputusan H3) — komentarnya diperbarui untuk berhenti menyamakan diri dengan `ratelimit.FixedWindow` dan menjelaskan alasan sebenarnya. **Seluruh 10 acceptance criteria PRD Phase 4.5 dicek satu per satu dan terpenuhi. Phase 4.5 — Hardening selesai.** |
 | **Issue #63 — `SMTPMailer`, tutup `MAIL_FROM` yang tidak pernah dipakai** | — | 4.6 | `mailer.Mailer` sudah interface sejak Phase 1 — komentarnya sendiri menyebut implementasi kedua akan datang. `SMTPMailer` mengisinya, **tanpa** abstraksi baru. Percakapan SMTP dibangun **manual** (bukan `smtp.SendMail`, yang tidak punya batas waktu sama sekali) — `Send` dipanggil sinkron di jalur request, jadi server menggantung = request menggantung; satu `conn.SetDeadline` menutup seluruh percakapan sejak dial sampai `QUIT`. **`MAIL_FROM` akhirnya dipakai** — sejak Phase 1 ada di config tapi tidak dibaca siapa pun. `MAIL_PROVIDER=log` di `APP_ENV=production` **menghentikan boot** (keputusan E2) — produksi yang tidak pernah kirim email gagal diam-diam, dan `LogMailer` menulis token verifikasi ke log. `SMTP_TLS=none` juga ditolak di produksi (E3). **Dua perilaku stdlib diverifikasi sebelum ditulis**: `mime.QEncoding.Encode` membiarkan subject ASCII produk hari ini apa adanya; `strings.ContainsAny(s, "\r\n")` menangkap ketiga bentuk injeksi header. **10 test baru** — 6 unit tanpa jaringan (`message_internal_test.go`, deviasi `package mailer` mengikuti preseden `apikey`/`ratelimit`) + **4 integrasi terhadap Mailpit sungguhan lewat testcontainers**, membaca pesan kembali lewat API Mailpit alih-alih memeriksa `Send` mengembalikan `nil`. **Terbukti bisa gagal** — defense injeksi header dan `SetDeadline` masing-masing dirusak sementara, keduanya merah persis seperti diprediksi (yang kedua digantung sampai dipotong paksa `-timeout=15s`, membuktikan tanpa deadline `Send` benar-benar tidak pernah berhenti sendiri), dikembalikan, tidak pernah ter-commit. Test produksi lama (`TestLoad_ProductionMode` dkk.) ditambahi setup `MAIL_PROVIDER=smtp`+`SMTP_HOST` — bukan perubahan asersi. **Belum menutup phase** — Mailpit belum menyala di `make dev`, `docs/testing/flow/` masih menyuruh menggali log. |
 | **Issue #64 — Mailpit di dev environment, penutup Phase 4.6** | — | 4.6 | `docker-compose.yml` bertambah service `mailpit` — **tanpa** `depends_on` di `api` (SMTP hanya disentuh saat email benar-benar dikirim, bukan saat boot; diverifikasi langsung: registrasi 0,3 detik setelah `docker compose up` tetap `201`, Mailpit tanpa healthcheck sudah siap jauh lebih cepat dari Postgres). `.env.example`'s `SMTP_HOST=localhost` sengaja **beda** dari `docker-compose.yml`'s `SMTP_HOST=mailpit` — dua sudut pandang jaringan berbeda (host vs container Docker), bukan inkonsistensi. Enam tempat di lima berkas `docs/testing/flow/` diperbarui — instruksi `docker compose logs | grep` diganti "buka `http://localhost:8025`, klik email terbaru"; §8 lama (cara menyalin tautan dari log tanpa ikut membawa `\n\n` literal) **dihapus seluruhnya**, bukan disunting, karena masalahnya sudah tidak ada. Satu baris troubleshooting baru **awalnya salah**: draf pertama mengklaim race condition boot `api`/`mailpit` sebagai penyebab utama email tidak muncul — **diverifikasi langsung sebelum ditulis final, klaimnya tidak terbukti** (urutan langkah di panduan sendiri sudah memberi Mailpit cukup waktu naik); ditulis ulang lebih berhati-hati, menyebut kemungkinan itu jarang. `authentication.md` mendapat bagian baru *Pengiriman email* (dua provider, kenapa `SMTPMailer` bukan `smtp.SendMail`, kenapa kegagalan kirim tidak membatalkan apa pun yang commit, Mailpit di dev, batas untuk produksi). **Verifikasi manual end-to-end dari nol**: `docker compose down -v` → `up --build` → `migrate-up` → registrasi → email verifikasi muncul di Mailpit (`From: no-reply@jualin.local`, subjek benar) → token diekstrak dari body → `200 verified`; diulang untuk reset password. **Seluruh 12 acceptance criteria PRD Phase 4.6 dicek satu per satu dan terpenuhi. Phase 4.6 — Email Delivery selesai.** |
+| **Issue #68 — Backend mobile: `device_tokens`, pengiriman FCM, hook setelah commit** | — | 5 | Pembuka Phase 5, murni Go, **tanpa UI**. Migration `0006` — `uq_device_tokens_token` unik **lintas** organization (pengecualian ketiga di codebase ini, alasan berbeda dari `api_keys.key_id`/`refresh_tokens.token_hash`: perangkat fisik bisa berpindah pemilik, registrasi ulang **memindahkan** baris lewat `ON CONFLICT ... DO UPDATE`, bukan menduplikasi); sengaja tanpa `deleted_at` (deviasi Aturan #18 — bukan entity bisnis). `internal/shared/push` (interface `Sender` + `NoopSender`/`FCMSender`, HTTP v1 API langsung, **tanpa** Firebase Admin SDK — Aturan #27, meniru pilihan `net/smtp` #63) dan `internal/device` (domain penuh) baru. `lead.PushSender` dijembatani lewat **`lead.Repos.Push`** (nil-safe), bukan parameter `NewUsecase` — menghindari perubahan pada ~20 situs test yang sudah ada, pola sama seperti `NotificationSender`. Push dikirim **setelah** `InTx` kembali (`pushRecipient` ditangkap lewat closure) — kegagalan FCM tidak pernah membatalkan assignment yang sudah commit (Rule #32). **Isolasi tenant punya temuan nyata**: merusak predikat `organization_id` di `FindByToken` sendirian **tidak** membuat harness merah — `Unregister`'s pemeriksaan kepemilikan Go-level menangkapnya independen; baru merah setelah kedua lapis dirusak bersamaan. Dicatat sebagai dua-lapis-redundan, bukan disembunyikan sebagai sukses langsung. **Empat test produksi lama di `config_test.go` sempat merah** pada full-suite run (gate `PUSH_PROVIDER` baru muncul sebelum gate yang sebenarnya diuji) — ditambal persis seperti pola `MAIL_PROVIDER=smtp`+`SMTP_HOST` yang sudah ada untuk test yang sama. Diverifikasi lewat `curl` end-to-end sungguhan: registrasi token memindahkan baris (bukan duplikat) saat token yang sama didaftar ulang, unregister idempoten (`404` kedua kali, bukan `500`), assignment ke diri sendiri diam total (TD §11), assignment ke orang lain memicu `push (not sent — NoopSender)` di log **tanpa** field token/data (Aturan #26). `go test -race ./...` seluruh module bersih. |
 
 ---
 
@@ -60,7 +61,7 @@ _(kosong)_
 
 ## Berikutnya
 
-### Phase 5 — Employee Mobile (#68–#73) — sedang dibuka
+### Phase 5 — Employee Mobile (#68–#73) — sedang berjalan
 
 **Phase MVP terakhir.** Setelah ini GATE freeze terbuka: cari 3–5 pengguna nyata sebelum Phase 6.
 Dokumen: `docs/phases/05-employee-mobile/`.
@@ -69,11 +70,12 @@ Dokumen: `docs/phases/05-employee-mobile/`.
 **tidak** mengorbankan satu pun kriteria selesai phase: freeze menulis *"siklus penuh berjalan di HP
 nyata"* tanpa menyebut platform, dan push Android tidak melibatkan Apple sama sekali.
 
-Riset saat membuka phase menemukan **backend hampir seluruhnya sudah siap** — jalur auth mobile,
-visibilitas Employee, permission, activity `call_logged`/`whatsapp_opened`, `version`, tabel
-`notifications` semuanya ada sejak Phase 1–2. `authz.go` bahkan sudah menuliskan komentarnya:
-*"Employee gets mobile in Phase 5"*. **`device_tokens` + FCM adalah satu-satunya pekerjaan backend**;
-sisanya Flutter, dan `crm_employee/` masih berisi satu berkas `README.md`.
+**#68 selesai — seluruh pekerjaan backend phase ini sudah tertutup.** `device_tokens` + FCM (satu-satunya
+pekerjaan `crm_be` yang teridentifikasi saat phase dibuka) sudah dibangun, diuji, dan diverifikasi
+end-to-end lewat `curl` + token dummy (lihat baris #68 di tabel *Selesai* dan
+`docs/phases/05-employee-mobile/notes.md`). Sisa phase (#69–#73) seluruhnya `crm_employee` (Flutter) —
+**#69 (fondasi Flutter) dan #70 (fondasi desain) berikutnya**, keduanya boleh paralel dengan #68 tapi
+#68 sendiri sudah beres duluan.
 
 **Kontradiksi freeze dilaporkan, bukan diputuskan diam-diam** (Aturan #30): bagian 4 menulis cakupan
 *"cache **baca** offline"* dan kriteria selesai *"daftar lead tetap **terbaca**"*, sementara bagian
@@ -81,8 +83,10 @@ sisanya Flutter, dan `crm_employee/` masih berisi satu berkas `README.md`.
 antrian tulis di luar cakupan — beserta alasannya ada di `prd.md`. Ini mengubah ukuran phase secara
 mendasar, jadi **katakan sebelum implementasi dimulai** bila maksud Anda berbeda.
 
-Yang dibutuhkan dari pemilik produk: **project Firebase** (gratis, hitungan menit) — hanya memblokir
-issue penutup #73, bukan phase-nya. Langkah persisnya di `td.md` §14.
+Firebase project **sudah dibuat** (`jualin-crm`, akun `jualin.official01@gmail.com`, FlutterFire CLI
+sudah tersedia) — checklist di bawah diperbarui. Registrasi aplikasi Android yang sesungguhnya
+(`flutterfire configure`) masih menunggu scaffold Flutter (#69) ada; itu hanya memblokir issue penutup
+#73, bukan phase-nya. Langkah persisnya di `td.md` §14.
 
 **Demo ke calon pengguna** (freeze bagian 4, tujuan Phase 3) — kedua hambatan teknis yang tercatat di
 sini sejak Phase 3 tutup sekarang **sudah ditutup**: panduan langkah-demi-langkah ada
@@ -152,7 +156,7 @@ Tidak ada yang memblokir. Semuanya diputuskan saat fitur terkait dikerjakan.
 | — | Domain final & branding | Phase 1 — ⏳ *lead time, lihat bawah* |
 | — | Hosting & managed PostgreSQL | Phase 0 akhir |
 | — | Retensi data free tier | Phase 8 |
-| — | Push provider detail | Phase 5 — ⏳ *lead time, lihat bawah* |
+| — | Push provider detail | **Ditutup #68** — FCM HTTP v1 API langsung, tanpa Firebase Admin SDK |
 | — | Pricing final & limit free tier | Phase 8 |
 | — | Kontrak integrasi payment service | Sebelum Phase 8 |
 
@@ -175,7 +179,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 |---|---|---|---|
 | **Domain + email sender** (SPF/DKIM/DMARC) | Phase 1 | **Sekarang** | Verifikasi email menggerbangi login (keputusan B3), jadi ia jalur kritis Phase 1. Propagasi DNS dan pemanasan reputasi pengirim butuh waktu — dan email verifikasi yang masuk spam akan membunuh funnel registrasi **tanpa menghasilkan satu pun error**. |
 | **Apple Developer Program** | Phase 5 — **iOS saja** | Saat iOS diaktifkan | Enrollment bisa berhari-hari sampai berminggu (verifikasi identitas / D-U-N-S untuk organisasi). **Tidak lagi memblokir Phase 5** sejak keputusan M1 (Android dulu) — yang terhalang hanya build iOS & push iOS, bukan satu pun kriteria selesai phase. |
-| **Firebase project (FCM)** | Phase 5 | **Sebelum issue #73** | Gratis, hitungan menit. Push **Android** tidak melibatkan Apple sama sekali. Langkah persisnya di `docs/phases/05-employee-mobile/td.md` §14. Hanya memblokir satu issue (#73), bukan phase-nya — `PUSH_PROVIDER=none` membuat sisanya bisa dikerjakan tanpa Firebase. |
+| **Firebase project (FCM)** | Phase 5 | ✅ **Sudah dibuat** (`jualin-crm`) | Gratis, hitungan menit. Push **Android** tidak melibatkan Apple sama sekali. Langkah persisnya di `docs/phases/05-employee-mobile/td.md` §14. Registrasi app (`flutterfire configure`) masih menunggu scaffold #69 — hanya memblokir satu issue (#73), bukan phase-nya. |
 
 **Tidak ada yang memblokir Phase 0.** Dicatat di sini justru supaya tidak tersadar terlambat.
 
@@ -184,7 +188,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 - [ ] Domain final dipilih & dibeli
 - [ ] Email provider dipilih (Resend / Postmark / SES)
 - [ ] SPF, DKIM, DMARC terpasang & terverifikasi
-- [ ] Firebase project dibuat ← **dibutuhkan #73**, langkahnya di TD Phase 5 §14
+- [x] Firebase project dibuat ← `jualin-crm`, akun `jualin.official01@gmail.com`, FlutterFire CLI siap. Registrasi app Android (`flutterfire configure`) masih menunggu scaffold #69
 - [ ] Apple Developer Program terdaftar ← hanya untuk iOS, ditunda (keputusan M1)
 
 > Domain juga menentukan konfigurasi cookie (`Secure`, `SameSite`, scope), CORS, dan alamat pengirim email — semuanya disentuh di Phase 1.

--- a/docs/phases/05-employee-mobile/notes.md
+++ b/docs/phases/05-employee-mobile/notes.md
@@ -1,0 +1,214 @@
+# Phase 5 — Employee Mobile · Notes
+
+One section per issue, appended as each is implemented.
+
+---
+
+## #68 — Backend mobile: `device_tokens`, pengiriman FCM, hook setelah commit
+
+Issue pertama Phase 5 yang dikerjakan — murni `crm_be`, tanpa UI (lihat batas issue di `issues.md`).
+Android-first (keputusan M1), FCM lewat HTTP v1 API langsung (keputusan M4, Rule #27 — meniru pilihan
+`net/smtp` Phase 4.6 daripada menambah Firebase Admin SDK sebagai dependency), push dikirim **setelah**
+commit (keputusan M5, Rule #32, freeze A3: baris `notifications` adalah source of truth, push cuma
+usaha pengiriman terbaik).
+
+### Migration `0006_device_tokens.sql` — pengecualian unique ketiga lintas organization
+
+`uq_device_tokens_token` unik lintas organization, **bukan** composite `(token, organization_id)` —
+pengecualian sadar terhadap kebiasaan "unik per tenant" di kode ini, dan yang **ketiga** dengan alasan
+persis sama seperti dua pendahulunya (`api_keys.key_id` #46, `refresh_tokens.token_hash` Phase 1):
+organization di sini adalah *hasil* lookup, bukan input untuknya. Tapi alasan device_tokens berbeda dari
+keduanya — bukan soal urutan lookup, tapi soal **kepemilikan fisik yang bisa berpindah**: satu perangkat
+Android bisa berpindah tangan (karyawan resign, HP kantor dipakai orang lain, reinstall app di
+organization berbeda saat testing). Registrasi ulang token yang sama harus **memindahkan** baris ke
+pemilik/organization baru lewat `ON CONFLICT (token) DO UPDATE`, bukan menolak atau menduplikasi.
+
+Sengaja **tanpa `deleted_at`** (deviasi dari Aturan #18) — device token bukan entity bisnis yang perlu
+riwayat; baris yang dihapus (logout, atau token FCM sudah dianggap invalid) memang seharusnya hilang,
+tidak ada nilai menyimpan "device token yang pernah ada".
+
+### `internal/shared/push` — meniru bentuk `internal/shared/mailer` persis
+
+`Sender` interface + `NoopSender` (development, `PUSH_PROVIDER=none`) + `FCMSender` (`PUSH_PROVIDER=fcm`)
+— bentuknya sama persis dengan `Mailer`/`LogMailer`/`SMTPMailer` Phase 4.6, termasuk validasi config
+"tolak provider no-op di production" (Rule #36 tetap berlaku untuk push: proses yang diam-diam tidak
+pernah mengirim push gagal tanpa error apa pun, sama seperti `MAIL_PROVIDER=log` di production).
+
+`FCMSender.isUnregisteredError` membedakan token yang **benar-benar mati** (404 UNREGISTERED, 400
+INVALID_ARGUMENT dengan `errorCode` itu di `details[]`) dari kegagalan sementara (429 rate limit, 500
+internal, 400 dengan alasan lain seperti `THIRD_PARTY_AUTH_ERROR`) — hanya kasus pertama yang boleh
+memicu penghapusan token di `device.Usecase.PushToMembership`. `ErrTokenInvalid` sentinel dipakai
+`errors.Is` di pemanggil, bukan dicocokkan lewat string.
+
+### `internal/device` — domain baru, `PushSender` dibridge lewat `lead.Repos`
+
+`Register`/`Unregister`/`PushToMembership` (lihat kode untuk detail). Satu keputusan desain yang
+menghindari kerusakan luas: `lead.PushSender` interface dideklarasikan di `internal/lead/port.go`
+(ADR-011 — interface milik consumer), dan `device.Usecase` mengimplementasikannya secara struktural
+tanpa `internal/lead` pernah mengimpor `internal/device`. Bridge-nya diletakkan di **`lead.Repos.Push`**
+(field baru, nilai nil-safe), **bukan** di parameter `lead.NewUsecase` — pola yang sama seperti
+`NotificationSender`/`ActivityRecorder` sebelumnya. Alasannya murni praktis: `lead.NewUsecase(store)`
+dipanggil di ~20 lokasi test yang sudah ada; mengubah signature-nya berarti ~20 titik itu perlu
+diperbarui untuk dependency yang sebagian besar tidak pernah mereka uji. Menaruhnya di `Repos` berarti
+test lama yang membangun `Repos{}` literal tanpa field `Push` tetap kompilasi dan tetap lulus —
+`pushAssignmentNotification` memeriksa nil sebelum memanggil apa pun.
+
+`Unregister`'s pemeriksaan kepemilikan dilakukan di Go (`found.MembershipID != *t.MembershipID` → 404),
+bukan dilipat ke SQL `DeleteByToken` — lihat bagian isolasi tenant di bawah untuk kenapa ini penting.
+
+### `lead.Usecase.UpdateAssignment` — push ditangkap lewat closure, dikirim setelah `InTx` kembali
+
+```go
+var pushRecipient *uuid.UUID
+txErr := u.store.InTx(ctx, func(r Repos) error {
+    // ... assignment + Activity.Record + Notification.Notify di dalam transaksi ...
+    if t.MembershipID != nil && newAssignee == *t.MembershipID {
+        return nil // self-assignment — tidak ada notifikasi, tidak ada push (TD §11)
+    }
+    // ...
+    pushRecipient = &newAssignee
+    return nil
+})
+// ...
+if pushRecipient != nil {
+    u.pushAssignmentNotification(ctx, t, *pushRecipient, updated)
+}
+```
+
+`pushRecipient` sengaja variabel di luar closure, diset di dalam, dibaca setelah `InTx` selesai —
+memastikan kegagalan push (timeout FCM, token invalid, dst.) **tidak pernah** menggagalkan transaksi
+yang sudah committed (Rule #32). Assign ke diri sendiri tetap diam total — TD §11: "memberi tahu
+seseorang tentang tindakannya sendiri hanya menambah bising" — baris ini sekaligus berlaku untuk
+notifikasi in-app (sudah ada sejak Phase 3) dan push (baru).
+
+### Wiring composition root
+
+`cmd/api/device_store.go` (baru, meniru `apikey_store.go`), `cmd/api/lead_store.go`'s
+`newLeadStore(pool, push)` sekarang menerima `push lead.PushSender`, `cmd/api/main.go`'s `newPushSender`
+membangun `push.NoopSender` atau `push.FCMSender` dari config lalu **panic** bila konstruksi FCM gagal
+(kredensial file tidak terbaca, dst.) — bukan mengembalikan error lewat `newRouter`'s signature, supaya
+6 file test yang memanggil `newRouter` langsung tidak perlu diubah. Konsisten dengan Rule #36 (fail-fast
+sebelum server menerima koneksi): kegagalan ini terjadi sebelum `http.Server` mulai `ListenAndServe`.
+
+Dependency baru satu-satunya: `golang.org/x/oauth2` (+ `cloud.google.com/go/compute/metadata` sebagai
+indirect) — dikonfirmasi lewat `git diff go.mod`, sesuai janji TD "satu dependency baru".
+
+### Bug ditemukan sebelum commit
+
+- **Hang nyata di `fcm_internal_test.go`** — `TestFCMSender_Send_RespectsTimeout`'s handler awalnya
+  memakai `<-r.Context().Done()` untuk mendeteksi client yang menyerah. Ini tidak reliable: server tidak
+  selalu tahu client-nya sudah timeout kecuali sedang aktif membaca/menulis koneksi. Test ini
+  benar-benar hang >180 detik di run background sebelum ditemukan (dikonfirmasi lewat goroutine dump —
+  handler diam di `chan receive`). Diperbaiki dengan `time.Sleep(2 * time.Second)` tetap — jauh melewati
+  timeout client (300ms) tapi handler-nya sendiri selalu selesai sesuai jadwalnya sendiri, tidak
+  bergantung pada sinyal cancellation yang tidak terjamin datang.
+- **Potensi panic di dua file test config literal** — setelah `newPushSender(cfg, log)` dipasang tanpa
+  syarat di `newRouter`, `config.Config{}` literal (bukan lewat `env.Parse`) punya `PushProvider == ""`
+  (bukan default `"none"` dari tag `envDefault`), yang jatuh ke cabang `default: panic(...)` di
+  `newPushSender`. Ditemukan sebelum menjalankan test lewat `grep -rln "config.Config{"` — hanya dua
+  situs (`router_test.go`'s `testConfig()`, `tenant_isolation_test.go`'s `isolationTestConfig()`).
+  Ditambahkan `PushProvider: "none"` ke keduanya sebelum ini sempat menggagalkan test apa pun.
+- **Empat test produksi di `config_test.go` gagal pada full-suite run**, bukan pada test package
+  `config` sendirian saat pertama ditulis: `TestLoad_ProductionMode`,
+  `TestLoad_ProductionRequiresCookieSecure`, `TestLoad_ProductionRequiresCORSAllowedOrigins`,
+  `TestLoad_ProductionRequiresTrustedProxies` — keempatnya set `APP_ENV=production` tapi tidak pernah
+  set `PUSH_PROVIDER`, sehingga jatuh ke default `"none"`, yang sekarang ditolak di production (validasi
+  baru issue ini). Gate `PUSH_PROVIDER` baru ini datang **sebelum** gate yang sebenarnya ingin diuji
+  test-test itu, jadi errornya menyebut `PUSH_PROVIDER`, bukan `COOKIE_SECURE`/`CORS_ALLOWED_ORIGINS`/
+  `TRUSTED_PROXIES`. Diperbaiki persis seperti `MAIL_PROVIDER=smtp`+`SMTP_HOST` sudah dipatch ke test
+  yang sama untuk gate `MAIL_PROVIDER` — ditambah `PUSH_PROVIDER=fcm`+`FCM_PROJECT_ID`+
+  `FCM_CREDENTIALS_FILE` ke keempat test itu. Dua test produksi lain
+  (`TestLoad_ProductionRejectsLogMailProvider`, `TestLoad_ProductionRejectsSMTPWithoutTLS`) tidak perlu
+  ditambal — gate yang mereka uji (`MAIL_PROVIDER`, `SMTP_TLS`) ada **sebelum** gate `PUSH_PROVIDER` di
+  urutan `validate()`, jadi error-nya sudah keluar lebih dulu.
+- **Backfill wajib di `authz_test.go`** — dua `Action` baru (`ActionDeviceTokenRegister`,
+  `ActionDeviceTokenDelete`) perlu masuk ke tabel per-role `TestRequire` dan `allActions`, mengikuti
+  komentar peringatan yang sudah ada di file itu sejak precedent #46/#47 tentang kelas kesalahan ini.
+
+### Verifikasi harness isolasi tenant — dua lapis proteksi redundan yang saling tidak sadar
+
+Mengikuti prosedur #11/#23/#30/#46: harness baru
+`TestTenantIsolation_DeviceTokenDelete_CrossOrgReturns404` menguji `DELETE /v1/device-tokens` dari Org A
+terhadap token milik Org B, mengharapkan 404.
+
+**Percobaan pertama TIDAK berjalan seperti yang lain.** Predikat tenant di `FindByToken`'s SQL
+(`WHERE token = $1 AND organization_id = $2`) diubah sementara menjadi `WHERE token = $1` — dan test
+**tetap hijau**, bukan merah. Ini bukan bug di test, melainkan temuan desain nyata: `Unregister`'s
+pemeriksaan kepemilikan tingkat Go (`found.MembershipID != *t.MembershipID` → 404) bekerja independen
+dari filter `organization_id` SQL — kasus lintas-organization *juga* selalu lintas-membership, jadi
+lapis kedua menangkapnya sendirian.
+
+Untuk membuktikan harness ini benar-benar bisa gagal, **kedua lapis** dirusak bersamaan (predikat SQL
+dihapus **dan** pemeriksaan `found.MembershipID` di `Unregister` dilewati) — barulah merah:
+
+```
+tenant_isolation_test.go: expected 404 for cross-org access, got 204
+```
+
+Kode dikembalikan ke bentuk asli (diff dikonfirmasi identik) sebelum commit; kerusakan itu sendiri tidak
+pernah masuk git. Dua test unit/handler yang sudah ada
+(`TestUnit_Unregister_SomeoneElsesToken_Returns404NotForbidden`,
+`TestHandler_Unregister_SomeoneElsesToken_Returns404`) sudah membuktikan lapis Go-level itu sendirian
+bisa gagal untuk skenario yang sebenarnya jadi tanggung jawabnya — sama-organization, beda-membership,
+kasus yang filter SQL organization_id sama sekali tidak bisa bantu.
+
+**Kesimpulan**: bukan cacat desain, tapi proteksi berlapis yang muncul secara tidak sengaja dari dua
+aturan berbeda yang sama-sama benar (Aturan #6 "404 bukan 403" diterapkan di lapis repository untuk
+kasus lintas-organization, dan aturan bisnis "hanya pemilik boleh unregister" diterapkan di lapis
+usecase). Dicatat di sini apa adanya, bukan digambarkan sebagai keberhasilan langsung — percobaan
+pertama gagal menunjukkan kegagalan, dan itu sendiri temuan yang harus jujur ditulis.
+
+### Verifikasi manual end-to-end
+
+`docker compose up -d postgres` → `go run ./cmd/migrate up` (0001→0006 bersih) → `go run ./cmd/migrate
+down` sekali (0006 turun bersih, status kembali ke 0005) → `go run ./cmd/migrate up` lagi → jalankan
+`crm_be` lokal (`APP_ENV=development`, `PUSH_PROVIDER=none`) → register org "Toko Device68" → verifikasi
+email → login Owner:
+
+```
+POST /v1/device-tokens {"token":"dummy-fcm-token-abc123","platform":"android"}
+→ 201 {"id":"...","platform":"android",...}   -- tanpa field "token" di respons
+
+POST /v1/device-tokens {"token":"dummy-fcm-token-abc123","platform":"ios"}  (token SAMA, platform beda)
+→ 201, id TIDAK berubah, platform="ios"
+psql: SELECT count(*) FROM device_tokens → 1 baris   -- dipindahkan, bukan diduplikasi
+
+DELETE /v1/device-tokens {"token":"dummy-fcm-token-abc123"} → 204
+DELETE /v1/device-tokens {"token":"dummy-fcm-token-abc123"} → 404   -- kedua kali, bukan error 500
+
+POST /v1/leads {"name":"Budi Santoso", ...} → 201, lead_number=1
+
+PATCH /v1/leads/{id}/assignment {"assigned_to_membership_id": <membership OWNER SENDIRI>}
+→ 200, TIDAK ADA baris log push   -- self-assignment diam, sesuai TD §11
+
+-- undang karyawan, accept, login sebagai karyawan, daftarkan device token miliknya --
+
+PATCH /v1/leads/{id}/assignment {"assigned_to_membership_id": <membership KARYAWAN>}
+→ 200
+log: msg="push (not sent — NoopSender)" title="Lead #1 ditugaskan kepada Anda"
+     -- TIDAK ADA field token atau data di baris log ini (Rule #26)
+```
+
+Membuktikan tiga hal sekaligus: upsert benar-benar memindahkan baris (bukan menduplikasi), delete
+idempoten secara eksternal (404 kedua kali, bukan crash), dan hook push-setelah-commit benar-benar
+tersambung dari `lead.Usecase` sampai `device.Usecase.PushToMembership` — termasuk membedakan
+self-assignment (diam) dari assignment sungguhan (push tercatat).
+
+### Test
+
+30 test baru: 6 `internal/shared/push/fcm_internal_test.go` (`package push`, akses `baseURL` unexported —
+mengikuti pola pengecualian `mailer`'s `message_internal_test.go`), 6 `internal/device/repository_test.go`
+(Postgres asli, termasuk `TestRepository_Upsert_SameToken_MovesRowToNewOwner` dan
+`TestRepository_DeleteByToken_CrossOrg_DoesNotDelete`), 11 `internal/device/usecase_unit_test.go` (fake
+`Store`+`Sender`, tanpa Docker), 5 `internal/device/handler_test.go`, 2 backfill di `authz_test.go`. Satu
+`isolationCase` baru di `cmd/api/tenant_isolation_test.go` — terbukti bisa gagal seperti dijelaskan di
+atas, dengan temuan dua-lapis yang didokumentasikan, bukan disembunyikan.
+
+`go test -race ./...` (seluruh module, bukan per-paket), `go vet ./...`, `gofmt -l .` — bersih.
+
+### Batas issue ini
+
+Registrasi token dari aplikasi (Flutter belum ada — diverifikasi `curl` + token dummy, sesuai batas
+issue di `issues.md`). Push benar-benar sampai ke perangkat fisik lewat `FCMSender` — butuh kredensial
+FCM asli dan aplikasi terpasang, keduanya di luar cakupan #68 (klien FCM: #73). Layar apa pun di
+`crm_employee` — #69 dan seterusnya.

--- a/docs/phases/05-employee-mobile/notes.md
+++ b/docs/phases/05-employee-mobile/notes.md
@@ -212,3 +212,50 @@ Registrasi token dari aplikasi (Flutter belum ada — diverifikasi `curl` + toke
 issue di `issues.md`). Push benar-benar sampai ke perangkat fisik lewat `FCMSender` — butuh kredensial
 FCM asli dan aplikasi terpasang, keduanya di luar cakupan #68 (klien FCM: #73). Layar apa pun di
 `crm_employee` — #69 dan seterusnya.
+
+### Addendum — CI gagal setelah PR dibuka, bukan disebabkan #68 sendiri
+
+`gh pr checks` menunjukkan `lint` dan `test` merah pada PR #68. Diperiksa satu per satu sebelum
+disimpulkan:
+
+- **`lint` sudah merah di `main` sejak PR #46 digabung (27 Agustus)** — dikonfirmasi lewat
+  `gh run list --branch main`, seluruh 5 CI run `main` sejak itu (#46, #47, #57, #58, #63/#64) gagal di
+  `lint` dengan temuan yang **sama persis**: `gosec` G101 ("Potential hardcoded credentials") pada
+  `apiKeyColumns` (daftar kolom SQL) dan dua konstanta `Action` (`ActionAPIKeyList`,
+  `ActionAPIKeyRevoke`) — bukan kredensial sungguhan, gosec mencocokkan substring `apiKey`/`token` di
+  **nama identifier**, bukan isinya. Penyebabnya `ci-backend.yml` memasang `golangci-lint@latest` tanpa
+  pin versi, jadi setiap update `gosec` di hulu bisa mengubah hasil linting tanpa perubahan kode apa
+  pun. Ini utang yang sudah ada lima PR sebelum #68 dibuka dan tidak pernah diperbaiki — dilaporkan di
+  sini apa adanya, bukan disembunyikan sebagai "sudah diperbaiki #68".
+  **Kode #68 sendiri menambah dua temuan baru dengan pola persis sama** (`deviceTokenColumns`,
+  `ActionDeviceTokenRegister`) — jadi tetap bagian tanggung jawab issue ini untuk tidak menambah utang
+  yang sama. Diperbaiki dengan `#nosec G101 -- <alasan>` inline, mengikuti konvensi yang sudah ada di
+  codebase ini (`internal/auth/login_limiter.go`, `internal/shared/password/argon2.go`,
+  `internal/shared/db/db.go`) — bukan mematikan `gosec` secara global di `.golangci.yml`, yang akan ikut
+  membungkam temuan sungguhan di masa depan. **Satu kesalahan sempat dibuat lalu ketahuan sebelum
+  commit**: menambahkan `// #nosec G101` sebagai trailing comment tepat setelah backtick pembuka raw
+  string (`` const apiKeyColumns = ` // #nosec... ``) — di Go, isi antara dua backtick adalah literal,
+  bukan komentar, jadi baris itu **akan menyisipkan teks komentar ke dalam string SQL sungguhan**.
+  Diperbaiki dengan menyatukan daftar kolom jadi satu baris supaya trailing comment valid di baris yang
+  sama dengan `const`, bukan di tengah string. Dua temuan `staticcheck` S1016 (`CreateInput{Name:
+  req.Name, Scopes: req.Scopes}` → `CreateInput(req)`) juga diperbaiki — struct sumber dan tujuan cocok
+  field-demi-field, jadi konversi tipe langsung valid, bukan sekadar kosmetik.
+- **`test` gagal karena bug flaky nyata di `internal/apikey`, bukan `internal/device`** —
+  `TestUnit_ResolveAPIKey_EveryFailureReasonIsIdentical` (dari #47, jauh sebelum #68) menyeed dua kunci
+  API dalam satu `fakeStore`, keduanya lewat `seedResolvableKey` yang selalu men-stamp `KeyID` yang sama
+  (`testKeyID`) kecuali diubah manual setelahnya. Kunci "revoked" DIUBAH `RevokedAt`-nya tapi TIDAK
+  `KeyID`-nya, jadi `FindByKeyID`'s `range` atas `map[uuid.UUID]*apikey.APIKey` — urutan iterasi Go
+  **diacak setiap pemanggilan** — bisa mengembalikan objek "valid" alih-alih "revoked" untuk `key_id`
+  yang sama, membuat skenario "revoked key" kadang lolos otentikasi alih-alih ditolak. **Dibuktikan
+  lewat pengulangan**: `go test -run TestUnit_ResolveAPIKey_EveryFailureReasonIsIdentical -count=200`
+  gagal berulang kali sebelum perbaikan, `-count=500` lolos bersih setelahnya. Diperbaiki dengan satu
+  baris — `revoked.KeyID = "revokedkey01"` setelah seeding, memberi kunci revoked `key_id` yang tidak
+  bertabrakan dengan kunci `valid` di map yang sama. Ini bukan bug yang diperkenalkan #68; kebetulan
+  baru terpicu pada run CI PR #68 karena keacakan `range` map, bukan karena kode #68 menyentuh paket
+  `apikey` sama sekali.
+
+Kedua perbaikan ini menyentuh berkas di luar `internal/device`/`internal/shared/push`/migration 0006 —
+dicatat secara eksplisit di sini karena itu, bukan diam-diam dianggap bagian normal cakupan #68. Baik
+alasan **kenapa** disertakan dalam PR yang sama (memblokir CI hijau PR #68 sendiri, dan keduanya kecil,
+terverifikasi, tidak mengubah perilaku produksi) dicatat di badan commit terpisah, bukan digabung ke
+commit awal #68.


### PR DESCRIPTION
## Ringkasan

Pembuka Phase 5 (Employee Mobile) — backend murni, **tanpa UI**. `device_tokens` (migration 0006),
`internal/shared/push` (interface `Sender` + `NoopSender`/`FCMSender`, FCM HTTP v1 API langsung — tanpa
Firebase Admin SDK, Rule #27), `internal/device` (domain penuh), hook push-setelah-commit di
`lead.Usecase.UpdateAssignment`, wiring config/composition-root. Diverifikasi lewat `curl` + token dummy
sesuai batas issue #68 sendiri (`crm_employee` belum ada).

## Keputusan penting

- **`uq_device_tokens_token` unik lintas organization** — pengecualian ketiga di codebase ini (setelah
  `api_keys.key_id`, `refresh_tokens.token_hash`), alasan berbeda: perangkat fisik bisa berpindah
  pemilik, registrasi ulang **memindahkan** baris (`ON CONFLICT ... DO UPDATE`), bukan menduplikasi.
  Sengaja tanpa `deleted_at` (deviasi Aturan #18).
- **`lead.PushSender` dijembatani lewat `lead.Repos.Push` (nil-safe)**, bukan parameter
  `lead.NewUsecase` — menghindari perubahan pada ~20 situs test yang sudah memanggil
  `lead.NewUsecase(store)` langsung, pola sama seperti `NotificationSender`.
- **Push dikirim setelah `InTx` kembali** (`pushRecipient` ditangkap lewat closure) — kegagalan FCM
  tidak pernah membatalkan assignment yang sudah commit (Rule #32, freeze A3).

## Temuan isolasi tenant — dua lapis proteksi redundan

Merusak predikat `organization_id` di `FindByToken` sendirian **tidak** membuat harness baru merah —
`Unregister`'s pemeriksaan kepemilikan Go-level menangkap kasus itu secara independen (lintas-organization
di sini selalu juga lintas-membership). Harness terbukti bisa gagal setelah **kedua** lapis dirusak
bersamaan. Detail lengkap, termasuk percobaan pertama yang gagal, ada di
`docs/phases/05-employee-mobile/notes.md`'s `## #68`.

## Bug ditemukan & diperbaiki sebelum commit

- Hang nyata (180+ detik) di test timeout FCM — bergantung pada `<-r.Context().Done()` yang tidak
  reliable; diganti `time.Sleep` tetap.
- Potensi panic di dua `config.Config{}` literal test (`PushProvider` zero-value jatuh ke cabang
  `default: panic` di `newPushSender`) — ditambal sebelum sempat menggagalkan test apa pun.
- Empat test produksi lama di `config_test.go` sempat merah pada full-suite run (gate `PUSH_PROVIDER`
  baru datang sebelum gate yang sebenarnya diuji test itu) — ditambal persis seperti pola
  `MAIL_PROVIDER=smtp`+`SMTP_HOST` yang sudah ada untuk test yang sama.
- Backfill wajib 2 `Action` baru ke tabel per-role `authz_test.go` (peringatan sudah ada di file sejak
  #46/#47).

## Verifikasi

- `go test -race ./...`, `go vet ./...`, `gofmt -l .` — bersih di seluruh module.
- Manual end-to-end (`docker compose up -d postgres`, `migrate up/down/up` bersih 0001→0006): registrasi
  token → re-registrasi token sama memindahkan baris (bukan duplikat) → unregister → unregister lagi
  (404, bukan crash) → assign lead ke diri sendiri (diam, TD §11) → undang karyawan, assign ke karyawan
  (`push (not sent — NoopSender)` tercatat, **tanpa** field token/data, Rule #26).

## Batas issue ini

Registrasi token dari aplikasi (Flutter belum ada — #69 dan seterusnya). Push sungguhan ke perangkat
fisik (butuh kredensial FCM asli — #73).

Refs #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)