### PR TITLE
fix(mobile): SecureTokenStorage constructor uses invalid private named parameter

### DIFF
--- a/crm_employee/lib/core/secure_store.dart
+++ b/crm_employee/lib/core/secure_store.dart
@@ -29,7 +29,18 @@ abstract class TokenStorage {
 class SecureTokenStorage implements TokenStorage {
   final FlutterSecureStorage _storage;
 
-  const SecureTokenStorage({this._storage = const FlutterSecureStorage()});
+  // NOT `{this._storage = ...}` — a named parameter can't start with an
+  // underscore (Dart's `private_optional_parameter` diagnostic). The
+  // project's FVM-pinned SDK happens not to flag this, but a plain
+  // `dart`/`flutter` on PATH does — proof this was never portable, not
+  // a version quirk to shrug off. Field stays private (encapsulation);
+  // the public parameter just has a different name and is assigned via
+  // the initializer list instead of the `this.` shorthand — which is
+  // exactly what `prefer_initializing_formals` below wants reverted,
+  // so it's suppressed here specifically, not disabled project-wide.
+  const SecureTokenStorage({FlutterSecureStorage storage = const FlutterSecureStorage()})
+    // ignore: prefer_initializing_formals
+    : _storage = storage;
 
   static const _accessTokenKey = 'access_token';
   static const _refreshTokenKey = 'refresh_token';


### PR DESCRIPTION
## Bug

`SecureTokenStorage`'s constructor used `{this._storage = const FlutterSecureStorage()}` — a named
parameter whose name starts with an underscore. Dart's `private_optional_parameter` diagnostic flags
this as an **error**, not a lint.

## Kenapa lolos CI/`fvm flutter analyze` sejauh ini

Proyek ini pinned ke Flutter 3.44.0 (Dart 3.12.0 via FVM), yang ternyata tidak menandai pola ini. SDK
Dart global di mesin dev (3.10.8 — yang dipakai editor manapun yang belum diarahkan ke
`.fvm/flutter_sdk`) **menandainya sebagai error nyata**, dikonfirmasi langsung dengan kedua SDK:

```
error - secure_store.dart:32:34 - Named parameters can't start with an underscore. - private_optional_parameter
```

Bukan false alarm IDE — kode ini memang tidak portable lintas versi SDK.

## Perbaikan

Field tetap privat (`_storage`) — enkapsulasi terjaga. Constructor sekarang pakai parameter publik
(`storage`) yang menginisialisasi field lewat initializer list, bukan shorthand `this._storage`. Ini
memunculkan lint berbeda di sisi FVM (`prefer_initializing_formals`, yang justru minta shorthand
dipakai lagi) — disupres dengan `// ignore:` **satu baris itu saja**, bukan project-wide, karena
mengikuti sarannya berarti error aslinya kembali.

## Verifikasi

- `dart analyze` (SDK global) — bersih
- `fvm flutter analyze` (SDK pinned proyek) — bersih
- `fvm flutter test` — 130 test lolos, tidak ada perubahan perilaku (murni rename constructor param +
  cara inisialisasi field)

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)