### PR TITLE
Buka Phase 6 — Connect & Embedded Form (PRD, TD, issues)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 30 Agustus 2026 — **Issue #73 selesai — Phase 5 tutup, GATE freeze terbuka** (My Tasks, FCM klien, deeplink, penutup phase).
-**Phase sekarang:** Phase 5 selesai — **GATE freeze terbuka**. Menunggu verifikasi HP Android (5 AC tersisa) dan 3–5 pengguna nyata sebelum Phase 6.
+**Last updated:** 30 Agustus 2026 — **Phase 6 dibuka** (Connect & Embedded Form, #85–#89).
+**Phase sekarang:** Phase 6 — Connect & Embedded Form. Phase 5 selesai; GATE freeze **dilewati secara sadar** oleh pemilik produk (lihat *Berikutnya*).
 
 ---
 
@@ -60,13 +60,41 @@
 
 ## Sedang Dikerjakan
 
-_(kosong)_
+**Phase 6 — Connect & Embedded Form** ([#85–#89](https://github.com/Pravasta/jualin-crm/milestone/9)).
+Dokumen: `docs/phases/06-connect-form/`. Belum ada satu baris kode; yang sudah ada baru PRD, TD, dan
+lima issue.
+
+**Sebelum #87 dikerjakan**: urus akun Cloudflare Turnstile (lihat *Punya Lead Time* di bawah). Empat
+issue lain jalan penuh tanpanya lewat `CAPTCHA_PROVIDER=none`.
 
 ---
 
 ## Berikutnya
 
-### Phase 5 — Employee Mobile — ✅ SELESAI. GATE freeze terbuka.
+### Phase 6 — Connect & Embedded Form — sedang berjalan (#85–#89)
+
+**Capture layer bisa dipakai tanpa developer.** Phase 4 membuktikan lead bisa masuk sendiri dari luar,
+tapi hanya bila pelanggan punya orang yang bisa menulis `POST /v1/leads`. Phase 6 menutup jarak itu:
+salin satu potong HTML, tempel, selesai. Sekaligus memberi capture layer rumah di produk —
+[ADR-012](./decisions/ADR-012-connect-surface-and-subscription-gating.md) menaikkan `Connect` jadi menu
+utama. Dokumen: `docs/phases/06-connect-form/`.
+
+**GATE freeze dilewati secara sadar.** Freeze bagian 4 meminta 3–5 pengguna nyata sebelum Phase 6, dan
+pemilik produk memutuskan melanjutkan lebih dulu — membangun busur SaaS penuh (Connect → Form →
+Webhook → Subscription) supaya produknya utuh sebelum dijual. **Dicatat sebagai keputusan, bukan
+kelalaian.** Konsekuensinya tetap berlaku: urutan Phase 7–9 yang direncanakan sekarang adalah tebakan
+kita, bukan permintaan pengguna, dan masih bisa berubah begitu ada masukan nyata.
+
+**Tim QA akan menguji lebih dulu** sebelum bug diperbaiki. Bug yang mereka temukan masuk lewat alur
+issue biasa (`docs/workflow.md`), bukan diperbaiki diam-diam di tengah Phase 6.
+
+> **Staging belum ada.** Belum ada satu pun deployment: `crm_be/Dockerfile` sendirian, CI berhenti di
+> `analyze`+`test`, dashboard `npm run dev`, APK harus di-build sendiri dengan berkas Firebase yang
+> di-gitignore. Tim QA praktis harus jadi developer dulu untuk bisa menguji — dan tiap tester punya
+> database sendiri, jadi bug mereka tidak saling bisa direproduksi. **Ini di luar phase manapun dan
+> belum punya issue**; ia juga tetap jadi prasyarat sebelum 3–5 pengguna nyata bisa didatangkan.
+
+### Phase 5 — Employee Mobile — ✅ SELESAI
 
 **Phase MVP terakhir tertutup total** (#68–#73). `docs/phases/05-employee-mobile/`. Kalimat inti MVP
 sekarang berjalan ujung-ke-ujung untuk pertama kalinya: login → lead → telepon/WA → ubah status →
@@ -83,10 +111,9 @@ dan `docs/testing/flow/06-checklist-akhir.md` bagian 7. **Ini adalah langkah man
 sebelum atau sejajar dengan mencari 3–5 pengguna nyata di bawah — keduanya butuh perangkat sungguhan
 untuk diyakini, bukan dibaca dari kode.
 
-**GATE freeze (bagian 4)**: cari **3–5 pengguna nyata** sebelum Phase 6. Urutan Phase 6–9 ditentukan
-apa yang mereka minta, bukan tebakan — freeze sendiri tidak memutuskan urutannya di muka. Panduan demo
-langkah-demi-langkah sudah ada (`docs/testing/flow/`), email produksi sungguhan terkirim (Phase 4.6) —
-tidak ada lagi penghalang teknis untuk demo, sisanya jadwal dan keputusan pemilik produk.
+**Mencari 3–5 pengguna nyata tetap belum dilakukan** — GATE-nya dilewati (lihat Phase 6 di atas), tapi
+kebutuhannya tidak hilang. Panduan demo langkah-demi-langkah sudah ada (`docs/testing/flow/`), email
+produksi sungguhan terkirim (Phase 4.6); yang menghalangi sekarang tinggal staging dan jadwal.
 
 **Android dulu, iOS ditunda** (keputusan M1, tetap berlaku pasca-phase) — Apple Developer Program
 berbayar dan belum ada. Tidak mengorbankan satu pun kriteria selesai phase (freeze tidak menyebut
@@ -193,6 +220,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | **Domain + email sender** (SPF/DKIM/DMARC) | Phase 1 | **Sekarang** | Verifikasi email menggerbangi login (keputusan B3), jadi ia jalur kritis Phase 1. Propagasi DNS dan pemanasan reputasi pengirim butuh waktu — dan email verifikasi yang masuk spam akan membunuh funnel registrasi **tanpa menghasilkan satu pun error**. |
 | **Apple Developer Program** | Phase 5 — **iOS saja** | Saat iOS diaktifkan | Enrollment bisa berhari-hari sampai berminggu (verifikasi identitas / D-U-N-S untuk organisasi). **Tidak lagi memblokir Phase 5** sejak keputusan M1 (Android dulu) — yang terhalang hanya build iOS & push iOS, bukan satu pun kriteria selesai phase. |
 | **Firebase project (FCM)** | Phase 5 | ✅ **App terdaftar** (`jualin-crm`, `flutterfire configure` sudah dijalankan #73) | Yang tersisa: service account untuk backend (`FCM_CREDENTIALS_FILE`) — sengaja ditinggalkan ke pemilik produk, mencetak kredensial GCP jangka panjang. Langkah persisnya `td.md` §14 langkah 3. |
+| **Cloudflare Turnstile** | Phase 6 — **issue #87 saja** | ⬜ Belum diurus | Gratis, hitungan menit, tapi butuh akun + site key + secret key. **Memblokir satu issue, bukan phase-nya**: `CAPTCHA_PROVIDER=none` membuat #85/#86/#88/#89 jalan penuh. Yang terhalang hanya verifikasi anti-spam sungguhan. Langkah persisnya `docs/phases/06-connect-form/td.md` §14. |
 
 **Tidak ada yang memblokir Phase 0.** Dicatat di sini justru supaya tidak tersadar terlambat.
 
@@ -205,6 +233,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 - [x] App Android terdaftar di Firebase ← `flutterfire configure` dijalankan #73, `google-services.json`/`firebase_options.dart` asli ada (git-ignored, lihat `crm_employee/README.md`)
 - [ ] Service account backend dibuat ← `FCM_CREDENTIALS_FILE`, ditinggalkan ke pemilik produk (`td.md` §14 langkah 3)
 - [ ] Apple Developer Program terdaftar ← hanya untuk iOS, ditunda (keputusan M1)
+- [ ] Cloudflare Turnstile disiapkan ← site key + secret key, memblokir issue #87 saja (`06-connect-form/td.md` §14)
 
 > Domain juga menentukan konfigurasi cookie (`Secure`, `SameSite`, scope), CORS, dan alamat pengirim email — semuanya disentuh di Phase 1.
 
@@ -239,5 +268,6 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 4.5 | Hardening | ✅ | ✅ | ✅ #57–#58 | ✅ |
 | 4.6 | Email Delivery | ✅ | ✅ | ✅ #63–#64 | ✅ |
 | 5 | Employee Mobile | ✅ | ✅ | ✅ #68–#73 | ✅ |
+| 6 | Connect & Embedded Form | ✅ | ✅ | ✅ #85–#89 | ⬜ |
 
 Pekerjaan yang sedang berjalan: `gh issue list --state open`

--- a/docs/phases/06-connect-form/issues.md
+++ b/docs/phases/06-connect-form/issues.md
@@ -1,0 +1,106 @@
+# Phase 6 — Connect & Embedded Form · Issues
+
+> Indeks pekerjaan. **Tanpa kolom status** — status hidup di GitHub ([ADR-008](../../decisions/ADR-008-delivery-workflow.md)).
+>
+> Status terkini: `gh issue list --milestone "Phase 6 — Connect & Embedded Form"`
+
+**Milestone:** [Phase 6 — Connect & Embedded Form](https://github.com/Pravasta/jualin-crm/milestone/9)
+
+---
+
+## Daftar
+
+| # | Judul | Aplikasi | Cakupan | TD |
+|---|---|---|---|---|
+| [85](https://github.com/Pravasta/jualin-crm/issues/85) | Migration `0007_forms`, domain `form`, CRUD kredensial | `crm_be` | `0007_forms` + `leads.source_form_id`, `internal/form`, format `pk_` (D3), 5 endpoint pengelolaan, audit log | §1, §2, §8, §11 |
+| [86](https://github.com/Pravasta/jualin-crm/issues/86) | Permukaan Connect + pindahkan pengelolaan API key | `crm_dashboard` | `NAV_ITEMS`/`NAV_ICONS`/`nav.test.ts`, `/connect` + tiga kartu, `/connect/api(/docs)` pindahan, redirect rute lama | §10 |
+| [87](https://github.com/Pravasta/jualin-crm/issues/87) | Endpoint submit publik + lima lapis anti-spam | `crm_be` | `POST /v1/forms/{public_key}/submit`, `PrincipalPublicForm` + `FormID`, cabang `authz` ketiga, Origin/honeypot/time-trap/rate limit/Turnstile. **Risiko keamanan tertinggi phase ini** | §3–§6, §9 |
+| [88](https://github.com/Pravasta/jualin-crm/issues/88) | Halaman embed (iframe) + CSP per-form | `crm_be` | `GET /embed/{public_key}`, `html/template` + `embed.FS`, `frame-ancestors` per-form. **Kelas kemampuan baru** | §7 |
+| [89](https://github.com/Pravasta/jualin-crm/issues/89) | Manajemen form + snippet embed | `crm_dashboard` | Layar buat/ubah/nonaktifkan, toggle+label field, allowlist, snippet. **Penutup phase** | §10, §12, §15 |
+
+---
+
+## Urutan
+
+```
+#85 domain ──┬──► #87 submit publik ──┬──► #89 UI + penutup
+             └──► #88 halaman embed ──┘
+#86 Connect ───────────────────────────────► #89
+```
+
+| Dependensi | Sifat |
+|---|---|
+| #87 → #85 | **Keras.** Tidak ada yang bisa di-resolve sebelum kredensialnya ada. |
+| #88 → #85 | **Keras.** Halaman perlu konfigurasi form untuk dirender. |
+| #87 ↔ #88 | **Bukan prasyarat satu sama lain.** Boleh paralel. #88 menanam token yang #87 validasi, tapi keduanya bisa ditulis terpisah — kontraknya `formtoken` (TD §6), bukan urutan pengerjaan. |
+| #86 → apa pun | **Tidak ada.** Boleh dikerjakan kapan saja, termasuk pertama. |
+| #89 → #85, #86 | **Keras.** Butuh endpoint pengelolaan **dan** rumah `/connect`. |
+
+**#86 boleh mendahului #85.** Sisanya berurutan sesuai graf.
+
+---
+
+## Batas per issue
+
+| Issue | Berhenti di |
+|---|---|
+| #85 | Form bisa dibuat, dilihat, dan dinonaktifkan lewat `curl` **sebagai user**. Kredensialnya **belum bisa dipakai untuk apa pun** — tidak ada endpoint yang menerimanya. |
+| #86 | `Connect` jadi menu, API key pindah, tautan lama tetap hidup. Kartu Formulir boleh mengarah ke rute yang **belum berisi**. |
+| #87 | `curl` dari mesin luar membuat lead lewat `public_key`. **Belum ada halaman yang menyajikan formnya**, belum ada UI. |
+| #88 | Halaman form tampil dan bisa di-iframe sesuai allowlist. Submit-nya ditangani #87. |
+| #89 | Phase 6 tutup. Webhook (Phase 7) dan penegakan paket (Phase 8) **tidak** disentuh. |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Dua issue yang perlu perhatian ekstra saat review
+
+**#87 — kredensialnya memang terbuka, jadi daftar kemampuannya yang harus tertutup.**
+
+Ini bukan hiperbola: `public_key` tertanam di HTML setiap halaman yang memasang form. Siapa pun yang
+membuka *view source* memilikinya. Yang membatasi kerusakannya **bukan** kerahasiaan kunci, melainkan
+`publicFormAllows` yang berisi tepat satu baris.
+
+Yang layak direview **bukan** jumlah test yang lolos, melainkan **bentuk** dua hal:
+
+1. Apakah penolakan datang dari *"action ini tidak ada di peta"* (gagal aman — action baru di phase
+   manapun otomatis tertutup) atau dari *"handler ini mengecek"* (gagal terbuka — handler yang lupa
+   otomatis terbuka)?
+2. Apakah test-nya **tabel atas seluruh `authz.Action`**, atau daftar action tulisan tangan? Yang kedua
+   hijau hari ini dan bocor di phase berikutnya, saat seseorang menambah action dan tidak ada yang
+   mengingatkannya.
+
+Ditambah satu yang khas issue ini: **honeypot yang bisa dibedakan tidak ada gunanya.** Bila bot bisa
+membedakan sukses palsu dari sukses sungguhan — lewat status code, bentuk body, atau **waktu
+respons** — ia akan belajar, dan lapisannya hilang tanpa ada yang sadar.
+
+**#88 — halaman HTML pertama di backend, dan satu-satunya jalur XSS di phase ini.**
+
+Label field berasal dari input pelanggan dan dirender ke HTML. `html/template` melakukan escaping
+kontekstual; `text/template` tidak. Keduanya punya API yang **hampir identik**, dan tertukarnya tidak
+menghasilkan error apa pun — hanya kerentanan yang diam.
+
+`frame-ancestors` juga harus per-form, bukan satu kebijakan global. Form dengan `allowed_origins`
+kosong wajib **gagal tertutup** (`'none'`), bukan terbuka.
+
+---
+
+## Setelah kelimanya selesai
+
+Phase 6 tutup bila **14 acceptance criteria** di [`prd.md`](./prd.md) terpenuhi — terutama #1
+(snippet ditempel di halaman kosong → lead masuk) dan #2 (`public_key` tidak bisa membaca apa pun).
+Lalu:
+
+1. `api.md`, `authentication.md`, `authorization.md`, `multi-tenancy.md` diperbarui (TD §15)
+2. `docs/testing/flow/` bertambah berkas: memasang form dan mengisinya dari browser
+3. `docs/STATUS.md` — Phase 6 ✅, **kunci Turnstile** masuk *Punya Lead Time*
+4. Buka **Phase 7 — Webhook**, kanal ketiga di `Connect` yang sudah berdiri
+
+> **Sebelum #87 dikerjakan, urus akun Cloudflare Turnstile** (TD §14). Gratis dan hitungan menit, tapi
+> ia satu-satunya pihak ketiga di phase ini. `CAPTCHA_PROVIDER=none` membuat #85, #86, #88, dan #89
+> jalan penuh tanpanya — yang terhalang hanya verifikasi anti-spam sungguhan di #87.
+
+> **Staging masih belum ada.** Phase 6 tidak mengubah itu. Tim QA tetap terhambat sampai deployment
+> diurus terpisah — dan kriteria #1/#10 phase ini (menempel snippet ke halaman sungguhan) akan jauh
+> lebih mudah diverifikasi setelah ada.

--- a/docs/phases/06-connect-form/prd.md
+++ b/docs/phases/06-connect-form/prd.md
@@ -1,0 +1,130 @@
+# Phase 6 — Connect & Embedded Form · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md).
+> Sumber: [`architecture/freeze.md`](../../architecture/freeze.md) bagian 1.2 (`forms`), 3.4 (Embedded Form → Phase 6), 5.1 (Aturan #23), 8.4 (migration `0007`) · [ADR-005](../../decisions/ADR-005-public-form-key.md) (kenapa `public_key` **bukan** API key, dan seluruh proteksi anti-spam) · [ADR-012](../../decisions/ADR-012-connect-surface-and-subscription-gating.md) (Connect sebagai permukaan produk) · [ADR-004](../../decisions/ADR-004-api-key-format.md) (format kredensial yang **tidak** ditiru di sini)
+
+---
+
+## Tujuan
+
+**Capture layer bisa dipakai tanpa developer.**
+
+Phase 4 membuktikan lead bisa masuk sendiri dari luar — tetapi hanya bila pelanggan punya orang yang
+bisa menulis `POST /v1/leads` dengan header `Authorization`. Untuk pemilik toko yang websitenya dibuat
+sekali oleh vendor tiga tahun lalu, itu sama saja dengan tidak bisa.
+
+Phase 6 menutup jarak itu: **salin satu potong HTML, tempel di halaman, selesai.**
+
+Sekaligus phase ini memberi capture layer **rumah** di dalam produk. Hari ini API key hidup sebagai
+sub-halaman `Pengaturan → API Keys`, ditemukan hanya oleh orang yang sudah tahu ia ada. ADR-012
+menaikkannya jadi menu `Connect` — satu tempat yang menjawab pertanyaan yang sebenarnya diajukan
+pelanggan: *"bagaimana cara menyambungkan website saya?"*, bukan *"di mana API key saya?"*.
+
+> Ini phase kedua yang menghadapi **klien yang bukan kita**, dan yang pertama menghadapi **browser orang
+> asing**. Bedanya tajam: integrator Phase 4 membaca dokumentasi dan memegang kredensial rahasia;
+> pengunjung Phase 6 tidak membaca apa pun, dan kredensialnya **sengaja terbuka untuk semua orang**.
+> Itulah kenapa ADR-005 memisahkannya dari API key sejak Agustus, jauh sebelum ada kode.
+
+---
+
+## Kebutuhan
+
+| # | Sebagai… | Saya butuh… | Supaya… |
+|---|---|---|---|
+| 1 | Pemilik toko | Memasang form penangkap lead di website saya **tanpa developer** | Website saya dibuat vendor tiga tahun lalu; menyewa orang untuk satu form tidak masuk akal |
+| 2 | Owner | Satu tempat yang menjawab *"bagaimana menyambungkan sistem saya"* | Saya tidak tahu bedanya "API key" dan "webhook" — saya cuma ingin lead masuk |
+| 3 | Owner | Form saya hanya bekerja di domain saya sendiri | Supaya orang lain tidak bisa menyalin formnya dan mengirimi saya sampah atas nama saya |
+| 4 | Owner | Mengganti label field mengikuti bahasa bisnis saya | "Product" tidak berarti apa-apa bagi pelanggan salon; "Layanan yang diminati" berarti |
+| 5 | Owner | Mematikan satu form tanpa mengganggu form atau integrasi lain | Kampanye selesai; formnya tidak perlu hidup selamanya |
+| 6 | Pengunjung website pelanggan | Mengisi form tanpa puzzle yang menyebalkan | Saya cuma ingin bertanya harga, bukan memilih gambar lampu lalu lintas |
+| 7 | Pemilik sistem | Spam tidak pernah masuk sebagai lead | Di model harga terjangkau, **setiap lead spam adalah biaya yang ditanggung Jualin** — storage, compute, dan reputasi |
+| 8 | Pemilik sistem | Kredensial form yang jelas-jelas terekspos **tidak bisa membaca apa pun** | Form hidup di browser siapa saja; kebocorannya otomatis pada setiap pemasangan, bukan risiko probabilistik |
+
+---
+
+## Acceptance Criteria
+
+Phase 6 selesai bila **semuanya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | Form ditempel di halaman HTML statis **di luar jaringan kita** → diisi → lead muncul di dashboard dengan `source = form` dan penanda form mana yang mengirimnya |
+| 2 | `public_key` yang diambil dari DevTools **tidak bisa** membaca lead, mengubah data, atau memanggil endpoint lain — bukan karena setiap handler mengeceknya, melainkan karena otorisasi memang tidak punya jalan untuk mengizinkannya (Aturan #23, ADR-005) |
+| 3 | Submit dari domain di luar allowlist form ditolak |
+| 4 | Honeypot terisi → submission dibuang **diam-diam**, dengan respons yang **tidak bisa dibedakan** dari sukses. Bot tidak boleh bisa belajar |
+| 5 | Submit lebih cepat dari 2 detik setelah form dirender ditolak |
+| 6 | Payload melebihi 32KB ditolak `413` |
+| 7 | Rate limit aktif **per IP dan per form**; setiap response membawa `X-RateLimit-*`, `429` membawa `Retry-After` |
+| 8 | `CAPTCHA_PROVIDER=none` cukup untuk mengembangkan seluruh phase; `none` **ditolak saat boot** ketika `APP_ENV=production` (Aturan #36) |
+| 9 | Owner membuat form, mengubah label field, mengatur allowlist, dan menonaktifkan form **dari dashboard**, tanpa `curl` |
+| 10 | Snippet embed bisa **disalin dan langsung bekerja** — diverifikasi dengan menempelkannya ke halaman kosong, bukan dengan membacanya |
+| 11 | `Connect` menjadi menu; pengelolaan API key pindah ke sana; **tautan lama `/settings/api-keys` tetap hidup** (redirect, bukan 404) |
+| 12 | Halaman embed mengirim `Content-Security-Policy` dengan `frame-ancestors` sesuai allowlist **form itu**, bukan daftar global |
+| 13 | Field yang tidak dikenal tetap tersimpan apa adanya di `raw_payload` — sama seperti jalur API |
+| 14 | Harness isolasi tenant bertambah kasus untuk kredensial baru, dan **tetap terbukti bisa gagal** |
+
+---
+
+## Keputusan yang ditutup di phase ini
+
+Tujuh keputusan yang jatuh tempo di sini, ditutup di muka daripada di tengah implementasi. Alasan
+teknis lengkap di [`td.md`](./td.md); yang di bawah adalah **apa** dan **kenapa** dalam kalimat produk.
+
+| # | Pertanyaan | Keputusan | Alasan |
+|---|---|---|---|
+| **D1** | Halaman form yang di-iframe disajikan dari mana? | **Backend Go**, `GET /embed/{public_key}`, memakai `html/template` + `embed.FS`. | Lihat catatan *"Penyimpangan tertulis dari ADR-005"* di bawah — ini satu-satunya keputusan phase ini yang menyimpang dari ADR yang sudah Accepted, dan karena itu ditulis terpisah. |
+| **D2** | CAPTCHA | `CAPTCHA_PROVIDER=none\|turnstile`. `none` = lewati verifikasi, ditolak saat `APP_ENV=production`. | Preseden persis `MAIL_PROVIDER` (Phase 4.6) dan `PUSH_PROVIDER` (Phase 5): satu env var membuat seluruh phase bisa dikerjakan tanpa akun pihak ketiga, sementara produksi tetap tidak bisa berjalan setengah siap. Kunci Turnstile punya lead time — ia tidak boleh memblokir empat dari lima issue. |
+| **D3** | Format `public_key` | `pk_` + 22 karakter base64url acak. Disimpan **plaintext**, tidak di-hash. | ADR-005 sudah menetapkan ia bukan rahasia — meng-hash-nya akan menyiratkan sebaliknya kepada siapa pun yang membaca skema, dan lookup-nya butuh nilai mentah. Prefix `pk_` sengaja **tidak** menyerupai `jln_live_`: dua kredensial dengan aturan yang berlawanan tidak boleh terlihat mirip, baik oleh manusia yang menyalinnya maupun oleh parser yang memilahnya. |
+| **D4** | Angka rate limit submit | Per IP **dan** per form, keduanya lewat env, default konservatif. | Dua sumbu berbeda: per-IP menghalangi satu bot; per-form menghalangi botnet yang menyerang satu pelanggan. Satu saja tidak cukup. Angkanya **bukan hasil pengukuran** — sama jujurnya dengan `PUBLIC_API_RATE_LIMIT=60`, dan header `X-RateLimit-*` ada supaya perubahannya tidak mengejutkan. |
+| **D5** | Bagaimana lead dibuat? | Memakai ulang `lead.Usecase.Create` apa adanya. `source` dipaksa `'form'` dan `source_form_id` diambil **dari principal**, tidak pernah dari body. | Persis pola jalur API key Phase 4. Menulis jalur pembuatan lead kedua berarti dua tempat yang harus tetap sama selamanya — termasuk penomoran lead, `raw_payload`, dan notifikasi assignment. |
+| **D6** | Siapa yang melihat menu `Connect`? | **Semua role**; gerbangnya di dalam layar, bukan di sidebar. | Mengikuti `/settings` hari ini. Nav sadar-role **belum pernah ada** di dashboard ini — menciptakannya untuk satu menu berarti menambah mekanisme baru demi kerapian yang tidak diminta siapa pun (Aturan #27). |
+| **D7** | Time-trap 2 detik | Token HMAC **stateless** yang ditanam di halaman embed, memuat id form + waktu terbit; divalidasi umurnya (>2 detik, <30 menit). | Tanpa token, waktu render hanya bisa dititipkan ke field tersembunyi — yang bisa dipalsukan bot dengan satu baris. HMAC membuatnya tidak bisa dikarang tanpa menyimpan state apa pun. **Ini time-trap, bukan anti-replay**: token yang sah masih bisa dipakai berulang dalam jendela 30 menit. Perlindungan terhadap pengulangan datang dari rate limit, bukan dari sini. |
+
+### Penyimpangan tertulis dari ADR-005 — D1
+
+ADR-005 menulis halaman form *"disajikan dari **domain terpisah** (`cdn.…`)"*. Kalimat itu menyiratkan
+host statis atau CDN. Phase 6 **tidak** melakukannya, dan alasannya perlu berdiri terbuka:
+
+| | |
+|---|---|
+| **Maksud ADR tetap dipenuhi** | Yang sebenarnya dilindungi ADR-005 adalah **isolasi origin**, CSP ketat, dan `frame-ancestors` yang mengikuti allowlist per-form. Ketiganya ditegakkan handler Go, dan `frame-ancestors` per-form justru **lebih tepat** dari host statis yang hanya bisa mengirim satu kebijakan untuk semua form. |
+| **Domain terpisah tetap bisa** | `cdn.jualin.id` diarahkan ke service yang sama saat deploy. Domain terpisah adalah keputusan **DNS**, bukan keputusan aplikasi — dan memisahkan aplikasinya sekarang tidak membuat domainnya lebih terpisah. |
+| **Belum ada deployment sama sekali** | Menambah aplikasi keempat berarti menambah deployable dan workflow CI untuk sesuatu yang, hari ini, belum punya satu pun tempat berjalan. Aturan #27. |
+
+**Kewajiban yang ikut lahir dari keputusan ini** — dicatat supaya tidak hilang: saat deployment
+akhirnya dikerjakan, halaman embed **wajib** disajikan dari hostname yang berbeda dari dashboard.
+Menyajikannya dari origin yang sama dengan dashboard membatalkan isolasi yang ADR-005 lindungi.
+
+---
+
+## Di luar cakupan
+
+| Tidak dikerjakan | Ke |
+|---|---|
+| Webhook masuk & keluar | Phase 7 — kanal ketiga di `Connect`, mekanisme yang sama sekali berbeda |
+| Penegakan paket, keadaan "terkunci", `usage_counters` | Phase 8 — ADR-012 §4 sengaja menunda angkanya sampai ada data pengguna nyata |
+| Landing page & alur *landing → register → dashboard* | Belum terjadwal — ADR-012 §Batas |
+| Form builder dinamis (field yang bisa ditambah pelanggan) | ADR-005: field tetap dengan label yang bisa diubah. Builder butuh schema field + mesin validasi + renderer + strategi penyimpanan — fitur besar tersendiri, dan tidak diperlukan untuk membuktikan capture layer bekerja |
+| Tabel `form_submissions` | **Tidak pernah.** Freeze 1.3 menolaknya: submission yang valid **adalah** Lead + `raw_payload`. Ia baru dipertimbangkan bila kita perlu menyimpan submission yang **ditolak** |
+| Embed lewat inline script (menyatu dengan CSS situs) | ADR-005 memilih iframe untuk MVP; styling terbatas adalah harga yang wajar untuk isolasi. Inline script bisa ditawarkan nanti sebagai opsi lanjutan |
+| Staging / deployment untuk QA | Terpisah dari phase manapun — dan tetap jadi prasyarat sebelum Tim QA bisa bekerja |
+
+---
+
+## Dependensi
+
+Phase 1–5 selesai. Yang dipakai phase ini sudah ada seluruhnya:
+
+| Yang dipakai | Dari | Catatan |
+|---|---|---|
+| `tenant.PrincipalPublicForm` | Phase 1 | **Sudah ada, nol pemakaian** — konstanta ini ditulis di `tenant.go` sejak Phase 1 dan tidak pernah disentuh siapa pun. Phase 6 adalah momen itu, persis seperti `APIKeyID` yang menunggu Phase 4 |
+| `authz.Require` yang bercabang pada `PrincipalType` | Phase 4 | Phase 6 menambah cabang **ketiga**, bukan menyisipkan baris ke peta API key. Dua gerbang yang sudah ada tidak berubah |
+| `apikey.Repository.FindByKeyID` — pengecualian tertulis tanpa `tenant.Context` | Phase 4 | `FindByPublicKey` bentuknya identik dengan alasan yang sama (Aturan #5): organization adalah **hasil** lookup, bukan input |
+| `leads.source` menerima `'form'`, `raw_payload jsonb` | Phase 2 | Dibuat di `0003` **sebelum** ada yang memakainya, persis untuk phase ini — tidak ada `ALTER` pada enum |
+| `lead.Usecase.Create` | Phase 2 | Dipakai ulang apa adanya (D5) — termasuk penomoran lead dan notifikasi assignment |
+| `ratelimit.FixedWindow.Take` + `httpx.SetRateLimitHeaders` | Phase 1, 4, 4.5 | Sudah lengkap dengan `Result{Limit, Remaining, ResetAt}` dan eviction dua generasi. Phase 6 hanya menambah key baru |
+| `crm_dashboard` — sesi, klien API, app shell, `canManageAPIKeys` | Phase 3, 4 | Layar baru menempel pada kerangka yang sudah ada; `canManageForms` lahir di sebelahnya |
+
+**Satu kewajiban diwarisi ADR-012**: memindahkan pengelolaan API key ke `/connect/api` **tanpa
+mematikan tautan lama**. Pelanggan Phase 4 yang sudah menyimpan `/settings/api-keys` tidak boleh
+menemukan 404 karena kita merapikan menu.

--- a/docs/phases/06-connect-form/td.md
+++ b/docs/phases/06-connect-form/td.md
@@ -1,0 +1,520 @@
+# Phase 6 — Connect & Embedded Form · TD
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+> Ini **delta** untuk phase ini. Aturan yang sudah ada di [`freeze.md`](../../architecture/freeze.md) tidak diulang, hanya dirujuk.
+
+---
+
+## 1. Schema — migration `0007_forms`
+
+Nomornya sudah dipesan freeze 8.4: *"`forms` + `leads.source_form_id`"*.
+
+```sql
+CREATE TABLE forms (
+    id               uuid PRIMARY KEY,
+    organization_id  uuid NOT NULL REFERENCES organizations (id),
+    public_key       text NOT NULL,
+    name             text NOT NULL,
+    fields           jsonb NOT NULL,
+    allowed_origins  text[] NOT NULL DEFAULT '{}',
+    submit_count     integer NOT NULL DEFAULT 0,
+    created_by_membership_id uuid,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now(),
+    deleted_at       timestamptz,
+
+    CONSTRAINT uq_forms_id_org    UNIQUE (id, organization_id),
+    CONSTRAINT uq_forms_public_key UNIQUE (public_key),
+    CONSTRAINT ck_forms_name_not_blank CHECK (btrim(name) <> ''),
+    CONSTRAINT fk_forms_created_by
+        FOREIGN KEY (created_by_membership_id, organization_id)
+        REFERENCES memberships (id, organization_id)
+);
+
+CREATE INDEX ix_forms_org ON forms (organization_id, created_at DESC)
+    WHERE deleted_at IS NULL;
+
+ALTER TABLE leads ADD COLUMN source_form_id uuid;
+ALTER TABLE leads ADD CONSTRAINT fk_leads_source_form
+    FOREIGN KEY (source_form_id, organization_id)
+    REFERENCES forms (id, organization_id);
+```
+
+`leads.source` **sudah** menerima `'form'` sejak `0003` dan `raw_payload jsonb` sudah ada — tidak ada
+`ALTER` pada keduanya. `ALTER TABLE ADD COLUMN` nullable bersifat instan.
+
+### `uq_forms_public_key` — pengecualian unik-lintas-organization **keempat**
+
+Sama seperti `api_keys.key_id` (0005), `device_tokens.token` (0006), dan `refresh_tokens.token_hash`
+(0002), constraint ini **tidak** composite dengan `organization_id`. Alasannya sekelas `api_keys.key_id`,
+bukan sekelas `device_tokens.token`:
+
+> Lookup kredensial terjadi **sebelum** organization diketahui — organization justru **hasil** dari
+> lookup itu (Aturan #5). Composite unique tidak mungkin dibuat: tidak ada `organization_id` untuk
+> dijadikan bagian kunci sebelum barisnya ditemukan.
+
+Komentar migration ditulis mengikuti bentuk tiga pendahulunya, dan `multi-tenancy.md` ditambah baris
+keempat (§15).
+
+### `fields` sebagai JSONB — alasan tertulis (Aturan #17)
+
+Aturan #17 menuntut alasan tertulis untuk setiap JSONB. Isinya adalah **konfigurasi tampilan**, bukan
+data yang di-query:
+
+```json
+{
+  "name":    { "enabled": true,  "required": true,  "label": "Nama Lengkap" },
+  "email":   { "enabled": true,  "required": false, "label": "Email" },
+  "phone":   { "enabled": true,  "required": true,  "label": "Nomor WhatsApp" },
+  "company": { "enabled": false, "required": false, "label": "Perusahaan" },
+  "message": { "enabled": true,  "required": false, "label": "Pesan" },
+  "product": { "enabled": false, "required": false, "label": "Layanan Diminati" }
+}
+```
+
+Enam kunci itu **tetap** (ADR-005: field tetap, bukan builder). Tidak pernah ada query yang memfilter
+atau mengurutkan berdasarkan isinya — ia dibaca utuh saat merender form dan saat memvalidasi submit.
+Kolom terpisah untuk 6 field × 3 atribut berarti 18 kolom yang seluruhnya hanya dibaca bersamaan.
+
+`submit_count` **bukan** usage counter Phase 8 — ia hanya angka untuk ditampilkan di dashboard
+("form ini pernah dipakai atau tidak"). Penegakan kuota adalah `usage_counters`, mekanisme berbeda
+(TD Phase 4 §19).
+
+---
+
+## 2. Format & siklus hidup `public_key` (keputusan D3)
+
+```
+pk_<22 karakter base64url>
+```
+
+| Aspek | Ketentuan |
+|---|---|
+| Pembangkitan | `crypto/rand`, 16 byte → 22 karakter base64url tanpa padding |
+| Penyimpanan | **Plaintext.** Tidak di-hash, tidak ada `secret_hash` |
+| Perbandingan | Kesetaraan biasa lewat query `WHERE public_key = $1`. **Bukan** `subtle.ConstantTimeCompare` |
+| Prefix | `pk_` — sengaja **tidak** menyerupai `jln_live_`/`jln_test_` |
+| Rotasi | Tidak ada di phase ini. Menonaktifkan form (`deleted_at`) adalah cara mencabutnya |
+
+**Kenapa plaintext, dan kenapa itu bukan kelalaian.** `public_key` memang dirancang untuk terbaca semua
+orang — ia tertanam di HTML halaman pelanggan. Meng-hash-nya akan (a) membuat lookup mustahil tanpa
+menyimpan nilai mentahnya juga, dan (b) menyesatkan siapa pun yang membaca skema, seolah bocornya
+adalah insiden. Yang melindungi endpoint ini **bukan** kerahasiaan kunci, melainkan daftar kemampuan
+yang tertutup (§4) plus lima lapis anti-abuse (§6).
+
+**Kenapa bukan `subtle.ConstantTimeCompare`.** Perbandingan waktu-tetap melindungi dari serangan
+timing yang menebak rahasia. Di sini tidak ada rahasia untuk ditebak. Memakainya akan menyiratkan
+ancaman yang tidak ada.
+
+> Aturan #20 mengikat **password (argon2id)** dan **API key (SHA-256 + `ConstantTimeCompare`)**.
+> `public_key` bukan keduanya — ADR-005 sudah menempatkannya di baris ketiga tabel kredensial freeze
+> 5.1 dengan kolom *"Punya identitas orang? ❌"* dan kemampuan *"hanya submit"*.
+
+---
+
+## 3. Autentikasi — principal keempat
+
+`tenant.PrincipalPublicForm` **sudah ada** di `internal/shared/tenant/tenant.go` sejak Phase 1 dengan
+**nol pemakaian**. Phase 6 adalah momen itu.
+
+`tenant.Context` bertambah satu field, mengikuti persis cara `APIKeyID` ditambahkan sebelum Phase 4:
+
+```go
+// FormID is only ever populated when PrincipalType == PrincipalPublicForm
+// (Phase 6). Like APIKeyID, it is the id of the credential that resolved
+// this request, and lead.Usecase.Create reads it to stamp
+// leads.source_form_id — never from the request body (Rule #5).
+FormID *uuid.UUID
+```
+
+### Resolusi — tidak lewat `Authorization`
+
+Berbeda dari API key, `public_key` **tidak pernah** dikirim sebagai bearer token. Ia ada di **path**:
+
+```
+POST /v1/forms/{public_key}/submit
+```
+
+Konsekuensinya: **tidak ada middleware auth yang dipasang** di route ini. Handler-nya sendiri yang
+memanggil `form.Usecase.ResolvePublicKey(ctx, key) (tenant.Context, error)`. Ini disengaja —
+`authn.MiddlewareWithAPIKey` membaca `Authorization` dan akan salah memperlakukan request tanpa header
+sebagai anonim.
+
+`ResolvePublicKey` mengembalikan `tenant.Context{OrganizationID, PrincipalType: PrincipalPublicForm,
+FormID: &found.ID}`. `MembershipID`, `UserID`, `Role`, `Scopes`, dan `APIKeyID` **seluruhnya kosong** —
+form tidak punya identitas orang, dan `Scopes` secara eksplisit hanya milik principal API key.
+
+Setiap kegagalan (kunci tidak ada, form dihapus, organization tidak aktif) mengembalikan **error yang
+identik** `404 not_found` — bukan `401`. Kunci yang salah dan form yang dihapus tidak boleh bisa
+dibedakan.
+
+---
+
+## 4. Otorisasi — cabang ketiga, daftar tertutup
+
+`authz.Require` hari ini bercabang dua: `PrincipalAPIKey` → `apiKeyScopeFor`, selain itu →
+`permissions[Role]`. Phase 6 menambah cabang **ketiga**, bukan menyisipkan baris ke peta API key:
+
+```go
+// publicFormAllows is the complete list of what a public form key can do.
+// One line, and it must stay that way: the credential is embedded in
+// every page that installs the form, so anything reachable here is
+// reachable by anyone who views source (ADR-005).
+var publicFormAllows = map[Action]bool{
+	ActionLeadCreate: true,
+}
+
+func Require(t tenant.Context, action Action) error {
+	if t.PrincipalType == tenant.PrincipalPublicForm {
+		if !publicFormAllows[action] {
+			return forbiddenError()
+		}
+		return nil
+	}
+	if t.PrincipalType == tenant.PrincipalAPIKey { /* unchanged */ }
+	/* role path unchanged */
+}
+```
+
+**Deny-by-absence, sama seperti `apiKeyScopeFor`.** Action baru yang lahir di phase manapun otomatis
+tertutup untuk form tanpa siapa pun perlu menuliskan pengecualiannya. Kriteria #2 PRD diuji sebagai
+**tabel atas seluruh `authz.Action`**, bukan daftar tulisan tangan — pola yang sama yang dituntut
+review #47.
+
+Dua peta tidak digabung karena keduanya menjawab pertanyaan berbeda: API key punya *scope yang bisa
+dipilih pelanggan*; form punya *satu kemampuan tetap*. Menyatukannya berarti suatu hari seseorang
+menambah scope ke API key dan tanpa sadar memberikannya juga kepada setiap form yang terpasang.
+
+---
+
+## 5. `POST /v1/forms/{public_key}/submit` — alur
+
+```
+1. Rate limit per IP        → 429 + X-RateLimit-* bila lewat
+2. Rate limit per public_key → 429 + X-RateLimit-* bila lewat
+3. Baca body, cap 32KB       → 413 bila lewat
+4. ResolvePublicKey          → 404 bila tidak ketemu / dihapus
+5. Origin allowlist          → 403 bila di luar daftar
+6. Honeypot terisi?          → 200 SUKSES PALSU, tidak ada lead
+7. Token time-trap           → 400 bila <2 detik atau >30 menit atau tanda tangan salah
+8. CAPTCHA (bila turnstile)  → 400 bila gagal
+9. Validasi field wajib      → 400 + details per field
+10. lead.Usecase.Create      → 201
+```
+
+Urutan itu **mengikat**. Rate limit lebih dulu dari segalanya (termasuk sebelum body dibaca) supaya
+banjir request tidak pernah sampai ke database — persis alasan yang sama di jalur API key Phase 4.
+Honeypot di posisi 6, **sebelum** validasi field, supaya bot tidak pernah menerima pesan kesalahan yang
+bisa dipelajari.
+
+### Pembuatan lead (keputusan D5)
+
+Memakai ulang `lead.Usecase.Create` apa adanya. `CreateLeadInput` diisi handler dengan:
+
+- `Source` = `"form"` — **dipaksa**, tidak pernah dari body
+- `SourceFormID` = `t.FormID` — dari principal, tidak pernah dari body
+- `RawPayload` = byte mentah request, apa adanya (kriteria #13)
+- `AssignedToMembershipID` = **ditolak** bila ada di body, sama seperti jalur API key
+
+`lead.Usecase.Create` bertambah cabang untuk `PrincipalPublicForm` yang bentuknya sama dengan cabang
+`PrincipalAPIKey` yang sudah ada.
+
+**Tidak ada idempotency key.** Browser pengunjung tidak mengirimnya, dan submit ganda dari manusia yang
+menekan tombol dua kali dilindungi rate limit per IP, bukan oleh key yang tidak pernah dikirim.
+
+---
+
+## 6. Lima lapis anti-abuse (ADR-005)
+
+Anti-spam di sini adalah **fitur ekonomi**, bukan sekadar keamanan: di harga terjangkau, setiap lead
+spam adalah biaya yang ditanggung Jualin.
+
+| Lapis | Mekanisme | Kejujuran tentang kekuatannya |
+|---|---|---|
+| **Origin allowlist** | Bandingkan header `Origin` dengan `forms.allowed_origins` | `Origin` **bisa dipalsukan** oleh klien non-browser. Ini menghalangi penyalahgunaan biasa, bukan penyerang tertarget — karena itu ia berpasangan, tidak pernah berdiri sendiri |
+| **Honeypot** | Field tersembunyi CSS; terisi → buang **diam-diam**, balas seperti sukses | Efektif terhadap bot naif. Bot yang merender CSS akan melewatinya |
+| **Time-trap** | Token HMAC berisi `form_id` + waktu terbit; tolak <2 detik atau >30 menit | **Time-trap, bukan anti-replay.** Token sah masih bisa dipakai berulang dalam 30 menit; yang membatasi pengulangan adalah rate limit |
+| **Rate limit** | `FixedWindow` per IP **dan** per form (D4) | Dua sumbu: per-IP menghalangi satu bot, per-form menghalangi botnet terhadap satu pelanggan |
+| **CAPTCHA** | Cloudflare Turnstile, `CAPTCHA_PROVIDER` (D2) | Lapis terkuat, dan satu-satunya yang butuh pihak ketiga |
+
+### Token time-trap — bentuk konkret
+
+```
+token = base64url(issued_at_unix) + "." + base64url(HMAC-SHA256(secret, form_id + "|" + issued_at))
+```
+
+`secret` dari env `FORM_TOKEN_SECRET` (wajib, min 32 byte, divalidasi saat boot — Aturan #36).
+**Bukan** `JWT_SECRET`: dua kegunaan berbeda tidak berbagi kunci, supaya rotasi salah satunya tidak
+memaksa rotasi yang lain.
+
+Stateless — tidak ada tabel nonce. Konsekuensi yang diterima sadar: token yang sah bisa dipakai
+berkali-kali dalam jendelanya. Menutupnya butuh penyimpanan nonce, dan itu tidak sebanding untuk
+ancaman yang rate limit sudah tangani.
+
+### `CAPTCHA_PROVIDER` (keputusan D2)
+
+```
+CAPTCHA_PROVIDER=none|turnstile     # none ditolak saat APP_ENV=production
+TURNSTILE_SITE_KEY=…                # wajib bila turnstile
+TURNSTILE_SECRET_KEY=…              # wajib bila turnstile
+CAPTCHA_TIMEOUT=5s
+```
+
+Bentuknya persis `MailProvider`/`PushProvider`: interface `captcha.Verifier` dengan `NoopVerifier`
+(selalu lolos) dan `TurnstileVerifier` (HTTP POST ke `siteverify`). Validasi konfigurasi mengikuti pola
+`config.Validate` yang sudah ada.
+
+`TURNSTILE_SECRET_KEY` **tidak pernah** di-log (Aturan #26). `TURNSTILE_SITE_KEY` publik — ia memang
+tertanam di halaman embed.
+
+---
+
+## 7. Halaman embed (keputusan D1)
+
+```
+GET /embed/{public_key}
+```
+
+Namespace **di luar** `/v1` — ia bukan API, ia halaman. Tidak ada middleware auth, tidak ada envelope
+`{data, meta}`.
+
+| Aspek | Ketentuan |
+|---|---|
+| Rendering | `html/template` + `//go:embed` — paket baru `internal/form/template/` |
+| Escaping | `html/template` melakukan escaping kontekstual otomatis. **Label field berasal dari input pelanggan** dan dirender ke HTML — ini satu-satunya jalur XSS di phase ini, dan `text/template` **dilarang** di sini |
+| CSP | `default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors <allowlist form ini>` |
+| `X-Frame-Options` | **Tidak dikirim** — ia tidak mengenal daftar origin, dan `frame-ancestors` menggantikannya sepenuhnya |
+| Cache | `Cache-Control: no-store` — halaman memuat token time-trap yang berumur pendek |
+| JavaScript | Hanya bila `CAPTCHA_PROVIDER=turnstile` (script Turnstile). Tanpa CAPTCHA, form murni HTML + `<form method="post">` |
+
+`frame-ancestors` **per-form**, diambil dari `forms.allowed_origins` baris itu — bukan satu kebijakan
+global. Ini justru lebih ketat daripada host statis, yang hanya bisa mengirim satu header untuk semua
+pelanggan.
+
+Bila `allowed_origins` kosong: `frame-ancestors 'none'`. Form yang belum dikonfigurasi **tidak bisa**
+di-iframe di mana pun — gagal tertutup, bukan terbuka.
+
+### Kemampuan baru yang perlu disadari
+
+Backend hari ini **tidak pernah** menyajikan HTML: nol `html/template`, nol `http.FileServer`, nol
+`.html` di repo. Seluruh response melewati `httpx.OK`/`httpx.WriteError` menjadi JSON. Menambahkan
+halaman ini berarti kelas kemampuan baru dengan urusan barunya sendiri (CSP, caching, escaping) —
+karena itu ia **issue tersendiri**, bukan tempelan pada issue submit.
+
+---
+
+## 8. Endpoint
+
+| Method | Path | Principal | Otorisasi |
+|---|---|---|---|
+| `POST` | `/v1/forms` | user | `form.create` — Owner/Admin |
+| `GET` | `/v1/forms` | user | `form.list` — Owner/Admin |
+| `GET` | `/v1/forms/:id` | user | `form.read` — Owner/Admin |
+| `PATCH` | `/v1/forms/:id` | user | `form.update` — Owner/Admin |
+| `DELETE` | `/v1/forms/:id` | user | `form.delete` — Owner/Admin (soft delete) |
+| `POST` | `/v1/forms/{public_key}/submit` | **public_form** | `lead.create` lewat `publicFormAllows` |
+| `GET` | `/embed/{public_key}` | — | tanpa autentikasi |
+
+**Tabrakan wildcard gin.** `/v1/forms/:id` (user) dan `/v1/forms/{public_key}/submit` (publik) berbagi
+prefix. Gin menuntut **nama wildcard yang sama** pada segmen yang sama — preseden persis ada di
+`internal/task` dan `internal/activity` yang berbagi `/v1/leads/:id`. Karena itu route publik
+didaftarkan sebagai `/v1/forms/:id/submit` dengan handler yang memperlakukan `:id` sebagai
+`public_key`, bukan UUID. Dicatat di sini karena ini **jebakan yang pasti ditemui saat implementasi**.
+
+Lima endpoint pengelolaan memakai `authMW` biasa. Endpoint submit dan embed **tidak** memasang
+middleware auth apa pun (§3).
+
+---
+
+## 9. Error code baru
+
+| Status | Code | Kapan |
+|---|---|---|
+| `403` | `origin_not_allowed` | `Origin` di luar `forms.allowed_origins` |
+| `400` | `form_token_invalid` | Token time-trap salah tanda tangan, terlalu cepat (<2s), atau kedaluwarsa (>30m) |
+| `400` | `captcha_failed` | Turnstile menolak |
+
+`404 not_found`, `413 payload_too_large`, `429 rate_limited`, dan `400 validation_failed` sudah ada di
+katalog `api.md` sejak Phase 4 — dipakai ulang apa adanya.
+
+---
+
+## 10. Dashboard
+
+### Connect surface
+
+`NAV_ITEMS` bertambah satu antara Tim dan Pengaturan:
+
+```ts
+{ href: "/connect", label: "Connect" }
+```
+
+`nav.test.ts` mengunci daftar itu **persis** (`toEqual([...])`) — test ikut diperbarui, dan itu memang
+yang diinginkan: perpindahan menu tidak boleh lolos diam-diam. `NAV_ICONS` di `app-shell.tsx` juga
+bertambah entri (`Plug` atau serupa); ikon yang hilang tidak membuat crash (`{Icon ? … : null}`) tapi
+akan terlihat kosong.
+
+`pageTitle` memakai pencocokan href-terpanjang-dulu, jadi `/connect` saja sudah benar untuk
+`/connect/api`. Waspadai tabrakan prefix — `nav.test.ts` sudah punya penjaga sejenis
+(`isActive("/teams-report", "/team") === false`).
+
+| Route | Isi |
+|---|---|
+| `/connect` | Tiga kartu kanal: API (aktif), Formulir (aktif), Webhook (**belum tersedia** — Phase 7) |
+| `/connect/api` | Pindahan `settings/api-keys/` |
+| `/connect/api/docs` | Pindahan `settings/api-keys/docs/` |
+| `/connect/form` | Daftar & pengelolaan form |
+
+Kartu Webhook menampilkan *"belum tersedia"* — **bukan** *"terkunci oleh paket"*. Ia belum ada; keadaan
+terkunci-oleh-paket baru lahir di Phase 8 (ADR-012 §4). Menyatakannya terkunci sekarang akan berbohong.
+
+### Yang patah saat folder dipindah
+
+Disebut eksplisit karena ketiganya diam saat dilewatkan:
+
+1. `docs/api-docs-screen.tsx` mengimpor `../create-api-key-dialog` secara **relatif**
+2. Lima `router.push("/settings/api-keys…")` tersebar di `api-keys-screen.tsx`, `docs/api-docs-screen.tsx`, `settings-screen.tsx`
+3. `nav.test.ts` assertion persis
+
+`/settings/api-keys` dan `/settings/api-keys/docs` menjadi **redirect permanen** ke lokasi baru — bukan
+dihapus (kriteria #11).
+
+### Manajemen form
+
+Layar `/connect/form`: daftar form, tombol buat, dan editor per form (nama, toggle+label 6 field,
+allowlist domain, snippet embed dengan tombol salin, tombol nonaktifkan).
+
+Gerbang role: `canManageForms(role)` di `src/lib/form-permissions.ts`, di sebelah `canManageAPIKeys`
+yang sudah ada di `src/lib/api-key-rows.ts`. Owner/Admin — sama dengan API key, karena keduanya
+kredensial yang memasukkan lead ke organization.
+
+**Nav tidak difilter role** (D6): menu Connect terlihat semua orang, gerbangnya di dalam layar —
+persis perilaku `/settings` hari ini.
+
+---
+
+## 11. Paket baru
+
+```
+crm_be/internal/form/
+    entity.go              Form, FieldConfig, generate(), parsePublicKey()
+    port.go                Repository, AuditRepository, Repos, Store
+    usecase.go             CRUD + ResolvePublicKey + Submit orchestration
+    repository_postgres.go FindByPublicKey (tanpa tenant.Context — §3)
+    handler_http.go        5 endpoint kelola + submit + embed
+    template/form.gohtml   halaman embed (//go:embed)
+
+crm_be/internal/shared/captcha/
+    captcha.go             interface Verifier + NoopVerifier
+    turnstile.go           TurnstileVerifier
+
+crm_be/internal/shared/formtoken/
+    formtoken.go           Issue(formID) / Verify(token, formID) — HMAC (§6)
+
+crm_be/cmd/api/form_store.go   newFormStore(pool) form.Store
+```
+
+`crm_dashboard/src/lib/forms.ts` (klien API tipis) dan `form-permissions.ts` (gerbang role), mengikuti
+`api-keys.ts` / `api-key-rows.ts`.
+
+---
+
+## 12. Rencana test
+
+| Berkas | Menguji |
+|---|---|
+| `internal/form/entity_test.go` | Format `public_key`, panjang, prefix, keacakan; parsing field config |
+| `internal/form/usecase_unit_test.go` | CRUD + `ResolvePublicKey` (semua kegagalan → 404 identik) |
+| `internal/form/repository_test.go` | Postgres asli: `FindByPublicKey` memakai index (`EXPLAIN`), soft delete tidak ikut terambil |
+| `internal/form/handler_test.go` | Urutan §5 ditegakkan; honeypot → 200 tanpa lead; time-trap; origin allowlist |
+| `internal/shared/formtoken/formtoken_test.go` | Tanda tangan valid/invalid, batas <2s dan >30m, token form lain ditolak |
+| `internal/shared/captcha/turnstile_test.go` | Bentuk request `siteverify`, penanganan gagal/timeout |
+| `internal/shared/authz/authz_test.go` | **Tabel atas seluruh `Action`**: `PrincipalPublicForm` hanya lolos `ActionLeadCreate` (kriteria #2) |
+| `cmd/api/public_form_api_test.go` | Ujung ke ujung dengan form yang di-seed lewat store sungguhan — meniru `public_lead_api_test.go` |
+| `cmd/api/tenant_isolation_test.go` | **Kasus baru**: submit ke `public_key` milik org lain, dan `GET/PATCH/DELETE /v1/forms/:id` lintas org → 404. **Tetap harus terbukti bisa gagal** |
+| `crm_dashboard/src/lib/nav.test.ts` | Diperbarui untuk "Connect" |
+| `crm_dashboard/src/lib/form-permissions.test.ts` | Gerbang role |
+
+Test komponen React **tidak ada dan tidak dijanjikan** — `vitest.config.mts` sengaja hanya
+`include: ["src/**/*.test.ts"]` tanpa `.tsx`. Logika yang bisa salah diam-diam ditempatkan di
+`src/lib/*.ts` supaya bisa diuji tanpa merender.
+
+### Verifikasi manual wajib
+
+Kriteria #1 dan #10 hanya bisa dibuktikan dengan **menempel snippet ke halaman HTML kosong** lalu
+mengisinya dari browser — bukan dengan `curl`, dan bukan dengan membaca snippet-nya. Prosedurnya masuk
+`docs/testing/flow/` sebagai berkas baru saat issue penutup.
+
+---
+
+## 13. Konfigurasi
+
+```
+FORM_TOKEN_SECRET=…              # wajib, min 32 byte (Aturan #36)
+CAPTCHA_PROVIDER=none|turnstile  # none ditolak saat APP_ENV=production
+TURNSTILE_SITE_KEY=…             # wajib bila turnstile
+TURNSTILE_SECRET_KEY=…           # wajib bila turnstile
+CAPTCHA_TIMEOUT=5s
+FORM_SUBMIT_RATE_LIMIT_IP=20     # per menit, per IP
+FORM_SUBMIT_RATE_LIMIT_FORM=60   # per menit, per form
+EMBED_BASE_URL=…                 # dipakai dashboard membangun snippet
+```
+
+Keduanya angka rate limit **bukan hasil pengukuran** — sama jujurnya dengan `PUBLIC_API_RATE_LIMIT=60`.
+
+---
+
+## 14. Yang harus disiapkan pemilik produk
+
+**Cloudflare Turnstile** — gratis, hitungan menit, tapi butuh akun:
+
+1. [dash.cloudflare.com](https://dash.cloudflare.com) → Turnstile → *Add site*
+2. Domain: domain tempat form akan dipasang (boleh `localhost` untuk pengembangan)
+3. Widget mode: **Managed** (tanpa puzzle — ADR-005 memilihnya justru karena ini)
+4. Salin **Site Key** → `TURNSTILE_SITE_KEY`, **Secret Key** → `TURNSTILE_SECRET_KEY`
+
+**Memblokir satu issue saja** (#3, verifikasi anti-spam sungguhan), bukan phase-nya —
+`CAPTCHA_PROVIDER=none` membuat empat issue lain jalan penuh tanpa akun Cloudflare.
+
+---
+
+## 15. Yang berubah pada dokumentasi
+
+| Berkas | Perubahan |
+|---|---|
+| `architecture/api.md` | Tiga error code baru (§9); bab endpoint submit publik |
+| `architecture/authentication.md` | Baris **ketiga** tabel kredensial dari rencana jadi kenyataan; `public_key` lewat path, bukan `Authorization` |
+| `architecture/authorization.md` | Matriks Phase 6 (`form.*`); bagian *"Daftar tertutup — principal public form"* di sebelah bagian scope Phase 4 |
+| `architecture/multi-tenancy.md` | Pengecualian unik-lintas-organization **keempat** (`forms.public_key`); kasus isolasi baru |
+| `docs/testing/flow/` | Berkas baru: memasang form di halaman kosong dan mengisinya dari browser |
+| `STATUS.md` | Baris Selesai; Phase 6 di *Progress per Phase*; **kunci Turnstile** masuk *Punya Lead Time* |
+
+`freeze.md` **tidak disentuh.** Penyimpangan D1 dari ADR-005 dicatat di `prd.md` sebagai keputusan
+phase beserta kewajiban deploy-nya — bukan diselipkan seolah ADR memang mengizinkannya (Aturan #30).
+
+---
+
+## 16. Risiko teknis
+
+| Risiko | Penanganan |
+|---|---|
+| **XSS lewat label field** — label dari pelanggan dirender ke HTML | `html/template` (escaping kontekstual otomatis), **bukan** `text/template`. Ditegaskan di §7 dan diuji |
+| `Origin` bisa dipalsukan klien non-browser | Diakui terbuka di ADR-005 dan §6. Ia satu dari lima lapis, tidak pernah berdiri sendiri |
+| Tabrakan wildcard gin pada `/v1/forms/:id` | Sudah dipetakan di §8 dengan preseden `task`/`activity` |
+| Halaman HTML pertama di backend membawa urusan baru (CSP, cache, escaping) | Dipisah jadi issue tersendiri (#4) supaya direview sebagai kemampuan baru, bukan sebagai tempelan |
+| `public_key` plaintext terlihat seperti kelalaian saat review | Alasannya ditulis di §2 **dan** di komentar migration, bukan hanya di ADR yang mungkin tidak dibuka reviewer |
+| Memindahkan `/settings/api-keys` memutus tautan pelanggan Phase 4 | Redirect permanen, kriteria #11, dan tiga titik yang patah disebut eksplisit di §10 |
+| Rate limit per IP salah di belakang proxy | `SetTrustedProxies` sudah ditegakkan sejak Phase 4.5 (#57); `c.ClientIP()` sudah benar selama `TRUSTED_PROXIES` diisi tepat |
+
+---
+
+## 17. Kewajiban yang diteruskan ke phase berikutnya
+
+- **Saat deployment dikerjakan**: halaman embed **wajib** dari hostname berbeda dari dashboard
+  (`prd.md` D1). Menyajikannya dari origin yang sama membatalkan isolasi ADR-005.
+- **Phase 7 (Webhook)**: kanal ketiga menempel pada `Connect` yang sudah ada — jangan buat menu baru.
+  Kredensialnya adalah yang **keempat**; jangan satukan dengan `public_key` maupun API key.
+- **Phase 8 (Subscription)**: `submit_count` di `forms` **bukan** usage counter. Kuota adalah
+  `usage_counters`, mekanisme terpisah (TD Phase 4 §19).
+- **Bila pelanggan meminta form builder dinamis**: itu bukan perluasan `fields` JSONB, melainkan fitur
+  tersendiri dengan schema field + validasi + renderer (ADR-005).


### PR DESCRIPTION
## Ringkasan

**Dokumen saja** — nol perubahan kode. Membuka Phase 6 sesuai `docs/workflow.md` Bagian 1:
PRD → TD → `issues.md` → issue GitHub.

**Tujuan phase**: capture layer bisa dipakai **tanpa developer**. Phase 4 membuktikan lead bisa masuk
sendiri dari luar — tapi hanya bila pelanggan punya orang yang bisa menulis `POST /v1/leads`. Untuk
pemilik toko yang websitenya dibuat vendor tiga tahun lalu, itu sama saja dengan tidak bisa.

## GATE freeze dilewati — sebagai keputusan, bukan kelalaian

Freeze bagian 4 meminta 3–5 pengguna nyata sebelum Phase 6. Pemilik produk memutuskan membangun busur
SaaS penuh (Connect → Form → Webhook → Subscription) lebih dulu supaya produknya utuh sebelum dijual.
Dicatat terbuka di `STATUS.md` beserta konsekuensinya: **urutan Phase 7–9 yang direncanakan sekarang
adalah tebakan kita, bukan permintaan pengguna**, dan masih bisa berubah.

## Riset menemukan tempatnya sudah disiapkan sejak lama

| Temuan | Verifikasi |
|---|---|
| `tenant.PrincipalPublicForm` ada sejak Phase 1 dengan **nol pemakaian** | `grep` seluruh `internal/` + `cmd/` — hanya baris definisinya |
| `leads.source` sudah menerima `'form'`, `raw_payload` sudah ada | `0003_crm_core.sql:43` |
| Nomor `0007_forms` sudah dipesan freeze | `freeze.md:1165` |
| Backend **belum pernah** menyajikan HTML | nol `html/template`, nol static serving, nol `.html` |
| `nav.test.ts` mengunci `NAV_ITEMS` **persis** | `toEqual([...])` — akan merah saat "Connect" ditambah, dan itu memang diinginkan |

Yang benar-benar baru cuma domain `form`, endpoint submit, dan halaman embed.

## Dua keputusan yang paling perlu dibaca saat review

**D1 — halaman embed disajikan backend Go, bukan host statis `cdn.…`.** Ini **penyimpangan tertulis
dari ADR-005** yang sudah Accepted, jadi ia berdiri terbuka di PRD dengan tiga alasannya, bukan
diselipkan. Maksud ADR (isolasi origin, CSP ketat, `frame-ancestors` per-form) tetap dipenuhi handler —
dan `frame-ancestors` per-form justru **lebih ketat** dari host statis yang hanya bisa mengirim satu
kebijakan untuk semua pelanggan. Satu kewajiban ikut lahir dan dicatat supaya tidak hilang: **saat
deployment dikerjakan, halaman embed wajib dari hostname berbeda dari dashboard.**

**D3 — `public_key` disimpan plaintext**, tanpa hash, tanpa `ConstantTimeCompare`. Bukan kelalaian:
ADR-005 sudah menempatkannya sebagai kredensial yang memang terbuka (ia tertanam di HTML setiap halaman
yang memasang form). Yang melindungi endpoint ini adalah **daftar kemampuan tertutup** — satu baris di
`publicFormAllows` — plus lima lapis anti-abuse, bukan kerahasiaan kunci. Alasannya ditulis di TD §2
**dan akan diulang di komentar migration**, bukan hanya di ADR yang mungkin tidak dibuka reviewer.

## Lima issue

| # | Judul | Aplikasi |
|---|---|---|
| [#85](https://github.com/Pravasta/jualin-crm/issues/85) | Migration `0007_forms`, domain `form`, CRUD | `crm_be` |
| [#86](https://github.com/Pravasta/jualin-crm/issues/86) | Permukaan Connect + pindahkan API key | `crm_dashboard` |
| [#87](https://github.com/Pravasta/jualin-crm/issues/87) | Submit publik + lima lapis anti-spam — **risiko keamanan tertinggi** | `crm_be` |
| [#88](https://github.com/Pravasta/jualin-crm/issues/88) | Halaman embed + CSP per-form — **kelas kemampuan baru** | `crm_be` |
| [#89](https://github.com/Pravasta/jualin-crm/issues/89) | Manajemen form + snippet — **penutup phase** | `crm_dashboard` |

```
#85 domain ──┬──► #87 submit ──┬──► #89 UI + penutup
             └──► #88 embed  ──┘
#86 Connect ────────────────────────► #89
```

## Item lead-time baru

**Cloudflare Turnstile** masuk `STATUS.md` *Punya Lead Time*, sejajar Firebase. Ia **memblokir satu
issue saja (#87), bukan phase-nya** — `CAPTCHA_PROVIDER=none` membuat empat issue lain jalan penuh,
mengikuti preseden `MAIL_PROVIDER` (Phase 4.6) dan `PUSH_PROVIDER` (Phase 5).

## Yang tetap terbuka dan tidak disembunyikan

**Staging masih belum ada** dan Phase 6 tidak mengubahnya. Tim QA praktis harus jadi developer dulu
untuk bisa menguji, dan tiap tester punya database sendiri sehingga bug mereka tidak saling bisa
direproduksi. Dicatat di `STATUS.md` sebagai hal di luar phase manapun yang belum punya issue.

`freeze.md` **tidak disentuh.**

Refs #85
Refs #86
Refs #87
Refs #88
Refs #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)