### PR TITLE
Tambah keputusan D8 — tinggi iframe & script auto-resize

### DIFF
--- a/docs/phases/06-connect-form/issues.md
+++ b/docs/phases/06-connect-form/issues.md
@@ -15,8 +15,12 @@
 | [85](https://github.com/Pravasta/jualin-crm/issues/85) | Migration `0007_forms`, domain `form`, CRUD kredensial | `crm_be` | `0007_forms` + `leads.source_form_id`, `internal/form`, format `pk_` (D3), 5 endpoint pengelolaan, audit log | §1, §2, §8, §11 |
 | [86](https://github.com/Pravasta/jualin-crm/issues/86) | Permukaan Connect + pindahkan pengelolaan API key | `crm_dashboard` | `NAV_ITEMS`/`NAV_ICONS`/`nav.test.ts`, `/connect` + tiga kartu, `/connect/api(/docs)` pindahan, redirect rute lama | §10 |
 | [87](https://github.com/Pravasta/jualin-crm/issues/87) | Endpoint submit publik + lima lapis anti-spam | `crm_be` | `POST /v1/forms/{public_key}/submit`, `PrincipalPublicForm` + `FormID`, cabang `authz` ketiga, Origin/honeypot/time-trap/rate limit/Turnstile. **Risiko keamanan tertinggi phase ini** | §3–§6, §9 |
-| [88](https://github.com/Pravasta/jualin-crm/issues/88) | Halaman embed (iframe) + CSP per-form | `crm_be` | `GET /embed/{public_key}`, `html/template` + `embed.FS`, `frame-ancestors` per-form. **Kelas kemampuan baru** | §7 |
-| [89](https://github.com/Pravasta/jualin-crm/issues/89) | Manajemen form + snippet embed | `crm_dashboard` | Layar buat/ubah/nonaktifkan, toggle+label field, allowlist, snippet. **Penutup phase** | §10, §12, §15 |
+| [88](https://github.com/Pravasta/jualin-crm/issues/88) | Halaman embed (iframe) + CSP per-form | `crm_be` | `GET /embed/{public_key}` + `GET /embed.js`, `html/template` + `embed.FS`, `frame-ancestors` per-form, auto-resize `postMessage` (D8). **Kelas kemampuan baru** | §7 |
+| [89](https://github.com/Pravasta/jualin-crm/issues/89) | Manajemen form + snippet embed | `crm_dashboard` | Layar buat/ubah/nonaktifkan, toggle+label field, allowlist, snippet **dua varian** (D8). **Penutup phase** | §10, §12, §15 |
+
+> **[#91](https://github.com/Pravasta/jualin-crm/issues/91)** menambahkan keputusan **D8** (tinggi
+> iframe & script auto-resize) setelah phase dibuka — celah yang ditemukan saat membahas bentuk snippet,
+> sebelum #88/#89 dikerjakan. Dokumen saja; cakupannya sudah terserap ke dua baris di atas.
 
 ---
 

--- a/docs/phases/06-connect-form/prd.md
+++ b/docs/phases/06-connect-form/prd.md
@@ -79,6 +79,7 @@ teknis lengkap di [`td.md`](./td.md); yang di bawah adalah **apa** dan **kenapa*
 | **D5** | Bagaimana lead dibuat? | Memakai ulang `lead.Usecase.Create` apa adanya. `source` dipaksa `'form'` dan `source_form_id` diambil **dari principal**, tidak pernah dari body. | Persis pola jalur API key Phase 4. Menulis jalur pembuatan lead kedua berarti dua tempat yang harus tetap sama selamanya — termasuk penomoran lead, `raw_payload`, dan notifikasi assignment. |
 | **D6** | Siapa yang melihat menu `Connect`? | **Semua role**; gerbangnya di dalam layar, bukan di sidebar. | Mengikuti `/settings` hari ini. Nav sadar-role **belum pernah ada** di dashboard ini — menciptakannya untuk satu menu berarti menambah mekanisme baru demi kerapian yang tidak diminta siapa pun (Aturan #27). |
 | **D7** | Time-trap 2 detik | Token HMAC **stateless** yang ditanam di halaman embed, memuat id form + waktu terbit; divalidasi umurnya (>2 detik, <30 menit). | Tanpa token, waktu render hanya bisa dititipkan ke field tersembunyi — yang bisa dipalsukan bot dengan satu baris. HMAC membuatnya tidak bisa dikarang tanpa menyimpan state apa pun. **Ini time-trap, bukan anti-replay**: token yang sah masih bisa dipakai berulang dalam jendela 30 menit. Perlindungan terhadap pengulangan datang dari rate limit, bukan dari sini. |
+| **D8** | Tinggi iframe | iframe **tetap** wadah form; ditambah **script pendamping opsional** (`embed.js`) yang menyesuaikan tinggi lewat `postMessage`. Tanpa script, iframe tetap bekerja dengan tinggi tetap. | `height` mati punya dua akibat yang pasti: form pendek meninggalkan ruang kosong, form panjang terpotong atau ber-scrollbar sendiri. Lihat catatan *"Kenapa script pendamping tidak membatalkan ADR-005"* di bawah — ini bukan kembali ke *inline script* yang ADR-005 tolak. |
 
 ### Penyimpangan tertulis dari ADR-005 — D1
 
@@ -94,6 +95,34 @@ host statis atau CDN. Phase 6 **tidak** melakukannya, dan alasannya perlu berdir
 **Kewajiban yang ikut lahir dari keputusan ini** — dicatat supaya tidak hilang: saat deployment
 akhirnya dikerjakan, halaman embed **wajib** disajikan dari hostname yang berbeda dari dashboard.
 Menyajikannya dari origin yang sama dengan dashboard membatalkan isolasi yang ADR-005 lindungi.
+
+### Kenapa script pendamping tidak membatalkan ADR-005 — D8
+
+ADR-005 menolak *inline script* dengan satu alasan spesifik: **"script host bisa membaca input"**.
+Yang membuat itu benar adalah **di mana form-nya hidup** — pada inline script, form disuntikkan ke DOM
+halaman pelanggan, sehingga script lain di halaman itu (termasuk plugin pihak ketiga yang tidak
+dikendalikan siapa pun) bisa membaca apa yang diketik pengunjung.
+
+D8 **tidak** memindahkan form ke DOM host:
+
+| | Inline script (ditolak ADR-005) | D8 — iframe + `embed.js` |
+|---|---|---|
+| Form hidup di | DOM halaman host | **Di dalam iframe**, origin terpisah |
+| Halaman host bisa membaca input? | ✅ Ya | ❌ **Tidak** — dihalangi browser, bukan oleh janji kita |
+| Yang dikerjakan script host | Merender & mengelola form | **Hanya menerima satu angka: tinggi** |
+| Tanpa script | Tidak ada form sama sekali | Form tetap jalan, tinggi tetap |
+
+Isolasi lintas-origin adalah properti yang ditegakkan browser. Selama form berada di dalam iframe,
+halaman host tidak punya cara membaca isinya — ada atau tidak ada `embed.js`.
+
+**Syarat yang mengikat** (tanpa ini, D8 justru membuka permukaan serangan baru):
+
+1. `postMessage` **tidak pernah** `targetOrigin: '*'` — selalu origin yang dituju secara eksplisit
+2. Penerima **wajib** memverifikasi `event.origin`; pesan dari origin lain diabaikan
+3. Tinggi dibatasi rentang wajar — pesan jahat tidak boleh bisa membuat iframe raksasa yang menutupi
+   halaman pelanggan (*clickjacking* terbalik)
+4. `embed.js` **hanya** mengenal satu jenis pesan. Ia tidak menerima perintah lain, tidak mengevaluasi
+   apa pun yang dikirim iframe
 
 ---
 

--- a/docs/phases/06-connect-form/td.md
+++ b/docs/phases/06-connect-form/td.md
@@ -294,12 +294,58 @@ pelanggan.
 Bila `allowed_origins` kosong: `frame-ancestors 'none'`. Form yang belum dikonfigurasi **tidak bisa**
 di-iframe di mana pun — gagal tertutup, bukan terbuka.
 
+### Auto-resize (keputusan D8)
+
+`height` mati membuat form pendek menyisakan ruang kosong dan form panjang terpotong. Solusinya
+**dua bagian**, dan bagian keduanya opsional.
+
+**Di halaman embed** — `ResizeObserver` pada `<body>`, mengirim tinggi setiap kali berubah:
+
+```js
+parent.postMessage(
+  { type: "jualin:resize", height: document.body.scrollHeight },
+  targetOrigin            // origin host, dari allowlist form — TIDAK PERNAH "*"
+);
+```
+
+`targetOrigin` diambil dari `document.referrer` **yang sudah dicocokkan dengan
+`forms.allowed_origins`**. Bila referrer tidak ada atau di luar allowlist, pesan **tidak dikirim sama
+sekali** — bukan dikirim ke `'*'`.
+
+**Di halaman pelanggan** — `GET /embed.js`, script kecil yang disajikan dari origin embed yang sama:
+
+```js
+window.addEventListener("message", (e) => {
+  if (e.origin !== EMBED_ORIGIN) return;                    // wajib
+  const d = e.data;
+  if (!d || d.type !== "jualin:resize") return;             // satu jenis pesan saja
+  const h = Number(d.height);
+  if (!Number.isFinite(h) || h < 100 || h > 4000) return;   // batas mengikat
+  frame.style.height = h + "px";
+});
+```
+
+| Syarat | Kenapa mengikat |
+|---|---|
+| `targetOrigin` eksplisit, tidak pernah `'*'` | `'*'` berarti pesan terbaca halaman mana pun yang kebetulan menyematkan iframe ini |
+| `e.origin` diverifikasi penerima | Tanpa ini, **halaman mana pun** bisa mengirim pesan palsu ke `embed.js` |
+| Tinggi dibatasi 100–4000px | Pesan jahat yang menyetel tinggi raksasa bisa menutupi seluruh halaman pelanggan — *clickjacking* terbalik |
+| Hanya satu jenis pesan dikenali | `embed.js` tidak boleh jadi jalur perintah umum dari iframe ke halaman host |
+
+**Progressive enhancement, bukan syarat.** Tanpa `embed.js`, iframe tetap tampil dan tetap bisa
+dikirim — hanya tingginya tetap. Kegagalan memuat script tidak boleh membuat form hilang.
+
+`embed.js` disajikan dengan `Cache-Control: public, max-age=3600` — berbeda dari halaman embed yang
+`no-store`, karena ia tidak memuat token dan isinya sama untuk semua form.
+
 ### Kemampuan baru yang perlu disadari
 
 Backend hari ini **tidak pernah** menyajikan HTML: nol `html/template`, nol `http.FileServer`, nol
 `.html` di repo. Seluruh response melewati `httpx.OK`/`httpx.WriteError` menjadi JSON. Menambahkan
 halaman ini berarti kelas kemampuan baru dengan urusan barunya sendiri (CSP, caching, escaping) —
 karena itu ia **issue tersendiri**, bukan tempelan pada issue submit.
+
+`embed.js` ikut lewat `//go:embed`, aset statis kedua setelah `form.gohtml`.
 
 ---
 
@@ -314,6 +360,7 @@ karena itu ia **issue tersendiri**, bukan tempelan pada issue submit.
 | `DELETE` | `/v1/forms/:id` | user | `form.delete` — Owner/Admin (soft delete) |
 | `POST` | `/v1/forms/{public_key}/submit` | **public_form** | `lead.create` lewat `publicFormAllows` |
 | `GET` | `/embed/{public_key}` | — | tanpa autentikasi |
+| `GET` | `/embed.js` | — | tanpa autentikasi; aset statis, sama untuk semua form (D8) |
 
 **Tabrakan wildcard gin.** `/v1/forms/:id` (user) dan `/v1/forms/{public_key}/submit` (publik) berbagi
 prefix. Gin menuntut **nama wildcard yang sama** pada segmen yang sama — preseden persis ada di
@@ -384,6 +431,33 @@ dihapus (kriteria #11).
 Layar `/connect/form`: daftar form, tombol buat, dan editor per form (nama, toggle+label 6 field,
 allowlist domain, snippet embed dengan tombol salin, tombol nonaktifkan).
 
+#### Snippet — dua varian (D8)
+
+**Dianjurkan** — tinggi menyesuaikan isi:
+
+```html
+<iframe src="{EMBED_BASE_URL}/embed/pk_…" data-jualin-form
+        width="100%" height="620" style="border:0" title="…"></iframe>
+<script src="{EMBED_BASE_URL}/embed.js" async></script>
+```
+
+**Tanpa script** — bagi pelanggan yang situsnya melarang script pihak ketiga:
+
+```html
+<iframe src="{EMBED_BASE_URL}/embed/pk_…"
+        width="100%" height="620" style="border:0" title="…"></iframe>
+```
+
+Keduanya **sama-sama bekerja**; yang kedua hanya bertinggi tetap. Layar menjelaskan bedanya dalam satu
+kalimat, bukan menyodorkan dua kotak tanpa keterangan.
+
+`height="620"` tetap ada di varian pertama sebagai **nilai awal sebelum script sempat jalan** — tanpa
+itu, iframe akan berkedip dari tinggi default browser ke tinggi sebenarnya.
+
+> Snippet-nya HTML biasa, jadi ia jalan di Next.js, WordPress, maupun HTML statis tanpa integrasi
+> khusus. Di JSX, `style="border:0"` perlu ditulis `style={{ border: 0 }}` — layar sebaiknya
+> menyediakan varian JSX juga, atau menyebutkan penyesuaian itu.
+
 Gerbang role: `canManageForms(role)` di `src/lib/form-permissions.ts`, di sebelah `canManageAPIKeys`
 yang sudah ada di `src/lib/api-key-rows.ts`. Owner/Admin — sama dengan API key, karena keduanya
 kredensial yang memasukkan lead ke organization.
@@ -430,6 +504,7 @@ crm_be/cmd/api/form_store.go   newFormStore(pool) form.Store
 | `internal/shared/formtoken/formtoken_test.go` | Tanda tangan valid/invalid, batas <2s dan >30m, token form lain ditolak |
 | `internal/shared/captcha/turnstile_test.go` | Bentuk request `siteverify`, penanganan gagal/timeout |
 | `internal/shared/authz/authz_test.go` | **Tabel atas seluruh `Action`**: `PrincipalPublicForm` hanya lolos `ActionLeadCreate` (kriteria #2) |
+| `internal/form/handler_test.go` (D8) | `targetOrigin` diambil dari referrer yang **cocok allowlist**; referrer di luar allowlist → pesan tidak dikirim sama sekali (bukan `'*'`); `embed.js` disajikan dengan `Cache-Control` yang benar |
 | `cmd/api/public_form_api_test.go` | Ujung ke ujung dengan form yang di-seed lewat store sungguhan — meniru `public_lead_api_test.go` |
 | `cmd/api/tenant_isolation_test.go` | **Kasus baru**: submit ke `public_key` milik org lain, dan `GET/PATCH/DELETE /v1/forms/:id` lintas org → 404. **Tetap harus terbukti bisa gagal** |
 | `crm_dashboard/src/lib/nav.test.ts` | Diperbarui untuk "Connect" |
@@ -505,6 +580,8 @@ phase beserta kewajiban deploy-nya — bukan diselipkan seolah ADR memang mengiz
 | `public_key` plaintext terlihat seperti kelalaian saat review | Alasannya ditulis di §2 **dan** di komentar migration, bukan hanya di ADR yang mungkin tidak dibuka reviewer |
 | Memindahkan `/settings/api-keys` memutus tautan pelanggan Phase 4 | Redirect permanen, kriteria #11, dan tiga titik yang patah disebut eksplisit di §10 |
 | Rate limit per IP salah di belakang proxy | `SetTrustedProxies` sudah ditegakkan sejak Phase 4.5 (#57); `c.ClientIP()` sudah benar selama `TRUSTED_PROXIES` diisi tepat |
+| **`postMessage` jadi permukaan serangan baru** (D8) | Empat syarat mengikat di §7: `targetOrigin` eksplisit, `e.origin` diverifikasi penerima, tinggi dibatasi 100–4000px, satu jenis pesan saja. Tanpa keempatnya, D8 justru menambah risiko alih-alih memperbaiki UX — karena itu ditulis sebagai syarat, bukan saran |
+| Auto-resize dikira menghidupkan kembali *inline script* yang ADR-005 tolak | Dijawab tuntas di `prd.md` §*"Kenapa script pendamping tidak membatalkan ADR-005"*: form tetap di dalam iframe lintas-origin, `embed.js` hanya menerima satu angka. Ditulis di PRD, bukan hanya di sini, karena inilah pertanyaan pertama yang akan diajukan reviewer |
 
 ---
 


### PR DESCRIPTION
## Celah yang ditutup

TD Phase 6 §7 menetapkan halaman embed disajikan lewat iframe, tapi **tidak pernah membahas
tingginya**. Snippet akan berisi `height="620"` — angka mati, dengan dua akibat yang pasti:

- Form 3 field → ruang kosong menganggur
- Form 6 field + pesan error → isi terpotong atau ber-scrollbar sendiri

Ketahuan saat membahas bentuk snippet dengan pemilik produk, **sebelum #88/#89 dikerjakan**.

## Keputusan

iframe **tetap** wadah form; ditambah **script pendamping opsional** (`embed.js`) yang hanya mengurus
tinggi lewat `postMessage`.

### Ini bukan kembali ke *inline script* yang ADR-005 tolak

Pertanyaan pertama yang wajar diajukan reviewer, jadi dijawab di **PRD**, bukan cuma di TD:

| | Inline script (ditolak ADR-005) | D8 |
|---|---|---|
| Form hidup di | DOM halaman host | **Di dalam iframe**, origin terpisah |
| Host bisa membaca input? | ✅ Ya | ❌ **Tidak** — dihalangi browser, bukan janji kita |
| Kerja script host | Merender & mengelola form | **Hanya menerima satu angka: tinggi** |
| Tanpa script | Tidak ada form | Form tetap jalan, tinggi tetap |

ADR-005 menolak inline script karena *"script host bisa membaca input"* — yang membuat itu benar
adalah **form disuntikkan ke DOM pelanggan**. D8 tidak memindahkannya ke sana.

## Empat syarat — ditulis sebagai syarat, bukan saran

Tanpa keempatnya, D8 justru **menambah** permukaan serangan alih-alih memperbaiki UX:

1. `targetOrigin` **eksplisit**, tidak pernah `'*'` — dari referrer yang sudah dicocokkan allowlist;
   di luar allowlist berarti **tidak mengirim sama sekali**
2. `event.origin` **wajib** diverifikasi penerima — tanpa ini, halaman mana pun bisa mengirim pesan palsu
3. Tinggi dibatasi **100–4000px** — pesan jahat tidak boleh bisa membuat iframe raksasa yang menutupi
   halaman pelanggan (*clickjacking* terbalik)
4. `embed.js` hanya mengenal **satu** jenis pesan — ia tidak boleh jadi jalur perintah umum dari iframe
   ke host

**Progressive enhancement, bukan syarat**: tanpa `embed.js`, iframe tetap tampil dan tetap bisa
dikirim. Kegagalan memuat script tidak boleh membuat form hilang.

## Yang berubah

- `prd.md` — D8 + bagian *"Kenapa script pendamping tidak membatalkan ADR-005"*
- `td.md` §7 (pengirim + empat syarat), §8 (`GET /embed.js`), §10 (snippet dua varian), §12 (test), §16 (dua risiko baru)
- `issues.md` — baris #88/#89 diperbarui
- Cakupan #88 dan #89 diperbarui lewat komentar issue

Snippet jadi **dua varian** — dengan dan tanpa script — keduanya sama-sama bekerja, untuk pelanggan
yang situsnya melarang script pihak ketiga.

Dokumen saja. Implementasinya di #88 dan #89.

Refs #91
Refs #88
Refs #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)