### PR TITLE
Buka Phase 7 — Outbound Webhook (PRD, TD, issues #100–#104)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 31 Agustus 2026 — **Issue #98 selesai** (sapu bersih `docs/issues/`: 6 berkas yang terlewat ditinjau, celah pointer ditutup). Sebelumnya: **#89 — Phase 6 selesai**.
-**Phase sekarang:** belum ada. Phase 6 selesai; Phase 7 (Webhook) belum dibuka. GATE freeze **dilewati secara sadar** oleh pemilik produk (lihat *Berikutnya*).
+**Last updated:** 31 Agustus 2026 — **Phase 7 dibuka** (PRD, TD, issues #100–#104). Sebelumnya: **#98** (sapu bersih `docs/issues/`), **#89** (Phase 6 selesai).
+**Phase sekarang:** Phase 7 — Outbound Webhook. Phase 6 selesai; GATE freeze **dilewati secara sadar** oleh pemilik produk (lihat *Berikutnya*).
 
 ---
 
@@ -66,9 +66,14 @@
 
 ## Sedang Dikerjakan
 
-**Tidak ada.** Phase 6 selesai ([#85–#89](https://github.com/Pravasta/jualin-crm/milestone/9),
-`docs/phases/06-connect-form/`). Phase 7 (Webhook) belum dibuka — belum ada PRD/TD/issue. Langkah
-manusia berikutnya ada di *Berikutnya* di bawah.
+**Phase 7 — Outbound Webhook** ([#100–#104](https://github.com/Pravasta/jualin-crm/milestone/10)).
+Dokumen: `docs/phases/07-outbound-webhook/`. PRD, TD, dan pemecahan issue selesai; **belum ada satu pun
+issue yang dikerjakan**. Berikutnya **#100** — migration `0008`, `safedial`, domain `webhook`, CRUD.
+
+**Dipecah secara sadar**: Phase 7 hanya **outbound**. Inbound webhook jadi **Phase 7.5** — ia
+pengulangan bentuk Phase 6 (kredensial publik, satu endpoint, signature menggantikan honeypot),
+sementara outbound kelas yang sama sekali berbeda (antrian, worker, SSRF). Bentuk payload inbound
+sudah diputuskan di muka: **tetap, sama seperti API Phase 4**.
 
 **Verifikasi anti-spam sungguhan (Turnstile) masih tertunda** — seluruh Phase 6 dibangun & diverifikasi
 dengan `CAPTCHA_PROVIDER=none` (akun Cloudflare belum diurus, lihat *Punya Lead Time* di bawah).
@@ -89,11 +94,11 @@ di bawah adalah poin yang jujur belum bisa diputuskan, dengan pemicunya masing-m
 | Berkas | Terbuka | Pemicu peninjauan |
 |---|---|---|
 | [`047`](./issues/047-public-lead-api.md) | angka `PUBLIC_API_RATE_LIMIT`; retensi `idempotency_key` | Traffic integrator produksi. **Baca sebelum menulis TD Phase 7** — webhook masuk hampir pasti butuh dedup, dan mekanisme `idempotency_key` yang ada belum pernah diuji di volume |
-| [`069`](./issues/069-flutter-foundation.md) | **cacat fungsional**: Employee multi-organization tidak bisa login di mobile; fallback biometric | Yang pertama **butuh issue tersendiri**, bukan menunggu apa pun |
+| [`069`](./issues/069-flutter-foundation.md) | **cacat fungsional**: Employee multi-organization tidak bisa login di mobile; fallback biometric | **Digabung ke sesi verifikasi HP Android** — keputusan pemilik produk 31 Agu 2026: perbaikannya toh tidak bisa diverifikasi tanpa perangkat fisik, jadi dikerjakan sekalian bersama 5 AC Phase 5 di `073`. Bukan lagi "butuh issue tersendiri sekarang" |
 | [`070`](./issues/070-design-foundation.md) | hitung mundur backoff; profil di gerbang biometric | Pemakaian nyata di HP |
 | [`071`](./issues/071-my-leads.md) | **tanpa paginasi** (ambang `per_page=25`); filter multi-select; kotak pencarian | Employee dengan >25 lead. Satu masalah dengan `073`'s pengurutan klien |
 | [`072`](./issues/072-detail-lead.md) | istilah aktor timeline; error layar penuh; aksi batal senyap | Mockup desain berikutnya / pemakaian nyata |
-| [`073`](./issues/073-tasks-fcm-notifications.md) | **5 AC menunggu HP Android**; pengurutan klien; cache notifikasi; `markRead` optimistik | Perangkat fisik + `FCM_CREDENTIALS_FILE` |
+| [`073`](./issues/073-tasks-fcm-notifications.md) | **5 AC menunggu HP Android**; pengurutan klien; cache notifikasi; `markRead` optimistik | Perangkat fisik + `FCM_CREDENTIALS_FILE`. **Sesi ini sekalian mengerjakan cacat 409 dari `069`** — keduanya butuh perangkat yang sama |
 | [`087`](./issues/087-form-submit-anti-spam.md) | angka rate limit form & time-trap; celah waktu honeypot | Form terpasang di situs pelanggan; celah honeypot **belum pernah aktif** (`CAPTCHA_PROVIDER=none`) |
 
 **Angka rate limit ditinjau sekali untuk semua**, bukan per angka — pemicunya sama, dan `api.md` bagian
@@ -103,6 +108,32 @@ daftar itu, bukan memulai keraguan terpisah.
 > **Kenapa bagian ini ada.** Pointer seperti ini tidak pernah dipasang untuk Phase 5 dan Phase 6,
 > sehingga enam berkas di atas tidak pernah dibaca saat phase-nya ditutup (#98). Templat issue kini
 > mewajibkannya.
+
+### Phase 7 — Outbound Webhook — baru dibuka (#100–#104)
+
+**Data berhenti jadi jalan satu arah.** Phase 4 dan 6 membuat lead bisa **masuk** tanpa developer;
+begitu masuk, ia berhenti di sini. Phase 7 membalik arahnya — saat sesuatu terjadi di Jualin, sistem
+lain diberi tahu sendiri. Dokumen: `docs/phases/07-outbound-webhook/`.
+
+**Phase pertama di mana kita yang memanggil, bukan yang dipanggil.** Seluruh permukaan jaringan produk
+ini sampai sekarang bersifat masuk. Di sini pelanggan memberi kita URL dan server kita meneleponnya —
+konsekuensi keamanannya terbalik arah dan lebih berat. **SSRF adalah risiko terbesar phase ini**, dan
+pertahanannya (`internal/shared/safedial`) sengaja lahir di issue pertama, bersama tempat pertama yang
+membutuhkannya.
+
+**Dua keputusan besar diambil di muka:**
+
+- **Tidak ada tabel `jobs` generik** — `webhook_deliveries` **adalah** antriannya. Ini penyimpangan
+  tertulis dari `freeze.md` bagian 5 ketentuan #4, dicatat penuh di `prd.md` D1 beserta kewajiban
+  evaluasi ulangnya: outbound webhook satu-satunya konsumen async di produk (email dan push keduanya
+  fire-and-forget), dan tabel generik untuk satu konsumen melanggar Aturan #28.
+- **Worker goroutine di binary `api` yang sama**, klaim lewat `FOR UPDATE SKIP LOCKED` — tanpa broker,
+  tanpa deployable baru, tanpa leader election. Postgres yang menjamin dua instance tidak mengirim
+  ganda, bukan koordinasi buatan kita — dan itu **wajib dibuktikan di bawah konkurensi nyata**, bukan
+  diasumsikan karena klausanya tertulis.
+
+**Tidak ada pihak ketiga** — berbeda dari Phase 5 (Firebase) dan Phase 6 (Turnstile). Tidak ada issue
+yang terblokir menunggu akun siapa pun.
 
 ### Phase 6 — Connect & Embedded Form — ✅ SELESAI (#85–#89)
 
@@ -312,5 +343,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 4.6 | Email Delivery | ✅ | ✅ | ✅ #63–#64 | ✅ |
 | 5 | Employee Mobile | ✅ | ✅ | ✅ #68–#73 | ✅ |
 | 6 | Connect & Embedded Form | ✅ | ✅ | ✅ #85–#89 | ✅ |
+| 7 | Outbound Webhook | ✅ | ✅ | ✅ #100–#104 | ⬜ |
+| 7.5 | Inbound Webhook | ⬜ | ⬜ | ⬜ | ⬜ |
 
 Pekerjaan yang sedang berjalan: `gh issue list --state open`

--- a/docs/issues/069-flutter-foundation.md
+++ b/docs/issues/069-flutter-foundation.md
@@ -66,5 +66,11 @@ ada yang peduli" itu penting — yang pertama benar, yang kedua tidak.
   sekali** — ia tidak akan pernah muncul sebagai keluhan tentang fitur ini, hanya sebagai "aplikasinya
   error". Pemicu tunggu itu tidak akan pernah terpicu. Layak jadi issue tersendiri; tidak diperbaiki
   di #98 (issue ini memutuskan, bukan mengimplementasi).
+  **Diputuskan pemilik produk 31 Agustus 2026 (saat Phase 7 dibuka): digabung ke sesi verifikasi HP
+  Android**, bukan issue terpisah sekarang. Alasannya kuat — perbaikannya butuh layar pemilih
+  organization di Flutter, dan itu **tidak bisa diverifikasi tanpa perangkat fisik**, persis seperti
+  lima AC Phase 5 yang sudah menunggu di `073`. Satu sesi dengan HP di tangan menyelesaikan keduanya;
+  dua sesi terpisah berarti yang satu tetap menunggu perangkat yang sama. Pemicunya sekarang **konkret
+  dan pasti terjadi** (sesi verifikasi HP), bukan "sampai skenarionya muncul" yang tidak akan pernah.
 - Poin kedua (fallback biometric memakai `LoginPage` penuh) **tetap terbuka** — murni UX, pemicunya
   pemakaian nyata di HP, yang juga belum terjadi.

--- a/docs/phases/07-outbound-webhook/issues.md
+++ b/docs/phases/07-outbound-webhook/issues.md
@@ -1,0 +1,101 @@
+# Phase 7 — Outbound Webhook · Issues
+
+> Indeks. **Tanpa kolom status** — status hidup di [GitHub Issues](https://github.com/Pravasta/jualin-crm/milestone/10) (ADR-008).
+> Apa & kenapa di [`prd.md`](./prd.md) · bagaimana di [`td.md`](./td.md).
+
+---
+
+## Daftar
+
+| # | Judul | Cakupan | TD |
+|---|---|---|---|
+| [100](https://github.com/Pravasta/jualin-crm/issues/100) | Migration `0008`, `safedial`, domain `webhook`, CRUD endpoint | Dua tabel, daftar tolak IP, lima berkas ADR-011, 5 endpoint kelola | §1, §2, §3, §6, §8 |
+| [101](https://github.com/Pravasta/jualin-crm/issues/101) | Signature HMAC + enqueue: pemicu dari `lead` | `signature.go`, `Enqueue`, bridge `WebhookEnqueuer` | §2, §5 |
+| [102](https://github.com/Pravasta/jualin-crm/issues/102) | Worker: klaim, kirim, retry, reaper, retensi | Infrastruktur async pertama di produk | §3.2–3.3, §4, §9, §10 |
+| [103](https://github.com/Pravasta/jualin-crm/issues/103) | Dashboard: `/connect/webhook` | Endpoint, riwayat pengiriman, kirim ulang | §6, §7 |
+| [104](https://github.com/Pravasta/jualin-crm/issues/104) | Dokumentasi verifikasi + penutup Phase 7 | `/connect/webhook/docs`, dokumentasi arsitektur, 14 AC | §2, §12, §15 |
+
+---
+
+## Urutan
+
+```
+#100 ──► #101 ──► #102 ──► #103 ──► #104
+```
+
+Berurutan penuh — tidak ada yang bisa paralel, berbeda dari Phase 6 (#85 ‖ #86).
+
+- **#101 butuh #100** — `Enqueue` menulis ke tabel yang belum ada sebelum `0008`.
+- **#102 butuh #101** — worker tidak punya apa pun untuk diklaim sampai ada yang menulis baris `pending`.
+- **#103 butuh #102** — riwayat pengiriman kosong dan tombol kirim ulang tidak ada artinya sampai
+  pengiriman sungguhan pernah terjadi.
+- **#104 butuh semuanya** — contoh verifikasi signature hanya bisa jujur setelah payload sungguhan
+  pernah terkirim dan diverifikasi.
+
+**#100 dan #101 sengaja dipisah** meski keduanya murni Go dan tidak besar. Alasannya sama seperti
+`apikey` #46/#47 dan `form` #85/#87: satu issue membangun **penyimpanan kredensial**, issue berikutnya
+membangun **yang memakainya**. Menggabungkannya menghasilkan PR yang mencampur dua kelas review —
+"apakah skemanya benar" dan "apakah pemicunya di tempat yang tepat".
+
+---
+
+## Batas per issue
+
+| Issue | Setelah selesai, yang **belum** ada |
+|---|---|
+| #100 | Belum ada yang menulis baris pengiriman, belum ada yang mengirimnya. `ClaimDue`/`Reap`/`Purge` ada tapi **nol pemanggil** — preseden `apikey.FindByKeyID` (#46), `form.FindByPublicKey` (#85) |
+| #101 | Baris `pending` menumpuk dan **tidak pernah terkirim**. Itu keadaan yang diinginkan, bukan bug |
+| #102 | Pengiriman jalan penuh, tapi **hanya bisa dikelola lewat `curl`** |
+| #103 | Owner bisa mengelola semuanya, tapi **penerima belum punya dokumentasi** cara memverifikasi signature |
+| #104 | Phase 7 tutup. Inbound webhook (7.5) dan penegakan paket (8) belum disentuh |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Kenapa lima issue, dan kenapa worker punya issue sendiri
+
+**#102 sengaja berdiri sendiri.** Ia infrastruktur async pertama di seluruh produk — antrian tahan
+crash, klaim aman lintas instance, retry berjeda, pemulihan baris menggantung, retensi. Setiap satu
+dari lima hal itu punya cara gagal yang berbeda, dan tiga di antaranya **hanya muncul di bawah
+konkurensi atau setelah crash** — dua keadaan yang tidak pernah terlihat di test berurutan.
+
+Menempelkannya ke issue lain berarti bagian paling sulit di-review dari phase ini masuk sebagai
+tambahan pada PR yang sudah membahas hal lain. Preseden yang sama: halaman embed Phase 6 dipisah jadi
+#88 justru karena ia kelas kemampuan baru (HTML, CSP, escaping), bukan karena ia besar.
+
+**`safedial` masuk #100, bukan issue sendiri.** URL tidak boleh **tersimpan** tanpa divalidasi, jadi
+validatornya harus lahir bersama tempat pertama yang membutuhkannya. Memisahkannya berarti #100
+menyimpan URL yang belum tervalidasi — walau sementara, itu keadaan yang tidak boleh pernah ada di
+`main`.
+
+---
+
+## Setelah kelimanya selesai
+
+Phase 7 tutup bila **14 acceptance criteria** di [`prd.md`](./prd.md) terpenuhi — terutama #1 (request
+sungguhan sampai ke penerima nyata), #4 (SSRF ditolak dua kali), dan #12 (dua instance tidak mengirim
+ganda). Lalu:
+
+0. **Cek `docs/issues/*` milik Phase 7** — checklist deviasi/keputusan dari #100–#104 yang perlu
+   ditinjau ulang sebelum phase benar-benar ditutup. Tiap poin terbuka **diputuskan atau dinyatakan
+   ulang dengan pemicu eksplisit**, bukan dilewati.
+   > Langkah ini ada di sini sejak phase dibuka — bukan retroaktif. Phase 5 dan Phase 6 melewatkannya
+   > karena tidak pernah memuatnya, dan enam berkas menumpuk tanpa dibaca (#98). Preseden yang bekerja:
+   > [`04-public-api/issues.md`](../04-public-api/issues.md) langkah 0.
+1. `api.md` (bab *Webhook Keluar* + dua error code), `authentication.md`, `authorization.md`,
+   `multi-tenancy.md` diperbarui (TD §15)
+2. `docs/testing/flow/` bertambah berkas: mendaftarkan endpoint, menerima pengiriman sungguhan,
+   memverifikasi signature dari sisi penerima
+3. `docs/STATUS.md` — Phase 7 ✅
+4. Buka **Phase 7.5 — Inbound Webhook** atau **Phase 8 — Subscription**, sesuai keputusan pemilik produk
+
+> **Tidak ada pihak ketiga di phase ini.** Berbeda dari Phase 5 (Firebase) dan Phase 6 (Turnstile),
+> tidak ada akun yang perlu diurus lebih dulu — verifikasi manual cukup dengan server penerima lokal
+> (`WEBHOOK_ALLOW_PRIVATE_TARGETS=true`) atau layanan penampung publik gratis. **Tidak ada issue yang
+> terblokir menunggu apa pun.**
+
+> **Staging masih belum ada.** Phase 7 tidak mengubah itu — dan di phase ini absennya lebih terasa:
+> webhook keluar adalah fitur pertama yang perilakunya bergantung pada **di mana ia berjalan**
+> (resolusi DNS, IP keluar, jaringan yang bisa dijangkau). Yang terbukti benar di laptop tidak otomatis
+> benar di produksi.

--- a/docs/phases/07-outbound-webhook/prd.md
+++ b/docs/phases/07-outbound-webhook/prd.md
@@ -1,0 +1,131 @@
+# Phase 7 — Outbound Webhook · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md).
+> Sumber: [`architecture/freeze.md`](../../architecture/freeze.md) bagian 8.4 (migration), 5 ketentuan #4 (`jobs` + worker), 3.4 (Webhook → Phase 7) · [`product/decisions.md`](../../product/decisions.md) §15 (syarat keamanan webhook), §25 (retry detail sengaja belum diputuskan) · [ADR-012](../../decisions/ADR-012-connect-surface-and-subscription-gating.md) (`/connect/webhook` sebagai kanal ketiga)
+
+---
+
+## Tujuan
+
+**Data berhenti menjadi jalan satu arah.**
+
+Phase 4 dan Phase 6 membuat lead bisa **masuk** tanpa developer. Tapi begitu masuk, ia berhenti di
+sini. Pemilik toko yang juga memakai spreadsheet stok, aplikasi akuntansi, atau grup WhatsApp tim
+harus membuka Jualin dan menyalin ulang — setiap kali. CRM menjadi tempat data mengendap, bukan
+tempat data mengalir.
+
+Phase 7 membalik arahnya: **saat sesuatu terjadi di Jualin, sistem lain diberi tahu sendiri.**
+
+> Ini phase pertama di mana **kita yang memanggil**, bukan yang dipanggil. Seluruh permukaan jaringan
+> produk ini sampai sekarang bersifat masuk — kita menerima request dan memutuskan menolaknya. Di sini
+> pelanggan memberi kita URL, dan server kita meneleponnya. Konsekuensi keamanannya terbalik arah dan
+> lebih berat: lihat *Kebutuhan #4* dan keputusan **D6**.
+
+---
+
+## Kebutuhan
+
+| # | Sebagai… | Saya butuh… | Supaya… |
+|---|---|---|---|
+| 1 | Owner | Sistem lain saya tahu ada lead baru **tanpa saya memberitahunya** | Saya sudah punya alat yang dipakai tim; menyalin ulang lead ke sana setiap hari adalah pekerjaan yang seharusnya tidak ada |
+| 2 | Owner | Tahu kalau pengiriman **gagal** | Integrasi yang diam-diam mati lebih berbahaya daripada integrasi yang tidak pernah ada — saya berhenti mengecek Jualin karena mengira sistem lain sudah tahu |
+| 3 | Owner | Mengirim ulang pengiriman yang gagal | Endpoint saya sempat mati satu jam; saya tidak mau kehilangan lead hari itu selamanya |
+| 4 | Pemilik sistem | URL yang diketik pelanggan **tidak bisa** dipakai menyerang infrastruktur kita | Pelanggan mengendalikan tujuan panggilan yang **server kita** lakukan. Ini SSRF, dan ia bukan risiko teoretis — `169.254.169.254` mengembalikan kredensial cloud di hampir setiap penyedia |
+| 5 | Penerima webhook | Memastikan request benar-benar dari Jualin | URL webhook pada akhirnya terekspos; tanpa tanda tangan, siapa pun yang menebaknya bisa menyuntik lead palsu ke sistem pelanggan |
+| 6 | Pemilik sistem | Endpoint pelanggan yang mati **berhenti dicoba** | Di harga terjangkau, endpoint mati yang dicoba selamanya adalah biaya yang ditanggung Jualin — sama persis alasan anti-spam Phase 6 |
+
+---
+
+## Acceptance Criteria
+
+Phase 7 selesai bila **semuanya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | Owner mendaftarkan URL dari dashboard → lead baru dibuat → **request sungguhan sampai** ke URL itu, diverifikasi dari server penerima nyata, bukan dari membaca log |
+| 2 | Payload membawa signature yang **bisa diverifikasi** penerima dengan secret yang ditampilkan sekali saat endpoint dibuat |
+| 3 | Signature menolak payload yang diubah satu byte, dan menolak request yang diputar ulang di luar toleransi waktu |
+| 4 | URL yang menunjuk ke alamat privat, loopback, atau link-local **ditolak saat disimpan** — dan tetap ditolak saat dikirim, bila DNS-nya berubah setelah tersimpan |
+| 5 | Redirect **tidak pernah diikuti** |
+| 6 | Endpoint yang mengembalikan `5xx` dicoba ulang dengan jeda menaik; setelah percobaan terakhir ia berhenti dan berstatus gagal permanen |
+| 7 | Endpoint yang mengembalikan `4xx` **tidak** dicoba ulang — kecuali `429` |
+| 8 | Pengiriman **tidak pernah** terjadi di dalam transaksi database yang memicunya (Aturan #32) |
+| 9 | Membuat lead **tetap berhasil** walau endpoint webhook mati total — pengiriman gagal tidak pernah membatalkan operasi yang memicunya |
+| 10 | Owner melihat riwayat pengiriman per endpoint: waktu, status, kode respons, percobaan ke berapa |
+| 11 | Owner bisa memicu kirim ulang manual untuk pengiriman yang gagal, dan hasilnya terlihat di riwayat yang sama |
+| 12 | Dua instance aplikasi berjalan bersamaan **tidak** mengirim pengiriman yang sama dua kali — dibuktikan di bawah konkurensi nyata, bukan diasumsikan dari `SKIP LOCKED` |
+| 13 | Endpoint webhook milik organization lain **tidak** terlihat maupun bisa disunting — harness isolasi tenant bertambah kasus, dan **tetap terbukti bisa gagal** |
+| 14 | `webhook_deliveries` punya retensi tertulis — ia tidak tumbuh selamanya |
+
+---
+
+## Keputusan yang ditutup di phase ini
+
+Delapan keputusan yang jatuh tempo di sini, ditutup di muka daripada di tengah implementasi. Alasan
+teknis lengkap di [`td.md`](./td.md); yang di bawah adalah **apa** dan **kenapa** dalam kalimat produk.
+
+| # | Pertanyaan | Keputusan | Alasan |
+|---|---|---|---|
+| **D1** | Antriannya tabel `jobs` generik atau `webhook_deliveries` sendiri? | **`webhook_deliveries` adalah antriannya.** Tidak ada tabel `jobs`. | Lihat catatan *"Penyimpangan tertulis dari freeze"* di bawah — satu-satunya keputusan phase ini yang menyimpang dari freeze, dan karena itu ditulis terpisah. |
+| **D2** | Worker jalan di mana? | **Goroutine di dalam binary `api` yang sama**, mengambil kerja lewat `SELECT … FOR UPDATE SKIP LOCKED`. Bukan proses, bukan deployable, bukan broker. | Batasan CLAUDE.md mengikat: monolith, tanpa message broker, biaya infrastruktur per tenant harus tetap rendah. `SKIP LOCKED` membuat banyak instance aman **tanpa** leader election — Postgres yang menjamin, bukan janji kita. Preseden `FOR UPDATE` sudah ada sejak rotasi refresh token (#10). |
+| **D3** | Event apa yang memicu? | **Dua**: `lead.created` dan `lead.status_changed`. | Cukup membuktikan seluruh mekanisme (antrian, retry, signature, SSRF) sekaligus benar-benar berguna — sinkronisasi pipeline, bukan sekadar pemberitahuan. Event ketiga kelak = satu pemanggil baru, bukan mekanisme baru. |
+| **D4** | Bentuk signature | `X-Jualin-Signature: t=<unix>,v1=<hmac-sha256>`, di-HMAC atas `<timestamp>.<body mentah>`. Toleransi waktu 5 menit. | Bentuk yang sudah dikenal integrator (pola yang sama dipakai Stripe dan GitHub) — pilihan yang membuat dokumentasi kita lebih pendek, bukan lebih panjang. Timestamp **ikut ditandatangani**, kalau tidak ia bisa diganti dan replay protection-nya hilang. |
+| **D5** | Kebijakan retry | **5 percobaan**, jeda 1m → 5m → 30m → 2j → 6j, lalu berhenti permanen. `4xx` tidak diulang, kecuali `429`. | `decisions.md` §25 sengaja menyisakan angka ini untuk diputuskan di phase-nya. Angkanya **bukan hasil pengukuran** — masuk daftar yang sama dengan angka rate limit (`api.md`). Yang **bukan** tebakan adalah bentuknya: `4xx` berarti "permintaanmu salah", mengulanginya tidak akan mengubah apa pun. |
+| **D6** | Pertahanan SSRF | Validasi **dua kali** — saat disimpan dan saat dikirim — terhadap **IP hasil resolusi**, bukan hostname. Redirect **tidak pernah** diikuti. | Validasi sekali saat disimpan bisa dilewati DNS rebinding: hostname yang tadinya publik diarahkan ulang ke `127.0.0.1` setelah tersimpan. Menolak redirect sepenuhnya menghapus seluruh kelas bypass tanpa kerja tambahan (Aturan #27) — pelanggan yang butuh redirect bisa mendaftarkan URL tujuannya langsung. |
+| **D7** | Kredensial keempat | **Signing secret** per endpoint, ditampilkan **sekali** saat dibuat (Aturan #21), disimpan sebagai hash. | Ini kredensial keempat produk ini, dan yang pertama yang **kita** pakai untuk membuktikan diri ke pihak lain — tiga sebelumnya untuk pihak lain membuktikan diri ke kita. Arahnya terbalik; formatnya sengaja tidak menyerupai `jln_live_` maupun `pk_`. |
+| **D8** | Retensi `webhook_deliveries` | **30 hari**, dibersihkan malas tanpa scheduler — pola persis retensi `idempotency_key` (Phase 4). | Riwayat pengiriman adalah alat diagnosis, bukan catatan audit — Aturan #18 mengikat `activities` dan `audit_log`, bukan ini. Tanpa retensi ia tabel dengan pertumbuhan tercepat di produk (satu baris per lead per endpoint per percobaan). |
+
+### Penyimpangan tertulis dari freeze — D1
+
+`freeze.md` bagian 5 ketentuan #4 menulis: *"Tabel `jobs` + worker diperkenalkan saat ada kebutuhan
+async yang **nyata**: push notification (Phase 5) atau outbound webhook (Phase 7)."*
+
+Phase 5 **tidak** memperkenalkannya — push dibangun fire-and-forget, best-effort, tanpa antrian. Jadi
+Phase 7 adalah momen yang dimaksud ketentuan itu. Tetapi phase ini tetap **tidak** membuat tabel
+`jobs`, dan alasannya perlu berdiri terbuka:
+
+| | |
+|---|---|
+| **Maksud ketentuan tetap dipenuhi** | Yang ketentuan #4 lindungi adalah *"jangan bangun infrastruktur async sebelum ada kebutuhan nyata"*. Phase 7 memang membangunnya — antrian tahan-crash, worker, retry berjeda, dead-letter. Yang berbeda hanya **bentuk tabelnya**. |
+| **Hanya ada satu konsumen** | Email, push, dan audit semuanya fire-and-forget hari ini. Outbound webhook adalah satu-satunya kerja async di seluruh produk. Tabel `jobs` generik dengan `payload jsonb` + `job_type` untuk **satu** tipe berarti membangun abstraksi sebelum implementasi kedua yang nyata — Aturan #28, dilanggar telak. |
+| **Bentuk generik justru kehilangan sesuatu** | `webhook_deliveries` butuh kolom yang `jobs` generik tidak punya tempatnya: `endpoint_id` (FK komposit tenant-scoped), `response_status`, `attempt`, `event_type`. Menyimpannya di dalam `payload jsonb` berarti riwayat pengiriman — yang **kriteria #10 wajibkan tampil di dashboard** — hanya bisa dibaca dengan menggali JSON, bukan di-query. |
+
+**Kewajiban yang ikut lahir dari keputusan ini** — dicatat supaya tidak hilang: bila kelak lahir
+konsumen async **kedua** yang nyata (laporan terjadwal, ekspor besar, pembersihan massal), saat itulah
+tabel `jobs` generik dievaluasi ulang — dengan dua implementasi nyata di tangan, sebagaimana Aturan #28
+memang mensyaratkan. Phase 7 tidak menutup pintu itu; ia hanya menolak membukanya lebih awal.
+
+---
+
+## Di luar cakupan
+
+| Tidak dikerjakan | Ke |
+|---|---|
+| **Inbound webhook** | **Phase 7.5** — dipecah secara sadar. Inbound adalah pengulangan bentuk Phase 6 (kredensial publik, satu endpoint, verifikasi signature menggantikan honeypot); outbound adalah kelas yang sama sekali berbeda (antrian, worker, SSRF). Menggabungkannya berarti satu PRD dengan dua profil risiko yang tidak berhubungan. Bentuk payload inbound sudah diputuskan: **tetap, sama seperti API Phase 4** — pengirim menyesuaikan ke bentuk kita |
+| Pemetaan payload dari platform lain | Belum terjadwal — konsekuensi langsung dari keputusan inbound di atas. Ia fitur besar tersendiri (UI pemetaan, penyimpanan aturan, mesin evaluasi), dan tidak diperlukan untuk membuktikan webhook bekerja |
+| Event di luar `lead.created` & `lead.status_changed` (D3) | Kapan pun diminta — menambahnya satu pemanggil baru, bukan mekanisme baru |
+| Penegakan paket, keadaan "terkunci" pada kartu Webhook | Phase 8 — ADR-012 §4. Kartu Webhook berhenti berbunyi *"belum tersedia"* di phase ini, tapi **tidak** berganti jadi *"terkunci"* |
+| Tabel `jobs` generik | Saat ada konsumen async **kedua** yang nyata (D1) |
+| Transformasi/penyaringan payload per endpoint | Belum ada yang memintanya. Endpoint menerima seluruh event yang ia langgan, apa adanya |
+| Staging / deployment untuk QA | Terpisah dari phase manapun — tetap prasyarat sebelum Tim QA bisa bekerja |
+
+---
+
+## Dependensi
+
+Phase 1–6 selesai. Yang dipakai phase ini sudah ada seluruhnya:
+
+| Yang dipakai | Dari | Catatan |
+|---|---|---|
+| `leads.source` menerima `'webhook'` | Phase 2 | Dibuat di `0003` **sebelum** ada yang memakainya — hadiah yang sama seperti `'form'` di Phase 6. Tidak ada `ALTER` pada enum. Dipakai Phase 7.5 (inbound), bukan phase ini |
+| `db.InTx` / `Store.InTx` per-domain | Phase 1, ADR-011 | Antrian ditulis **di dalam** transaksi yang memicunya; pengiriman terjadi **di luar** (Aturan #32) |
+| `SELECT … FOR UPDATE` | Phase 1 (#10) | Rotasi refresh token sudah memakainya. Phase 7 menambah `SKIP LOCKED`, bukan mekanisme kunci baru |
+| Pola bridge konsumen (`ActivityRecorder`, `LeadCreator`) | Phase 2, 6 | `lead` memicu webhook lewat interface yang **ia sendiri** deklarasikan, bukan dengan mengimpor `internal/webhook` |
+| `apikey` — kredensial ditampilkan sekali, hash tersimpan | Phase 4 | Signing secret (D7) mengikuti bentuknya, dengan arah kepercayaan terbalik |
+| Retensi malas tanpa scheduler | Phase 4 (`idempotency_key`) | D8 memakai pola yang sama persis |
+| `crm_dashboard` — Connect, `canManageForms`/`canManageAPIKeys` | Phase 4, 6 | `/connect/webhook` menempel pada kerangka yang sudah ada; `canManageWebhooks` lahir di sebelahnya |
+
+**Satu poin terbuka yang wajib dibaca sebelum TD final**:
+`docs/issues/047-public-lead-api.md` — retensi `idempotency_key` belum pernah diuji di volume
+produksi, dan **D8 memakai pola yang sama**. Bukan alasan menghindarinya, tapi jangan mewarisi
+keraguannya diam-diam: kalau polanya ternyata bermasalah, ia bermasalah di dua tempat.

--- a/docs/phases/07-outbound-webhook/td.md
+++ b/docs/phases/07-outbound-webhook/td.md
@@ -1,0 +1,515 @@
+# Phase 7 — Outbound Webhook · TD
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+> Ini **delta** untuk phase ini. Aturan yang sudah ada di [`freeze.md`](../../architecture/freeze.md) tidak diulang, hanya dirujuk.
+
+---
+
+## 1. Schema — migration `0008_webhooks`
+
+Nomor `0008` belum dipesan freeze 8.4 (tabelnya berhenti di `0007`). Dua tabel, satu migration.
+
+```sql
+CREATE TABLE webhook_endpoints (
+    id               uuid PRIMARY KEY,
+    organization_id  uuid NOT NULL REFERENCES organizations (id),
+    url              text NOT NULL,
+    secret_hash      text NOT NULL,
+    secret_prefix    text NOT NULL,
+    events           text[] NOT NULL,
+    description      text NOT NULL DEFAULT '',
+    is_active        boolean NOT NULL DEFAULT true,
+    created_by_membership_id uuid,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now(),
+    deleted_at       timestamptz,
+
+    CONSTRAINT uq_webhook_endpoints_id_org UNIQUE (id, organization_id),
+    CONSTRAINT ck_webhook_endpoints_url_scheme CHECK (url LIKE 'https://%' OR url LIKE 'http://%'),
+    CONSTRAINT ck_webhook_endpoints_events_not_empty CHECK (cardinality(events) > 0),
+    CONSTRAINT fk_webhook_endpoints_created_by
+        FOREIGN KEY (created_by_membership_id, organization_id)
+        REFERENCES memberships (id, organization_id)
+);
+
+CREATE INDEX ix_webhook_endpoints_org ON webhook_endpoints (organization_id, created_at DESC)
+    WHERE deleted_at IS NULL;
+
+CREATE TABLE webhook_deliveries (
+    id               uuid PRIMARY KEY,
+    organization_id  uuid NOT NULL REFERENCES organizations (id),
+    endpoint_id      uuid NOT NULL,
+    event_type       text NOT NULL,
+    payload          jsonb NOT NULL,
+    status           text NOT NULL DEFAULT 'pending',
+    attempt          integer NOT NULL DEFAULT 0,
+    next_attempt_at  timestamptz NOT NULL DEFAULT now(),
+    response_status  integer,
+    error            text,
+    delivering_since timestamptz,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT uq_webhook_deliveries_id_org UNIQUE (id, organization_id),
+    CONSTRAINT ck_webhook_deliveries_status
+        CHECK (status IN ('pending', 'delivering', 'succeeded', 'failed')),
+    CONSTRAINT fk_webhook_deliveries_endpoint
+        FOREIGN KEY (endpoint_id, organization_id)
+        REFERENCES webhook_endpoints (id, organization_id)
+);
+
+-- Riwayat per endpoint, dibaca dashboard (kriteria #10). Tenant-aware, berawalan
+-- organization_id sesuai Aturan #16.
+CREATE INDEX ix_webhook_deliveries_org ON webhook_deliveries
+    (organization_id, endpoint_id, created_at DESC);
+
+-- Antrian worker. SENGAJA TIDAK berawalan organization_id — lihat §1.2.
+CREATE INDEX ix_webhook_deliveries_claim ON webhook_deliveries (next_attempt_at)
+    WHERE status = 'pending';
+```
+
+`ck_webhook_endpoints_url_scheme` sengaja **tidak** memaksa `https://` di level database: pengembangan
+lokal butuh `http://localhost` (§9, `WEBHOOK_ALLOW_PRIVATE_TARGETS`). Penegakan `https` di produksi
+ada di usecase, bukan di `CHECK` — kalau di database, ia tidak bisa dilonggarkan per-environment tanpa
+migration.
+
+### 1.1 `payload` sebagai JSONB — alasan tertulis (Aturan #17)
+
+Ia **snapshot event pada saat terjadi**, bukan data yang di-query. Payload harus dibekukan saat
+di-enqueue, bukan dibangun ulang saat dikirim — kalau lead berubah status tiga kali dalam lima menit,
+tiga pengiriman itu harus membawa tiga isi yang berbeda, bukan tiga salinan keadaan terakhir. Tidak
+pernah ada query yang memfilter berdasarkan isinya; ia dibaca utuh saat mengirim dan saat menampilkan
+riwayat.
+
+### 1.2 `ix_webhook_deliveries_claim` — pengecualian tertulis atas Aturan #16
+
+Aturan #16: *"Index tenant-aware selalu berawalan `organization_id`"*. Index ini **sengaja tidak**,
+dan itu bukan kelalaian:
+
+> Worker mengambil kerja **lintas seluruh organization** — ia infrastruktur, bukan pemanggil
+> tenant-scoped. `organization_id` adalah **hasil** dari baris yang terambil, bukan input untuk
+> mencarinya. Mengawali index dengan `organization_id` membuatnya tidak terpakai sama sekali oleh
+> query klaim, yang predikatnya hanya `status` dan `next_attempt_at`.
+
+Bentuknya sekelas pengecualian yang sudah ada tiga kali: `apikey.FindByKeyID`, `form.FindByPublicKey`,
+dan `device_tokens.token` — semuanya lookup di mana organization adalah keluaran. Perbedaannya, di sini
+yang dikecualikan **index**, bukan constraint unik. Ditambahkan ke `multi-tenancy.md` sebagai
+pengecualian jenis baru, bukan diselipkan ke daftar yang sudah ada (§15).
+
+Index riwayat (`ix_webhook_deliveries_org`) **tetap** berawalan `organization_id` — ia memang dibaca
+dari jalur tenant-scoped.
+
+---
+
+## 2. Signature (keputusan D4)
+
+```
+signed_payload = "<timestamp>" + "." + <body mentah, byte demi byte>
+signature      = HMAC-SHA256(secret, signed_payload)
+header         = X-Jualin-Signature: t=<timestamp>,v1=<signature hex>
+```
+
+| Aspek | Ketentuan |
+|---|---|
+| Secret | 32 byte `crypto/rand` → base64url. Format `whsec_<43 karakter>` |
+| Penyimpanan | **SHA-256 hash**, sama seperti API key (Aturan #20). `secret_prefix` (8 karakter pertama) disimpan terpisah untuk ditampilkan di daftar |
+| Tampil | **Sekali**, saat endpoint dibuat (Aturan #21) |
+| Toleransi | 5 menit — dinyatakan di dokumentasi untuk penerima, bukan ditegakkan pengirim |
+
+**Kenapa timestamp ikut ditandatangani.** Kalau `t` berada di luar `signed_payload`, penyerang yang
+menangkap satu request sah bisa mengubah `t` ke waktu sekarang dan memutarnya ulang selamanya —
+signature-nya tetap cocok karena ia hanya menutupi body. Menyatukan keduanya membuat perubahan `t`
+merusak signature. Ini kesalahan yang sering terjadi pada implementasi buatan sendiri, dan alasan
+bentuk `t=…,v1=…` dipilih apa adanya dari pola yang sudah teruji luas.
+
+**`whsec_` sengaja tidak menyerupai `jln_live_` maupun `pk_`.** Tiga kredensial dengan aturan
+berlawanan tidak boleh terlihat mirip — dan yang ini arahnya terbalik dari keduanya: ia bukti **kita**
+kepada pihak lain, bukan sebaliknya.
+
+Dokumentasi verifikasi untuk penerima (contoh Node/PHP/Python) masuk `/connect/webhook/docs`, mengikuti
+preseden `/connect/api/docs` (#49).
+
+---
+
+## 3. Pertahanan SSRF (keputusan D6) — bagian paling berbahaya di phase ini
+
+Pelanggan mengetik URL; **server kita** yang memanggilnya. Tanpa pertahanan, endpoint ini adalah
+proxy request yang dikendalikan pelanggan ke dalam jaringan kita sendiri.
+
+### 3.1 Daftar tolak
+
+Ditolak bila **IP hasil resolusi** masuk salah satu:
+
+| Rentang | Kenapa |
+|---|---|
+| `127.0.0.0/8`, `::1` | Loopback — service internal di host yang sama |
+| `10/8`, `172.16/12`, `192.168/16`, `fc00::/7` | Jaringan privat |
+| `169.254.0.0/16`, `fe80::/10` | **Link-local — metadata cloud (`169.254.169.254`)**, kredensial instance |
+| `100.64.0.0/10` | CGNAT |
+| `0.0.0.0/8`, `::` | Unspecified |
+| Multicast, broadcast, reserved | Tidak pernah tujuan HTTP yang sah |
+
+### 3.2 Divalidasi dua kali, dan yang divalidasi adalah IP
+
+```
+Saat disimpan   → parse URL → resolve DNS → tiap IP dicek daftar tolak → tolak 400 bila ada yang kena
+Saat dikirim    → resolve ulang → cek ulang → dial IP YANG SUDAH DIVALIDASI, bukan hostname
+```
+
+**Kenapa dua kali.** Validasi hanya saat disimpan bisa dilewati **DNS rebinding**: hostname yang saat
+disimpan menunjuk IP publik, diarahkan ulang pemiliknya ke `127.0.0.1` setelah tersimpan. Setiap
+pengiriman berikutnya lolos tanpa pernah dicek lagi.
+
+**Kenapa dial IP, bukan hostname.** Kalau kita memvalidasi hostname lalu menyerahkan hostname itu ke
+`http.Client`, ada dua resolusi DNS terpisah — satu untuk cek, satu untuk koneksi — dan penyerang bisa
+membuat keduanya menjawab berbeda (TOCTOU). Resolusi dilakukan **sekali**, dan koneksi memakai IP hasil
+resolusi itu (lewat `DialContext` kustom); header `Host` tetap hostname aslinya supaya TLS dan
+virtual-host di sisi penerima tetap benar.
+
+### 3.3 Redirect tidak pernah diikuti
+
+`http.Client.CheckRedirect` selalu mengembalikan error. Redirect adalah jalur bypass paling langsung:
+URL publik yang sah membalas `302` ke `http://169.254.169.254/`, dan seluruh validasi di atas terlewati
+karena ia terjadi setelahnya.
+
+Menolaknya sepenuhnya menghapus kelas bypass itu tanpa kerja tambahan (Aturan #27). Konsekuensi yang
+diterima sadar: pelanggan yang URL-nya me-redirect harus mendaftarkan URL tujuan langsung. `3xx`
+diperlakukan sebagai kegagalan **permanen**, bukan dicoba ulang — mengulanginya akan menghasilkan
+redirect yang sama.
+
+### 3.4 `WEBHOOK_ALLOW_PRIVATE_TARGETS`
+
+Pengembangan lokal harus bisa mengirim ke `http://localhost:9099`. Satu env var melonggarkannya,
+**ditolak saat boot** ketika `APP_ENV=production` (Aturan #36) — bentuk persis `CAPTCHA_PROVIDER=none`
+(Phase 6), `MAIL_PROVIDER` (4.6), dan `PUSH_PROVIDER` (5). Pola yang sama untuk alasan yang sama:
+seluruh phase bisa dikerjakan dan diuji tanpa layanan pihak ketiga, sementara produksi tidak bisa
+berjalan setengah siap.
+
+---
+
+## 4. Worker (keputusan D2)
+
+Goroutine di dalam binary `api`, dimulai setelah HTTP server siap, dihentikan pada graceful shutdown
+(#1). Bukan proses, bukan deployable baru, bukan broker.
+
+### 4.1 Klaim
+
+```sql
+SELECT id, organization_id, endpoint_id, event_type, payload, attempt
+FROM webhook_deliveries
+WHERE status = 'pending' AND next_attempt_at <= now()
+ORDER BY next_attempt_at
+LIMIT $1
+FOR UPDATE SKIP LOCKED;
+```
+
+lalu, di transaksi yang sama:
+
+```sql
+UPDATE webhook_deliveries
+SET status = 'delivering', delivering_since = now(), updated_at = now()
+WHERE id = ANY($1);
+```
+
+**Transaksi ditutup sebelum HTTP apa pun terjadi** (Aturan #32). Baris sudah bertanda `delivering`, jadi
+instance lain tidak akan mengambilnya.
+
+`SKIP LOCKED` yang membuat banyak instance aman **tanpa leader election** — Postgres yang menjamin dua
+transaksi tidak mengunci baris yang sama, bukan koordinasi buatan kita. Ini yang memenuhi kriteria #12,
+dan ia **wajib diuji di bawah konkurensi nyata** (§12), bukan diasumsikan benar karena klausanya
+tertulis.
+
+### 4.2 Reaper — baris `delivering` yang menggantung
+
+Crash tepat setelah transaksi klaim commit meninggalkan baris `delivering` selamanya: tidak ada yang
+mengambilnya (bukan `pending`), tidak ada yang menyelesaikannya.
+
+```sql
+UPDATE webhook_deliveries
+SET status = 'pending', next_attempt_at = now(), delivering_since = NULL
+WHERE status = 'delivering' AND delivering_since < now() - interval '10 minutes';
+```
+
+Dijalankan di awal tiap putaran worker. Ambang 10 menit jauh di atas `WEBHOOK_DELIVERY_TIMEOUT` (10
+detik), jadi ia tidak akan pernah merebut pengiriman yang benar-benar sedang berjalan.
+
+**Konsekuensi yang diterima sadar:** crash antara "HTTP terkirim" dan "hasil tercatat" menghasilkan
+pengiriman **ganda**. Ini `at-least-once`, bukan `exactly-once`, dan itu keputusan — `exactly-once`
+lintas jaringan tidak bisa dicapai tanpa kerja sama penerima. Karena itu setiap payload membawa
+`delivery_id` yang stabil lintas percobaan, supaya penerima bisa melakukan deduplikasi sendiri; ini
+**didokumentasikan ke penerima**, bukan disembunyikan.
+
+### 4.3 Hasil
+
+| Respons | Perlakuan |
+|---|---|
+| `2xx` | `succeeded`, selesai |
+| `429` | Dicoba ulang — server penerima yang minta |
+| `4xx` lain | `failed` **permanen**, tidak dicoba ulang (D5: "permintaanmu salah" tidak berubah dengan diulang) |
+| `3xx` | `failed` permanen (§3.3) |
+| `5xx`, timeout, DNS gagal, koneksi ditolak | Dicoba ulang sampai `WEBHOOK_MAX_ATTEMPTS` |
+
+Jeda: **1m → 5m → 30m → 2j → 6j** (D5). Setelah percobaan kelima → `failed`.
+
+Body respons **tidak disimpan** — hanya `response_status` dan `error` singkat. Body penerima bisa
+berisi apa saja, termasuk data sensitif mereka sendiri, dan kita tidak punya alasan menyimpannya
+(Aturan #26 semangatnya sama).
+
+---
+
+## 5. Alur pemicu (keputusan D3)
+
+```
+lead.Usecase.Create
+  └─ Store.InTx
+       ├─ lead.Create
+       ├─ activity.Record("lead_created")        ← sudah ada sejak #21
+       └─ webhook.Enqueue("lead.created", ...)   ← BARU, di DALAM transaksi
+     (commit)
+  … worker mengambilnya nanti, HTTP di LUAR transaksi
+```
+
+`Enqueue` menulis **satu baris `pending` per endpoint aktif** yang melanggan event itu. Ia murni
+operasi database, jadi ia **wajib** di dalam transaksi pemicunya: lead yang commit tanpa baris
+pengiriman berarti event hilang selamanya, dan baris pengiriman yang commit tanpa lead berarti kita
+mengirim event tentang sesuatu yang tidak ada.
+
+Ini **tidak** melanggar Aturan #32 — yang dilarang aturan itu adalah **efek samping eksternal** (HTTP,
+email) di dalam transaksi. Menulis baris antrian adalah operasi database biasa; justru pemisahan
+inilah yang membuat Aturan #32 bisa dipenuhi tanpa kehilangan event.
+
+### Bridge — `lead` tidak pernah mengimpor `internal/webhook`
+
+Interface dideklarasikan **konsumen** (ADR-011), primitif saja, persis bentuk `ActivityRecorder` (#21)
+dan `LeadCreator` (#87):
+
+```go
+// internal/lead/port.go
+type WebhookEnqueuer interface {
+    Enqueue(ctx context.Context, t tenant.Context, eventType string, payload []byte) error
+}
+```
+
+Dijembatani di composition root (`cmd/api/`), bukan lewat impor langsung.
+
+### Payload
+
+```json
+{
+  "delivery_id": "01a0…",
+  "event": "lead.created",
+  "occurred_at": "2026-08-31T06:20:17.531933Z",
+  "organization_id": "01a0…",
+  "data": { "lead": { … bentuk leadJSON … } }
+}
+```
+
+`data.lead` memakai **`leadJSON` yang sama** dengan API dashboard — satu bentuk lead di seluruh produk,
+bukan bentuk kedua yang harus dijaga tetap sama selamanya. `delivery_id` stabil lintas percobaan (§4.2).
+
+`lead.status_changed` menambahkan `"changes": {"status": {"from": "new", "to": "contacted"}}` — bentuk
+yang sama dengan `activities.metadata` untuk `status_changed` (#21), bukan bentuk ketiga.
+
+---
+
+## 6. Endpoint
+
+| Method | Path | Principal | Otorisasi |
+|---|---|---|---|
+| `POST` | `/v1/webhook-endpoints` | user | `webhook.create` — Owner/Admin |
+| `GET` | `/v1/webhook-endpoints` | user | `webhook.list` — Owner/Admin |
+| `GET` | `/v1/webhook-endpoints/:id` | user | `webhook.read` — Owner/Admin |
+| `PATCH` | `/v1/webhook-endpoints/:id` | user | `webhook.update` — Owner/Admin |
+| `DELETE` | `/v1/webhook-endpoints/:id` | user | `webhook.delete` — Owner/Admin (soft delete) |
+| `GET` | `/v1/webhook-endpoints/:id/deliveries` | user | `webhook.read` — berpaginasi |
+| `POST` | `/v1/webhook-deliveries/:id/retry` | user | `webhook.update` |
+
+Path `webhook-endpoints` (bukan `webhooks`) supaya `/v1/webhook-deliveries/…` di sebelahnya tidak
+ambigu, dan supaya tidak ada tabrakan wildcard seperti yang Phase 6 §8 hadapi.
+
+**Kirim ulang manual** (kriteria #11) menyetel baris kembali ke `pending` dengan `next_attempt_at =
+now()` dan `attempt = 0`. Hanya sah untuk status `failed` — `409` untuk status lain, supaya menekan
+tombol dua kali tidak menggandakan pengiriman yang sedang berjalan.
+
+---
+
+## 7. Error code baru
+
+| Status | Code | Kapan |
+|---|---|---|
+| `400` | `webhook_url_not_allowed` | URL menunjuk alamat privat/loopback/link-local, skema bukan http(s), atau DNS tidak bisa diresolusi |
+| `409` | `delivery_not_retryable` | Kirim ulang dipanggil untuk pengiriman yang statusnya bukan `failed` |
+
+`404 not_found`, `400 validation_failed`, `403 forbidden` dipakai ulang apa adanya.
+
+`webhook_url_not_allowed` sengaja **satu kode untuk semua alasan penolakan URL** — membedakan "privat"
+dari "tidak bisa diresolusi" memberi pelanggan alat memetakan jaringan internal kita lewat pesan error.
+Pesannya generik; alasan detailnya masuk log server, bukan response.
+
+---
+
+## 8. Otorisasi
+
+Owner/Admin penuh; Manager dan Employee **tidak punya akses sama sekali** — sama seperti `api_key`
+(#46) dan `form` (#85), dan untuk alasan yang sama: endpoint webhook adalah kredensial yang mengalirkan
+data organization ke luar.
+
+Empat `Action` baru: `webhook.create`, `webhook.list`, `webhook.read`, `webhook.update`,
+`webhook.delete`. Ditambahkan ke tabel per-role di `authz_test.go` **dan** ke `allActions` — celah yang
+sama sudah terjadi dua kali (`ActionAPIKey*` di #46, `ActionForm*` di #85, keduanya di-backfill
+belakangan). Jangan ketiga kalinya.
+
+Principal `api_key` dan `public_form` **tidak** mendapat satu pun dari kelimanya — deny-by-absence di
+`apiKeyScopeFor`/`publicFormAllows` menanganinya otomatis, dan tabel-atas-seluruh-`Action` yang sudah
+ada membuktikannya tanpa baris baru.
+
+---
+
+## 9. Konfigurasi
+
+```
+WEBHOOK_WORKER_ENABLED=true          # false untuk instance yang hanya melayani HTTP
+WEBHOOK_WORKER_INTERVAL=10s
+WEBHOOK_WORKER_BATCH=20
+WEBHOOK_DELIVERY_TIMEOUT=10s
+WEBHOOK_MAX_ATTEMPTS=5
+WEBHOOK_ALLOW_PRIVATE_TARGETS=false  # ditolak saat APP_ENV=production (Aturan #36)
+WEBHOOK_DELIVERY_RETENTION_DAYS=30
+```
+
+`WEBHOOK_MAX_ATTEMPTS`, interval, dan batch **bukan hasil pengukuran** — masuk daftar bersama di
+`api.md` bagian *Angka batasnya belum pernah diukur*, bukan keraguan terpisah yang menunggu sendiri
+(keputusan #98).
+
+---
+
+## 10. Retensi (keputusan D8)
+
+`webhook_deliveries` adalah tabel dengan pertumbuhan tercepat di produk: satu baris per lead × per
+endpoint × per percobaan.
+
+```sql
+DELETE FROM webhook_deliveries
+WHERE status IN ('succeeded', 'failed')
+  AND created_at < now() - ($1 || ' days')::interval;
+```
+
+Dijalankan **malas, tanpa scheduler**, di-throttle 1×/jam dari dalam putaran worker — pola persis
+retensi `idempotency_key` (#47). Baris `pending`/`delivering` tidak pernah dihapus berapa pun umurnya.
+
+Aturan #18 (*"Activity & audit log tidak pernah dihapus"*) **tidak** berlaku di sini: riwayat pengiriman
+adalah alat diagnosis, bukan catatan audit. Yang bersifat audit — endpoint dibuat/dihapus — tetap masuk
+`audit_log` seperti biasa dan tidak pernah dihapus.
+
+> **Poin terbuka yang diwarisi sadar:** pola retensi malas ini belum pernah diuji di volume produksi
+> (`docs/issues/047-public-lead-api.md`). Kalau polanya bermasalah, ia bermasalah di dua tempat
+> sekarang. Dicatat, bukan didiamkan.
+
+---
+
+## 11. Paket baru
+
+```
+crm_be/internal/webhook/
+    entity.go               Endpoint, Delivery, generateSecret(), backoff()
+    port.go                 Repository, DeliveryRepository, Repos, Store
+    usecase.go              CRUD endpoint + Enqueue + Retry
+    repository_postgres.go  ClaimDue (tanpa tenant.Context — §1.2), Reap, Purge
+    handler_http.go         7 endpoint
+    worker.go               loop, klaim, kirim, catat hasil
+    signature.go            Sign(secret, ts, body)
+
+crm_be/internal/shared/safedial/
+    safedial.go             daftar tolak IP + DialContext yang mem-pin IP tervalidasi
+
+crm_be/cmd/api/webhook_store.go   newWebhookStore(pool) webhook.Store
+```
+
+`safedial` dipisah dari `internal/webhook` karena ia **bukan** logika domain webhook — ia primitif
+jaringan yang akan dipakai lagi oleh inbound webhook (Phase 7.5) dan setiap panggilan keluar
+berikutnya. Satu-satunya paket `shared/` baru di phase ini.
+
+`crm_dashboard/src/lib/webhooks.ts` dan `webhook-permissions.ts`, mengikuti `forms.ts`/
+`form-permissions.ts`.
+
+---
+
+## 12. Rencana test
+
+| Berkas | Menguji |
+|---|---|
+| `internal/shared/safedial/safedial_test.go` | **Tabel atas seluruh rentang §3.1** — tiap CIDR ditolak, alamat publik lolos. IPv4 **dan** IPv6. Ini test paling penting di phase ini |
+| `internal/webhook/signature_test.go` | Signature cocok terhadap vektor yang dihitung tangan; body diubah satu byte → tidak cocok; `t` diubah → tidak cocok (membuktikan timestamp benar-benar ditandatangani) |
+| `internal/webhook/entity_test.go` | Format `whsec_`, panjang, keacakan; `backoff(attempt)` menghasilkan jeda D5 persis |
+| `internal/webhook/usecase_unit_test.go` | CRUD; `Enqueue` menulis satu baris per endpoint aktif yang melanggan; endpoint nonaktif/tidak melanggan **tidak** dapat baris; retry menolak status non-`failed` |
+| `internal/webhook/repository_test.go` | Postgres asli: `ClaimDue` memakai index (`EXPLAIN`), `Reap` hanya menyentuh yang melewati ambang, `Purge` tidak pernah menghapus `pending` |
+| **`internal/webhook/worker_concurrency_test.go`** | **Kriteria #12 — konkurensi nyata**: N goroutine menjalankan `ClaimDue` bersamaan terhadap Postgres sungguhan → tiap baris diklaim **tepat sekali**. Pola yang sama seperti alokasi `lead_number` (#19) dan idempotency (#20) — bukan test berurutan yang hijau meski logikanya salah |
+| `internal/webhook/worker_test.go` | `2xx`→`succeeded`; `5xx`→dicoba ulang dengan `next_attempt_at` sesuai backoff; `4xx`→`failed` tanpa retry; `429`→dicoba ulang; `3xx`→`failed`; timeout→dicoba ulang. Terhadap `httptest.Server` sungguhan |
+| `internal/webhook/handler_test.go` | URL privat ditolak `400` saat disimpan; kirim ulang manual; riwayat berpaginasi |
+| `internal/lead/…` | `Create`/`UpdateStatus` memanggil `Enqueue` **di dalam** transaksi yang sama — dibuktikan lewat fake **dan** lewat rollback Postgres sungguhan (pola `repository_atomicity_test.go` #21): transaksi gagal → tidak ada baris pengiriman tersisa |
+| `internal/shared/authz/authz_test.go` | Lima `Action` baru masuk `allActions` **dan** tabel per-role. Jangan ulangi celah #46/#85 |
+| `cmd/api/tenant_isolation_test.go` | **Kasus baru**: `GET/PATCH/DELETE /v1/webhook-endpoints/:id` dan `GET …/deliveries` lintas org → `404`. **Tetap harus terbukti bisa gagal** |
+| `crm_dashboard/src/lib/webhook-permissions.test.ts` | Gerbang role |
+
+### Verifikasi manual wajib
+
+Kriteria #1 hanya bisa dibuktikan dengan **server penerima sungguhan** yang mencatat apa yang diterima —
+bukan dengan membaca log pengirim. Prosedurnya masuk `docs/testing/flow/` sebagai berkas baru saat issue
+penutup, termasuk **verifikasi signature dari sisi penerima** dengan secret yang benar-benar disalin
+dari dialog.
+
+---
+
+## 13. Risiko teknis
+
+| Risiko | Penanganan |
+|---|---|
+| **SSRF** — pelanggan mengendalikan tujuan panggilan server kita | §3, tiga lapis: daftar tolak, validasi dua kali atas IP hasil resolusi, redirect ditolak total. Diuji sebagai tabel atas seluruh rentang, bukan beberapa contoh |
+| **DNS rebinding / TOCTOU** | Resolusi **sekali**, koneksi ke IP hasil resolusi itu lewat `DialContext` kustom (§3.2) — bukan validasi hostname lalu menyerahkan hostname ke `http.Client` |
+| **Pengiriman ganda antar-instance** | `FOR UPDATE SKIP LOCKED` (§4.1) + test konkurensi nyata (§12). Bukan leader election, bukan kunci aplikasi |
+| **Baris `delivering` menggantung setelah crash** | Reaper berambang waktu (§4.2). Konsekuensinya `at-least-once` — diakui terbuka dan didokumentasikan ke penerima lewat `delivery_id` yang stabil |
+| **Endpoint lambat menahan worker** | `WEBHOOK_DELIVERY_TIMEOUT` 10 detik, batch terbatas. Satu endpoint lambat memperlambat batch-nya, tidak menghentikan antrian |
+| **Secret bocor lewat log** | Aturan #26. Secret tidak pernah masuk log, termasuk pada jalur gagal — diuji dengan mencari string secret di keluaran, bukan dipercaya dari baca kode (pola `TURNSTILE_SECRET_KEY` #87) |
+| **`webhook_deliveries` tumbuh tak terkendali** | Retensi §10. Dicatat sebagai tabel dengan pertumbuhan tercepat di produk |
+| **Worker menyulitkan graceful shutdown** | Worker berhenti pada sinyal yang sama dengan HTTP server (#1); pengiriman yang sedang berjalan diberi waktu selesai, sisanya ditinggal `delivering` dan diambil reaper setelah restart |
+
+---
+
+## 14. Yang harus disiapkan pemilik produk
+
+**Tidak ada pihak ketiga** — berbeda dari Phase 6 (Turnstile) dan Phase 5 (Firebase). Yang dibutuhkan
+untuk verifikasi manual hanyalah satu URL penerima, dan itu bisa berupa server lokal sederhana
+(`WEBHOOK_ALLOW_PRIVATE_TARGETS=true` saat pengembangan) atau layanan penampung publik gratis.
+
+**Tidak memblokir issue manapun.**
+
+---
+
+## 15. Yang berubah pada dokumentasi
+
+| Berkas | Perubahan |
+|---|---|
+| `architecture/api.md` | Dua error code baru (§7); bab *Webhook Keluar* — bentuk payload, signature, cara verifikasi, kebijakan retry. Angka retry masuk daftar *Angka batasnya belum pernah diukur* yang sudah ada |
+| `architecture/authentication.md` | Baris **keempat** tabel kredensial — dan yang pertama dengan arah kepercayaan terbalik (kita membuktikan diri ke pihak lain) |
+| `architecture/authorization.md` | Matriks Phase 7 (`webhook.*`) |
+| `architecture/multi-tenancy.md` | Pengecualian jenis **baru**: index yang sengaja tidak berawalan `organization_id` (§1.2) — bukan ditambahkan ke daftar pengecualian unik yang sudah ada empat |
+| `docs/testing/flow/` | Berkas baru: mendaftarkan endpoint, menerima pengiriman sungguhan, memverifikasi signature dari sisi penerima |
+| `STATUS.md` | Baris Selesai; Phase 7 di *Progress per Phase* |
+
+`freeze.md` **tidak disentuh.** Penyimpangan D1 dari ketentuan #4 dicatat di `prd.md` sebagai keputusan
+phase beserta kewajiban evaluasi ulangnya — bukan diselipkan seolah freeze memang mengizinkannya
+(Aturan #30).
+
+---
+
+## 16. Kewajiban yang diteruskan ke phase berikutnya
+
+- **Phase 7.5 (Inbound webhook)**: kredensial **kelima**; jangan disatukan dengan `whsec_`. Bentuk
+  payload sudah diputuskan **tetap, sama seperti API Phase 4** (`prd.md` *Di luar cakupan*).
+  `safedial` sudah ada dan dipakai ulang.
+- **Phase 8 (Subscription)**: kartu Webhook di `/connect` berhenti berbunyi "belum tersedia" di phase
+  ini. Keadaan "terkunci oleh paket" lahir di Phase 8, bukan sekarang (ADR-012 §4).
+- **Saat konsumen async kedua lahir**: evaluasi ulang tabel `jobs` generik dengan dua implementasi
+  nyata di tangan (`prd.md` D1).
+- **Saat ada traffic produksi**: angka retry, interval, dan batch ikut peninjauan bersama angka rate
+  limit di `api.md`.


### PR DESCRIPTION
Refs #100 · #101 · #102 · #103 · #104

Membuka **Phase 7 — Outbound Webhook**: PRD, TD, dan pemecahan issue. **Tidak ada kode.**

## Pemecahan: Phase 7 = outbound saja

Inbound webhook jadi **Phase 7.5**. Alasannya bukan ukuran, tapi **profil risiko**: inbound adalah
pengulangan bentuk Phase 6 (kredensial publik, satu endpoint, signature menggantikan honeypot),
sementara outbound kelas yang sama sekali berbeda (antrian, worker, SSRF). Satu PRD untuk keduanya
berarti dua profil risiko tak berhubungan dalam satu dokumen. Preseden phase pecahan sudah ada (4.5,
4.6).

Bentuk payload inbound **sudah diputuskan di muka**: tetap, sama seperti API Phase 4.

## Dua keputusan besar, diambil di muka

**D1 — tidak ada tabel `jobs` generik.** `webhook_deliveries` **adalah** antriannya. Ini **penyimpangan
tertulis dari `freeze.md` bagian 5 ketentuan #4**, dicatat penuh di `prd.md` beserta kewajiban evaluasi
ulangnya. Alasannya: outbound webhook satu-satunya konsumen async di seluruh produk (email dan push
keduanya fire-and-forget), dan tabel generik untuk satu konsumen melanggar Aturan #28 telak. Bentuk
generik juga justru kehilangan sesuatu — riwayat pengiriman yang kriteria #10 wajibkan tampil di
dashboard hanya bisa dibaca dengan menggali `payload jsonb`, bukan di-query.

**D2 — worker goroutine di binary `api` yang sama**, klaim lewat `FOR UPDATE SKIP LOCKED`. Tanpa
broker, tanpa deployable baru, **tanpa leader election** — Postgres yang menjamin dua instance tidak
mengirim ganda. Batasan CLAUDE.md (monolith, tanpa broker, biaya per tenant rendah) mengikat langsung
ke sini.

## SSRF — risiko terbesar phase ini

Phase pertama di mana **kita yang memanggil**, bukan yang dipanggil. Pelanggan memberi URL, server kita
meneleponnya. Pertahanannya tiga lapis dan lahir di **issue pertama**, bersama tempat pertama yang
membutuhkannya — URL tidak boleh pernah tersimpan tanpa divalidasi:

- Daftar tolak lengkap (loopback, privat, **link-local `169.254.169.254`**, CGNAT, IPv6)
- Validasi **dua kali** — saat disimpan dan saat dikirim — terhadap **IP hasil resolusi**, bukan
  hostname. Resolusi sekali, dial IP itu (`DialContext` kustom), supaya DNS rebinding dan TOCTOU
  tertutup
- **Redirect tidak pernah diikuti** — jalur bypass paling langsung, dihapus sepenuhnya (Aturan #27)

## Lima issue

| # | Judul |
|---|---|
| #100 | Migration `0008`, `safedial`, domain `webhook`, CRUD endpoint |
| #101 | Signature HMAC + enqueue: pemicu dari `lead` |
| #102 | **Worker**: klaim, kirim, retry, reaper, retensi |
| #103 | Dashboard `/connect/webhook` |
| #104 | Dokumentasi verifikasi + penutup phase |

Berurutan penuh — tidak ada yang paralel. **#102 berdiri sendiri** karena ia infrastruktur async
pertama di produk, dan tiga dari lima hal di dalamnya hanya gagal di bawah konkurensi atau setelah
crash — keadaan yang tidak pernah terlihat di test berurutan.

## Hal lain

- `issues.md` memuat langkah **"cek `docs/issues/*`" sejak phase dibuka**, bukan retroaktif — celah
  yang #98 temukan di Phase 5 dan 6.
- **Tidak ada pihak ketiga.** Berbeda dari Phase 5 (Firebase) dan 6 (Turnstile) — tidak ada issue yang
  terblokir menunggu akun siapa pun.
- Pengecualian tertulis atas **Aturan #16**: index klaim worker sengaja tidak berawalan
  `organization_id` — organization adalah hasil klaim, bukan input. Jenis pengecualian baru, masuk
  `multi-tenancy.md` di #104.
- Koreksi `069`: cacat 409 mobile digabung ke sesi verifikasi HP Android sesuai keputusanmu, bukan
  issue terpisah sekarang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014szPSUU6DhnG6hRvmEGfKQ
