### PR TITLE
Buka Phase 8 — Subscription: PRD, TD, issues (#112–#115)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -3,8 +3,8 @@
 > **Ledger state project.** Dibaca di **awal setiap session**, diperbarui di **akhir setiap session**.
 > Ini satu-satunya jawaban atas pertanyaan *"sekarang sudah sampai mana?"* — jangan merekonstruksinya dari kode.
 
-**Last updated:** 3 September 2026 — **Issue #104 selesai — Phase 7 tutup** (halaman verifikasi `/connect/webhook/docs`, ADR-013, dokumen arsitektur, `docs/testing/flow/09-webhook.md`, review 14 AC PRD). **Verifikasi manual `09-webhook.md` dijalankan** (sesi browser, pasca-merge #110): AC #1/#2/#6/#9/#10/#11 + gerbang role terkonfirmasi dari sisi penerima sungguhan; §9.8 SSRF dilewati (butuh env flip) — dikunci `denylist_test.go` + #100. Follow-up PR [#111](https://github.com/Pravasta/jualin-crm/pull/111) memperbaiki kontradiksi env di `09-webhook.md` §9.8. Sebelumnya: **#103**, **#102**, **#101**, **#100**.
-**Phase sekarang:** Belum ada — Phase 7 selesai. Berikutnya **Phase 7.5 (Inbound Webhook)** atau **Phase 8 (Subscription)**, sesuai keputusan pemilik produk. Phase 6 GATE freeze **dilewati secara sadar** (lihat *Berikutnya*).
+**Last updated:** 3 September 2026 — **Phase 8 — Subscription dibuka** (PRD/TD/issues, #112–#115): gerbang paket, **mekanismenya bukan angkanya** (ADR-012 §4); tanpa `usage_counters`, tanpa tabel `plans`, tanpa migration. **Phase 7.5 ditunda** atas keputusan pemilik produk. Sebelumnya: **Issue #104 selesai — Phase 7 tutup** (halaman verifikasi `/connect/webhook/docs`, ADR-013, dokumen arsitektur, `docs/testing/flow/09-webhook.md`, review 14 AC PRD). **Verifikasi manual `09-webhook.md` dijalankan** (sesi browser, pasca-merge #110): AC #1/#2/#6/#9/#10/#11 + gerbang role terkonfirmasi dari sisi penerima sungguhan; §9.8 SSRF dilewati (butuh env flip) — dikunci `denylist_test.go` + #100. Follow-up PR [#111](https://github.com/Pravasta/jualin-crm/pull/111) memperbaiki kontradiksi env di `09-webhook.md` §9.8. Sebelumnya: **#103**, **#102**, **#101**, **#100**.
+**Phase sekarang:** **Phase 8 — Subscription** ([#112–#115](https://github.com/Pravasta/jualin-crm/milestone/11)), baru dibuka. **Mekanismenya, bukan angkanya** — tidak ada harga/limit/`usage_counters` (ADR-012 §4). Phase 7.5 (Inbound Webhook) **ditunda**, konsep dicari dulu. GATE freeze (3–5 pengguna nyata) **masih dilewati secara sadar** (lihat *Berikutnya*).
 
 ---
 
@@ -71,26 +71,17 @@
 
 ## Sedang Dikerjakan
 
-**Tidak ada.** Phase 7 (Outbound Webhook, #100–#104) selesai. Langkah berikutnya adalah keputusan
-pemilik produk: buka **Phase 7.5 (Inbound Webhook)** atau **Phase 8 (Subscription)** — belum ada
-PRD/TD/issue untuk keduanya.
+**Phase 8 — Subscription** ([#112–#115](https://github.com/Pravasta/jualin-crm/milestone/11)) — **baru
+dibuka**, belum ada issue yang dikerjakan. Dokumen: `docs/phases/08-subscription/`.
 
-**Verifikasi manual `09-webhook.md` sudah dijalankan** (sesi browser, 3 Sep 2026, pasca-merge #110):
-endpoint didaftarkan dari dashboard → lead → **request sungguhan sampai ke `receiver.py` lokal yang
-memverifikasi signature dengan skema terdokumentasi** (`[OK] signature_valid=True`, HTTP 200); contoh
-Python di `/connect/webhook/docs` = konstruksi `receiver.py` persis; `lead.status_changed` dengan
-`changes` benar dan snapshot `lead.created` tetap beku; gagal→retry→**Kirim ulang** memulihkan baris
-yang sama; gerbang role Manager nol panggilan API. §9.8 (SSRF saat disimpan) **dilewati** — butuh
-`WEBHOOK_ALLOW_PRIVATE_TARGETS=false` yang mematikan receiver lokal; dikunci
-`internal/shared/safedial/denylist_test.go` (~35 alamat) + `curl` #100. Detail: `notes.md` `## #104`
-bagian *Verifikasi manual dijalankan*.
+**Phase 7.5 (Inbound Webhook) ditunda** — keputusan pemilik produk 3 September 2026: konsepnya masih
+dicari lebih dulu. Analisis awal yang sudah dilakukan (kasus WordPress: plugin form yang sudah ada,
+hanya bisa diberi satu URL) tercatat di *Berikutnya* di bawah supaya tidak hilang.
 
-**Dipecah secara sadar**: Phase 7 hanya **outbound**. Inbound webhook jadi **Phase 7.5** — ia
-pengulangan bentuk Phase 6 (kredensial publik, satu endpoint, signature menggantikan honeypot),
-sementara outbound kelas yang sama sekali berbeda (antrian, worker, SSRF). Bentuk payload inbound
-sudah diputuskan di muka: **tetap, sama seperti API Phase 4**. Kredensial verifikasi inbound = **kelima**,
-di-hash (Aturan #20 apa adanya) — [ADR-013](./decisions/ADR-013-signing-secret-storage.md) hanya
-mengecualikan `whsec_` outbound.
+**Apa yang Phase 8 tidak akan selesaikan** — dibaca sebelum mengharapkan sebaliknya: setelah #115
+merge, produk punya gerbang paket yang bekerja dan **nol paket berbayar untuk digerbangi**. Kartu
+terkunci tidak akan muncul di layar siapa pun sampai peta `planChannels` diisi paket kedua, dan itu
+menunggu **data pengguna nyata** (ADR-012 §4) — bukan menunggu kode. Detail di *Berikutnya*.
 
 **Verifikasi anti-spam sungguhan (Turnstile) masih tertunda** — seluruh Phase 6 dibangun & diverifikasi
 dengan `CAPTCHA_PROVIDER=none` (akun Cloudflare belum diurus, lihat *Punya Lead Time* di bawah).
@@ -127,6 +118,64 @@ daftar itu, bukan memulai keraguan terpisah.
 > **Kenapa bagian ini ada.** Pointer seperti ini tidak pernah dipasang untuk Phase 5 dan Phase 6,
 > sehingga enam berkas di atas tidak pernah dibaca saat phase-nya ditutup (#98). Templat issue kini
 > mewajibkannya.
+
+### Phase 8 — Subscription — baru dibuka (#112–#115)
+
+**Batas paket menjadi nyata — mekanismenya, bukan angkanya.** `subscriptions` ada sejak `0002`
+(Phase 1, amandemen S1) dan **belum pernah dibaca satu query pun**; Phase 8 melahirkan pembaca
+pertamanya, lalu menegakkan gerbangnya di usecase (ADR-012 §3). Dokumen:
+`docs/phases/08-subscription/`.
+
+**Yang sengaja TIDAK dikerjakan, dan kenapa:**
+
+- **Tidak ada harga, limit free tier, atau peta kanal-per-paket yang mengunci sesuatu.** ADR-012 §4
+  mengikat angka-angka itu ke *"setelah gate freeze (3–5 pengguna nyata) memberi data yang membuat
+  angka itu bisa dipilih dengan jujur"*. Yang ADR-012 nyatakan bisa dikerjakan sekarang adalah
+  kalimatnya sendiri: **"ADR ini menetapkan mekanismenya, bukan angkanya."**
+- **Tidak ada `usage_counters`** (keputusan D1) — penyimpangan tertulis dari `freeze.md` 8.4, bentuk
+  yang sama dengan D1 Phase 7 yang menolak tabel `jobs`: kuota adalah *"berapa banyak"*, dan tidak ada
+  satu pun angka untuk ditegakkan. Penghitung tanpa pembanding hanya menulis baris.
+- **Tidak ada tabel `plans`** (keputusan D2) — ADR-012 §4 sudah memutuskannya; `plan_code` sebagai
+  `text` masih cukup untuk satu paket (Aturan #28).
+- **Tidak ada migration sama sekali** — phase kedua tanpa migration setelah Phase 3. Kolomnya sudah ada
+  sejak `0002`; amandemen S1 menyebut biayanya "mendekati nol", dan phase ini yang menagih hasilnya.
+
+**Konsekuensi yang harus dibaca jujur:** setelah #115 merge, produk punya gerbang paket yang bekerja
+dan **nol paket berbayar untuk digerbangi**. Kartu terkunci tidak akan muncul di layar siapa pun
+sampai `planChannels` diisi paket kedua — dan itu menunggu data pengguna nyata, bukan menunggu kode.
+
+**Tidak ada pihak ketiga, tidak ada angka yang harus diputuskan lebih dulu, tidak ada issue yang
+terblokir.**
+
+---
+
+### Phase 7.5 — Inbound Webhook — ditunda, konsep dicari dulu
+
+Keputusan pemilik produk **3 September 2026**: 7.5 tidak dibuka sekarang; konsepnya dicari lebih dulu.
+Analisis awal yang sudah dilakukan dicatat di sini supaya tidak diulang dari nol:
+
+- **Kasus penggunanya = WordPress.** Pemilik toko punya form yang **sudah ada** (Contact Form 7 /
+  WPForms / Gravity / Fluent) yang tidak mau ia ganti dengan snippet embed Phase 6. Yang ia mau: form
+  itu tetap dipakai, submission-nya **juga** masuk ke Jualin. Plugin webhook WP-nya sering hanya
+  menyediakan **satu kolom URL**, tanpa custom header.
+- **Konsekuensinya**: kredensial harus muat di **path** (bentuk `pk_`), bukan `Authorization` — dan
+  **signature tidak bisa jadi penjaga utama**, karena pengirim yang hanya bisa diberi URL tidak bisa
+  menandatangani apa pun. Itu **bertentangan** dengan `07/prd.md` yang menulis *"verifikasi signature
+  menggantikan honeypot"*; pertentangan ini harus dihadapi terbuka di PRD 7.5, bukan didiamkan.
+- **Endpoint-nya hampir persis `POST /v1/forms/{public_key}/submit` yang sudah ada** — kredensial di
+  path, terima `x-www-form-urlencoded`, field tak dikenal ke `raw_payload`, rate limit + cap body.
+  Yang membuat plugin WP **gagal** kalau diarahkan ke sana hari ini hanya tiga: **Origin allowlist**,
+  **honeypot**, dan **time-trap token** — ketiganya pertahanan khusus-browser. Jadi 7.5 ≈ endpoint itu
+  tanpa ketiganya, **dengan penggantinya** — dan apa penggantinya adalah pertanyaan yang belum dijawab.
+- `leads.source` sudah menerima `'webhook'` sejak `0003`, menunggu phase ini.
+
+> **Satu klaim di dokumen Phase 7 yang perlu dikoreksi saat 7.5 dibuka** (Aturan #30 — dilaporkan,
+> bukan diam-diam diubah): `07/td.md` §11 dan §16 menulis *"`safedial` … akan dipakai lagi oleh inbound
+> webhook (Phase 7.5)"*. Itu kemungkinan besar keliru — `safedial` adalah pertahanan untuk panggilan
+> **keluar** (resolve DNS + dial IP tervalidasi). Inbound **menerima** request; ia tidak men-dial ke
+> mana pun. TD 7.5 harus menyatakan ini, bukan mewarisi asumsinya.
+
+---
 
 ### Phase 7 — Outbound Webhook — ✅ SELESAI (#100–#104)
 
@@ -300,10 +349,10 @@ Tidak ada yang memblokir. Semuanya diputuskan saat fitur terkait dikerjakan.
 | — | Email provider (Resend / Postmark / SES) | **Tidak lagi memblokir** sejak Phase 4.6 — transport SMTP, ganti provider = ganti env |
 | — | Domain final & branding | Phase 1 — ⏳ *lead time, lihat bawah* |
 | — | Hosting & managed PostgreSQL | Phase 0 akhir |
-| — | Retensi data free tier | Phase 8 |
+| — | Retensi data free tier | Phase 8 — **tetap terbuka**; Phase 8 sengaja hanya membangun mekanismenya (ADR-012 §4) |
 | — | Push provider detail | **Ditutup #68** — FCM HTTP v1 API langsung, tanpa Firebase Admin SDK |
-| — | Pricing final & limit free tier | Phase 8 |
-| — | Kontrak integrasi payment service | Sebelum Phase 8 |
+| — | Pricing final & limit free tier | Phase 8 — **tetap terbuka setelah Phase 8 dibuka.** ADR-012 §4 mengikatnya ke gate freeze (3–5 pengguna nyata), bukan ke phase-nya. Phase 8 membangun tempat yang menunggunya: satu peta `planChannels` yang tinggal diisi |
+| — | Kontrak integrasi payment service | `freeze.md` menulis "sebelum Phase 8" — **belum ada, dan Phase 8 berjalan tanpanya secara sadar**: keputusan D6 menghentikan kartu terkunci tepat di batas yang membutuhkannya (tanpa tombol upgrade, tanpa harga). Yang tidak boleh terjadi adalah menebak bentuk kontraknya lalu membangun ke arah tebakan itu |
 
 Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 dan `docs/brainstorming/architecture_product_review.md` bagian 12.
 
@@ -375,6 +424,7 @@ Rekomendasi untuk masing-masing ada di `docs/architecture/freeze.md` bagian 7 da
 | 5 | Employee Mobile | ✅ | ✅ | ✅ #68–#73 | ✅ |
 | 6 | Connect & Embedded Form | ✅ | ✅ | ✅ #85–#89 | ✅ |
 | 7 | Outbound Webhook | ✅ | ✅ | ✅ #100–#104 | ✅ |
-| 7.5 | Inbound Webhook | ⬜ | ⬜ | ⬜ | ⬜ |
+| 7.5 | Inbound Webhook | ⬜ | ⬜ | ⬜ | ⬜ — **ditunda**, konsep dicari dulu (3 Sep 2026) |
+| 8 | Subscription | ✅ | ✅ | ✅ #112–#115 | ⬜ |
 
 Pekerjaan yang sedang berjalan: `gh issue list --state open`

--- a/docs/phases/08-subscription/issues.md
+++ b/docs/phases/08-subscription/issues.md
@@ -1,0 +1,112 @@
+# Phase 8 — Subscription · Issues
+
+> Indeks. **Tanpa kolom status** — status hidup di [GitHub Issues](https://github.com/Pravasta/jualin-crm/milestone/11) (ADR-008).
+> Apa & kenapa di [`prd.md`](./prd.md) · bagaimana di [`td.md`](./td.md).
+
+**Milestone:** [Phase 8 — Subscription](https://github.com/Pravasta/jualin-crm/milestone/11)
+
+---
+
+## Daftar
+
+| # | Judul | Aplikasi | Cakupan | TD |
+|---|---|---|---|---|
+| [112](https://github.com/Pravasta/jualin-crm/issues/112) | Domain `subscription` penuh: peta kanal + `plan` di `GET /v1/me` | `crm_be` | `plan.go` (peta, jantung phase), `port.go`, `usecase.go`, `FindActiveByOrg`, `auth.PlanResolver` | §1, §2, §4, §6 |
+| [113](https://github.com/Pravasta/jualin-crm/issues/113) | Gerbang paket di usecase: tiga kanal + `plan_upgrade_required` | `crm_be` | `PlanGate` per konsumen, bridge di composition root, urutan role→paket, error code baru | §3, §5, §11 |
+| [114](https://github.com/Pravasta/jualin-crm/issues/114) | Dashboard: keadaan "terkunci oleh paket" di Connect | `crm_dashboard` | Tiga keadaan kartu, `plan` di sesi, `lib/plan.ts`, penanganan `403` balapan | §8, §4 |
+| [115](https://github.com/Pravasta/jualin-crm/issues/115) | Dokumentasi + penutup Phase 8 | `crm_be` + docs | `api.md`, `authorization.md`, `testing/flow/`, review 10 AC. **Penutup phase** | §12, §15 |
+
+---
+
+## Urutan
+
+```
+#112 ──► #113 ──► #114 ──► #115
+```
+
+Berurutan penuh — tidak ada yang bisa paralel, sama seperti Phase 7 dan berbeda dari Phase 6 (#85 ‖ #86).
+
+| Dependensi | Sifat |
+|---|---|
+| #113 → #112 | **Keras.** Tidak ada yang bisa digerbangi sebelum ada peta yang menjawab "boleh atau tidak". |
+| #114 → #112 | **Keras.** Kartu terkunci merender `plan.channels` yang lahir di #112. |
+| #114 → #113 | **Keras dalam praktik.** Kartu terkunci tanpa gerbang server hanyalah UI yang berbohong — persis yang ADR-012 §3 tolak. Menggabungkan keduanya sebagai "terlihat sekaligus ditegakkan" adalah satu-satunya urutan yang jujur. |
+| #115 → semuanya | **Keras.** Prosedur verifikasi hanya bisa ditulis setelah gerbangnya benar-benar menolak sesuatu. |
+
+**#112 dan #113 sengaja dipisah** meski keduanya murni Go dan tidak besar. Alasannya sama seperti
+`apikey` #46/#47, `form` #85/#87, dan `webhook` #100/#101: satu issue membangun **kapabilitasnya**,
+issue berikutnya membangun **yang memakainya**. Menggabungkannya menghasilkan PR yang mencampur dua
+kelas review — *"apakah petanya benar"* dan *"apakah gerbangnya dipasang di tempat yang tepat"*.
+
+---
+
+## Batas per issue
+
+| Issue | Setelah selesai, yang **belum** ada |
+|---|---|
+| #112 | `RequireChannel` ada dan diuji penuh, tapi **nol pemanggil** — tidak satu pun endpoint menolak apa pun. Preseden `apikey.FindByKeyID` (#46), `form.FindByPublicKey` (#85), `webhook.ClaimDue` (#100) |
+| #113 | Gerbang menolak sungguhan lewat `curl`, tapi **tidak terlihat pengguna** — kartu Connect masih ketiganya aktif |
+| #114 | Owner melihat dan merasakan batas paket, tapi **belum ada prosedur verifikasi tertulis** dan dokumen arsitektur belum menyebut gerbangnya |
+| #115 | Phase 8 tutup. Harga, limit, `usage_counters`, dan payment service **belum disentuh** — dan memang tidak boleh |
+
+Yang di luar batas ini ada di [`prd.md`](./prd.md) bagian *Di luar cakupan*, dan bersifat mengikat.
+
+---
+
+## Kenapa empat issue, dan kenapa tidak ada yang lebih besar
+
+Phase ini **kecil secara sengaja**. Tidak ada migration (TD §1), tidak ada tabel baru, tidak ada env
+var, tidak ada pihak ketiga, dan tidak ada satu pun angka. Yang dibangun hanyalah: satu peta, satu
+pembaca, tiga titik pasang, dan satu keadaan UI.
+
+Ukuran itu **hasil dari keputusan D1 dan D2**, bukan kebetulan. `freeze.md` 8.4 membayangkan Phase 8
+sebagai `plans` + `subscriptions` + `usage_counters` + penegakan limit; phase ini menolak dua dari
+empat karena angkanya belum ada. Kalau `usage_counters` ikut, phase ini akan punya migration, jalur
+tulis di banyak usecase, dan dashboard pemakaian — untuk kuota yang belum satu pun ditetapkan.
+
+**#113 yang paling perlu perhatian saat review**, dan bukan karena ia besar. Dua hal di dalamnya gagal
+secara **senyap**:
+
+1. **Urutan `authz` → `plan` terbalik** membocorkan keadaan paket organization kepada role yang tidak
+   berhak mengelola kanalnya. Tidak ada error, tidak ada test yang gagal secara alami — hanya kode
+   `403` yang salah isinya. Karena itu urutannya diuji dengan fake yang menolak **keduanya sekaligus**.
+2. **Gerbang gagal terbuka.** `plan_code` adalah `text` tanpa `CHECK`, dan nilainya bisa datang dari
+   luar CRM. Peta yang mengembalikan "boleh" untuk paket tak dikenal akan terlihat benar di setiap
+   test yang memakai `free`.
+
+---
+
+## Setelah keempatnya selesai
+
+Phase 8 tutup bila **10 acceptance criteria** di [`prd.md`](./prd.md) terpenuhi — terutama #3 (penolakan
+dibuktikan lewat `curl`, bukan UI), #4 (gerbang terbukti bisa gagal), #8 (gagal tertutup), dan #9
+(tidak ada satu pun angka). Lalu:
+
+0. **Cek `docs/issues/*` milik Phase 8** — checklist deviasi/keputusan dari #112–#115 yang perlu
+   ditinjau ulang sebelum phase benar-benar ditutup. Tiap poin terbuka **diputuskan atau dinyatakan
+   ulang dengan pemicu eksplisit**, bukan dilewati.
+
+   > Langkah ini ada di sini sejak phase dibuka — bukan retroaktif. Phase 5 dan Phase 6 melewatkannya
+   > karena tidak pernah memuatnya, dan enam berkas menumpuk tanpa dibaca (#98). Preseden yang bekerja:
+   > [`04-public-api/issues.md`](../04-public-api/issues.md) dan
+   > [`07-outbound-webhook/issues.md`](../07-outbound-webhook/issues.md) langkah 0.
+
+1. `api.md` (bab *Gerbang Paket* + satu error code) dan `authorization.md` (dua pertanyaan berbeda)
+   diperbarui (TD §15)
+2. `docs/testing/flow/` bertambah bagian: balik satu entri peta → `403` lewat `curl` + kartu terkunci
+3. `docs/STATUS.md` — Phase 8 ✅, dan `Keputusan Belum Diambil` menyatakan pricing/limit/retensi
+   **tetap terbuka**
+4. Keputusan pemilik produk: **Phase 7.5 (Inbound Webhook)**, atau mengejar apa yang gate freeze
+   sebenarnya minta — pengguna nyata, yang butuh deployment/staging
+
+> **Tidak ada pihak ketiga di phase ini**, dan tidak ada angka yang harus diputuskan lebih dulu. Itu
+> justru bentuk yang dipilih (`prd.md`, *Kenapa mekanismenya dibangun sebelum angkanya*). **Tidak ada
+> issue yang terblokir menunggu apa pun.**
+
+> **Apa yang phase ini tidak selesaikan, dan jangan berpura-pura sebaliknya.** Setelah #115 merge,
+> produk punya gerbang paket yang bekerja dan **nol paket berbayar untuk digerbangi**. Kartu terkunci
+> tidak akan pernah muncul di layar siapa pun sampai `planChannels` diisi paket kedua — dan itu
+> menunggu data pengguna nyata (ADR-012 §4), bukan menunggu kode.
+
+> **Staging masih belum ada.** Phase 7 tidak mengubah itu, dan Phase 8 juga tidak. Gerbang yang
+> terbukti benar di laptop belum terbukti benar di tempat pelanggan memakainya.

--- a/docs/phases/08-subscription/notes.md
+++ b/docs/phases/08-subscription/notes.md
@@ -1,0 +1,9 @@
+# Phase 8 — Subscription · Implementation Notes
+
+> Realitas implementasi, satu bagian per issue. Penyimpangan dari TD/PRD beserta alasannya,
+> utang teknis, catatan untuk session berikutnya. Naratif lengkap — berbeda dari `docs/issues/11*`
+> yang hanya checklist penutupan phase.
+
+---
+
+*Belum ada issue yang dikerjakan. Bagian pertama ditambahkan saat #112 selesai.*

--- a/docs/phases/08-subscription/prd.md
+++ b/docs/phases/08-subscription/prd.md
@@ -1,0 +1,144 @@
+# Phase 8 — Subscription · PRD
+
+> **Apa & kenapa.** Detail teknis di [`td.md`](./td.md).
+> Sumber: [ADR-012](../../decisions/ADR-012-connect-surface-and-subscription-gating.md) §2–§4 (subscription sebagai gerbang kanal, dan apa yang sengaja **tidak** diputuskan di sana) · [`architecture/freeze.md`](../../architecture/freeze.md) bagian 8.4 (`plans`/`subscriptions`/`usage_counters`), amandemen **S1** (`subscriptions` minimal di Phase 1) · [`product/decisions.md`](../../product/decisions.md) §16 (Free Plan sejak registrasi), §24, §25 (pricing & limit sengaja ditunda) · TD Phase 4 §19 (`usage_counters` menghitung, `ratelimit` melindungi)
+
+---
+
+## Tujuan
+
+**Batas paket menjadi nyata — mekanismenya, bukan angkanya.**
+
+`subscriptions` sudah ada sejak `0002_identity.sql` (Phase 1, amandemen S1): setiap organization
+mendapat baris `plan_code = 'free'` sejak detik registrasi. Sejak itu **tidak ada satu pun query yang
+pernah membacanya kembali.** Kolomnya hidup; pembacanya tidak pernah lahir.
+
+Sementara itu Phase 4, 6, dan 7 membangun tiga kanal Connect — API key, Formulir, Webhook — dan ADR-012
+sudah memutuskan bahwa **subscription-lah yang menggerbangi ketiganya**. Kartu di `/connect` hari ini
+ketiganya aktif tanpa syarat, karena gerbangnya memang belum ada.
+
+Phase 8 menutup jarak itu: **`plan_code` mendapat pembaca pertamanya, dan gerbangnya ditegakkan di
+usecase.**
+
+> **Phase ini sengaja tidak menetapkan angka apa pun.** Tidak ada harga, tidak ada limit free tier,
+> tidak ada peta "kanal X hanya untuk paket Y" yang mengunci sesuatu hari ini. ADR-012 §4 mengikat
+> angka-angka itu ke *"setelah gate freeze (3–5 pengguna nyata) memberi data yang membuat angka itu
+> bisa dipilih dengan jujur"* — dan gate itu belum terlewati. Yang ADR-012 nyatakan bisa dikerjakan
+> sekarang adalah kalimatnya sendiri: ***"ADR ini menetapkan mekanismenya, bukan angkanya."***
+
+### Kenapa mekanismenya dibangun sebelum angkanya
+
+Bukan untuk mendahului keputusan produk, melainkan karena keduanya **berbeda jenis pekerjaan**:
+
+| | Mekanisme (phase ini) | Angka (menyusul) |
+|---|---|---|
+| Bentuk | Kode: pembaca `plan_code`, peta kapabilitas, gerbang di usecase, keadaan "terkunci" di UI | Data: satu peta diisi ulang |
+| Butuh pengguna nyata? | **Tidak** — bentuknya sudah ditetapkan ADR-012 | **Ya** — itu yang gate freeze minta |
+| Biaya menundanya | Tiga kanal terus bertambah tanpa tempat untuk digerbangi; makin lama makin banyak titik yang harus disisipi belakangan | Nol — mengisi peta yang sudah ada |
+| Biaya salah | Rendah, dan terlihat: gerbang yang salah menolak akan langsung ketahuan | **Tinggi, dan tidak terlihat**: angka tebakan bertahan karena terlanjur tertulis (ADR-012 menamai risiko ini sendiri) |
+
+---
+
+## Kebutuhan
+
+| # | Sebagai… | Saya butuh… | Supaya… |
+|---|---|---|---|
+| 1 | Pemilik sistem | Kanal yang tidak termasuk paket sebuah organization **ditolak di server**, bukan sekadar disembunyikan tombolnya | Menyembunyikan kartu adalah kenyamanan; siapa pun yang bisa memanggil `curl` bisa melewatinya. ADR-012 §3 menyatakan ini eksplisit |
+| 2 | Owner | **Melihat** kanal yang belum saya punya, bukan tidak tahu ia ada | Pelanggan yang tidak pernah melihat bahwa Webhook ada tidak akan pernah meng-upgrade untuk mendapatkannya (ADR-012, *Alasan*) |
+| 3 | Owner | Tahu paket apa yang sedang saya pakai | Hari ini tidak ada satu pun layar yang bisa menjawabnya — `plan_code` tidak pernah keluar dari database |
+| 4 | Pemilik sistem | Peta "paket apa membuka kanal apa" hidup di **satu tempat** | Peta yang tersebar akan menyimpang; dan bila dashboard menyalinnya ke TypeScript, ada dua sumber kebenaran untuk satu keputusan (kesalahan yang #33 harus koreksi pada `lib/lead-status.ts`) |
+| 5 | Pemilik sistem | Membuka atau menutup satu kanal untuk satu paket **tanpa menyentuh usecase manapun** | Kalau mengubah paket berarti menyunting `apikey`, `form`, dan `webhook` satu per satu, angka yang menyusul akan mahal untuk dipasang |
+| 6 | Pemilik produk | CRM ini **tidak pernah** tahu tentang uang | Batas ADR-012 §2 — harga, checkout, kartu, invoice, refund seluruhnya di payment service. CRM menyimpan `external_reference` dan membaca `plan_code`; tidak menghitung apa pun tentang uang |
+
+---
+
+## Acceptance Criteria
+
+Phase 8 selesai bila **semuanya** terpenuhi:
+
+| # | Kriteria |
+|---|---|
+| 1 | `plan_code` punya **pembaca nyata** — `GET /v1/me` mengembalikan paket aktif organization beserta kanal yang dibukanya |
+| 2 | Peta paket → kapabilitas ada di **satu tempat**, dan menambah/mengurangi satu kanal untuk satu paket adalah perubahan **satu baris** di peta itu — bukan perubahan di usecase manapun |
+| 3 | `POST /v1/api-keys`, `POST /v1/forms`, dan `POST /v1/webhook-endpoints` menolak dengan **`403 plan_upgrade_required`** bila paket organization tidak membuka kanal itu — **dibuktikan lewat `curl`**, bukan hanya lewat UI yang menyembunyikan tombol |
+| 4 | Gerbang itu **terbukti bisa gagal**: membalik satu entri peta jadi `false` membuat endpoint yang tadinya `201` menjadi `403`, dan kartu Connect-nya menjadi terkunci — dibuktikan dengan menjalankannya, lalu dikembalikan |
+| 5 | Kartu Connect punya keadaan **"terkunci oleh paket"** yang nyata dan **terlihat** — bukan disembunyikan, dan bukan lagi teks *"belum tersedia"* yang berbohong tentang alasannya |
+| 6 | Dashboard **tidak memuat peta paket→kanal versinya sendiri** — ia merender apa yang backend kirim. Ditegakkan dengan tidak pernah mengirim `plan_code` mentah sebagai dasar keputusan UI |
+| 7 | Layar Connect menangani `403 plan_upgrade_required` yang datang dari balapan (paket berubah antara render dan klik) tanpa menjadi tombol yang diam |
+| 8 | Organization yang paketnya tidak dikenal peta **ditolak**, bukan diizinkan — gerbang gagal tertutup, bukan gagal terbuka |
+| 9 | Tidak ada satu pun angka harga, limit, atau kuota di dalam kode maupun dokumen phase ini |
+| 10 | `go test -race ./...` dan `npm run typecheck && lint && test && build` bersih |
+
+---
+
+## Keputusan yang ditutup di phase ini
+
+Enam keputusan, ditutup di muka daripada di tengah implementasi.
+
+| # | Pertanyaan | Keputusan | Alasan |
+|---|---|---|---|
+| **D1** | `usage_counters` dibangun sekarang? | **Tidak.** Phase ini hanya gerbang kapabilitas. | Lihat *Penyimpangan tertulis dari freeze* di bawah — satu-satunya keputusan phase ini yang menyimpang dari freeze, dan karena itu ditulis terpisah. |
+| **D2** | Tabel `plans`? | **Tidak.** `plan_code` sebagai `text` tetap cukup. | ADR-012 §4 sudah memutuskan ini: *"Aturan #28 — belum ada implementasi kedua yang nyata"*. Hari ini hanya ada satu paket (`free`). Tabel untuk satu baris adalah abstraksi sebelum implementasi kedua. `freeze.md` 8.4 mendaftarkan `plans` untuk Phase 8; ADR-012 lebih baru dan lebih spesifik, dan ADR-lah yang diikuti (Aturan #30 — dilaporkan di sini, bukan diam-diam dipilih). |
+| **D3** | Di mana peta paket→kapabilitas hidup? | **Peta Go di satu paket**, bentuk yang sama dengan `authz.apiKeyScopeFor`/`publicFormAllows`. Hari ini `free` membuka ketiga kanal. | Peta yang dibaca dengan **satu baris** adalah syarat kriteria #2. Bentuk ini sudah dipakai dua kali di codebase ini untuk pertanyaan yang sebentuk ("principal jenis ini boleh apa"), dan keduanya dikunci test yang mengulang seluruh himpunan — bukan daftar tulis tangan. |
+| **D4** | Gerbang di **membuat** resource, atau juga di **memakai** yang sudah ada? | **Hanya saat membuat** (`POST`). Form, API key, dan endpoint webhook yang sudah ada tetap bekerja. | Menutup resource yang sudah jalan adalah perilaku **downgrade**, dan hari ini tidak ada jalur downgrade sama sekali — hanya `free` yang eksis. Membangun penegakan untuk transisi yang belum bisa terjadi adalah Aturan #29. Saat angka mendarat, pertanyaan "apa yang terjadi pada form yang sudah ada saat paket turun" dijawab bersama pertanyaan retensi — keduanya butuh keputusan produk yang sama. |
+| **D5** | Dashboard menerima `plan_code`, atau kapabilitas yang sudah diselesaikan? | **Kapabilitas yang sudah diselesaikan.** `GET /v1/me` mengirim kanal mana yang terbuka, bukan kode paketnya sebagai dasar keputusan. | Kalau dashboard menerima `plan_code`, ia harus menyalin peta D3 ke TypeScript untuk tahu artinya — dua sumber kebenaran untuk satu keputusan. Persis kesalahan yang #33 harus koreksi: `lib/lead-status.ts` sempat memakai logika transisi versi mockup dan ditulis ulang sebagai port baris-demi-baris dari Go. Di sini biayanya bisa **dihindari sepenuhnya** dengan mengirim jawabannya, bukan bahannya. |
+| **D6** | Kartu terkunci mengarahkan ke mana? | **Tidak ke mana-mana — belum.** Kartu menyatakan kanal itu tidak termasuk paket saat ini, tanpa tombol upgrade dan tanpa harga. | ADR-012 §2 menempatkan checkout di payment service, dan service itu **belum ada kontraknya** (`freeze.md`: *"Kontrak integrasi payment service — sebelum Phase 8"*, masih terbuka). Tombol "Upgrade" yang tidak menuju ke mana pun lebih buruk daripada tidak ada tombol. Menampilkan harga akan melanggar kriteria #9. Saat payment service punya kontrak, yang ditambahkan adalah satu tautan keluar — bukan perubahan bentuk kartunya. |
+
+### Penyimpangan tertulis dari freeze — D1
+
+`freeze.md` 8.4 mendaftarkan `usage_counters` sebagai tabel Phase 8, dan bagian 3 menempatkan
+*"Penegakan limit, usage, upgrade, payment"* di phase ini.
+
+Phase 8 **tidak** membuat tabel itu, dan alasannya perlu berdiri terbuka:
+
+| | |
+|---|---|
+| **Tidak ada angka untuk ditegakkan** | Kuota adalah *"berapa banyak"*. Phase ini sengaja tidak menetapkan satu pun angka (kriteria #9, ADR-012 §4). Penghitung tanpa pembanding tidak menegakkan apa pun — ia hanya menulis baris. |
+| **Aturan #28 dan #29 mengikat** | *"Abstraksi hanya setelah ada implementasi kedua yang nyata"*, *"jangan buat tabel untuk kebutuhan yang belum ada"*. `usage_counters` hari ini adalah tabel dengan nol pembaca dan jalur tulis di banyak usecase — schema mati yang menyentuh banyak tempat. |
+| **Preseden yang sama persis sudah ada** | Phase 7 **D1**: `freeze.md` bagian 5 ketentuan #4 menyebut tabel `jobs`, dan Phase 7 menolak membuatnya karena baru ada **satu** konsumen async yang nyata. Alasannya identik, dan hasilnya dicatat sebagai keputusan phase — bukan diselipkan seolah freeze memang mengizinkannya. |
+| **Maksud freeze tetap dipenuhi** | Yang bagian 3 lindungi adalah *"batas paket harus ditegakkan, bukan sekadar ditampilkan"*. Phase ini memang menegakkannya — di usecase, gagal tertutup, terbukti bisa gagal. Yang berbeda hanya **dimensi** yang digerbangi: kapabilitas (kanal apa), bukan kuota (berapa banyak). |
+
+**Kewajiban yang ikut lahir dari keputusan ini** — dicatat supaya tidak hilang: `usage_counters`
+dievaluasi ulang **bersamaan** dengan mendaratnya angka limit, bukan terpisah. Saat itu pertanyaannya
+sudah punya jawaban yang jujur: metrik mana yang benar-benar dibatasi, dan pada angka berapa. Phase 8
+tidak menutup pintu itu; ia hanya menolak membukanya sebelum ada yang lewat.
+
+---
+
+## Di luar cakupan
+
+| Tidak dikerjakan | Ke |
+|---|---|
+| **Harga, limit free tier, peta kanal-per-paket yang mengunci sesuatu** | Setelah gate freeze — 3–5 pengguna nyata (ADR-012 §4). Ini bukan penundaan teknis; ini syarat yang ADR-nya sendiri tetapkan |
+| **`usage_counters` dan penegakan kuota** | Bersama mendaratnya angka limit (D1) |
+| **Tabel `plans`** | Saat ada paket kedua yang nyata (D2) |
+| **Integrasi payment service** — checkout, kartu, invoice, refund, webhook pembayaran | **Selamanya di luar repository ini** (ADR-012 §2, `CLAUDE.md` *Di luar cakupan*). Yang akan ditambahkan kelak hanyalah satu tautan keluar dan pembacaan `external_reference` |
+| **Alur upgrade & downgrade** | Butuh kontrak payment service, yang belum ada. D4 dan D6 keduanya berhenti di batas ini |
+| **Retensi data free tier** | Keputusan produk yang belum diambil (`STATUS.md` *Keputusan Belum Diambil*); jatuh tempo bersama angka limit |
+| **Dashboard analytics pemakaian** (grafik request per hari) | PRD Phase 4 sudah menempatkannya bersama usage counter — ikut D1 |
+| **Menggerbangi resource yang sudah ada saat paket turun** | D4 — tidak ada jalur downgrade hari ini |
+
+---
+
+## Dependensi
+
+Phase 1–7 selesai. Yang dipakai phase ini sudah ada seluruhnya:
+
+| Yang dipakai | Dari | Catatan |
+|---|---|---|
+| Tabel `subscriptions` + baris `free` per organization | Phase 1 (`0002`, amandemen S1) | **Tidak ada migration baru di phase ini** — kolom yang dibutuhkan (`plan_code`, `status`) sudah ada sejak awal. S1 menyebut biayanya "mendekati nol"; phase ini yang menagih hasilnya |
+| `subscription.Repository.CreateFree` | Phase 1 | Satu-satunya method yang pernah ada; phase ini menambah pembacanya |
+| Pola interface consumer-declared (`ActivityRecorder`, `LeadCreator`, `WebhookEnqueuer`) | Phase 2, 6, 7 | `apikey`/`form`/`webhook` memanggil gerbang lewat interface yang **mereka sendiri** deklarasikan — tidak satu pun mengimpor `internal/subscription` (ADR-011) |
+| Pola peta kapabilitas satu-tempat (`authz.apiKeyScopeFor`, `publicFormAllows`) | Phase 4, 6 | D3 memakai bentuk yang sama, termasuk test yang mengulang seluruh himpunan alih-alih daftar tulis tangan |
+| Kartu Connect + `canManageAPIKeys`/`canManageForms`/`canManageWebhooks` | Phase 6, 7 | Keadaan "terkunci" menempel pada kerangka yang sudah ada; gerbang **paket** berdiri di samping gerbang **role**, bukan menggantikannya |
+| `GET /v1/me` + `SessionGate` | Phase 1, 3 | Kapabilitas ikut di response yang dashboard **sudah** panggil di setiap layar terproteksi — tanpa request tambahan (D5) |
+
+**Dua poin terbuka yang wajib dibaca sebelum TD final:**
+
+- [`docs/issues/047-public-lead-api.md`](../../issues/047-public-lead-api.md) — retensi dan angka rate
+  limit yang belum pernah diukur. Phase ini **tidak** menambah angka ke daftar itu (kriteria #9), tapi
+  peninjauan bersama yang dijanjikan `api.md` akan jatuh tempo pada momen yang sama dengan angka limit
+  Phase 8.
+- `freeze.md` — *"Kontrak integrasi payment service: **sebelum** Phase 8"*. Kontrak itu **belum ada**,
+  dan phase ini berjalan tanpanya secara sadar: D6 berhenti tepat di batas yang membutuhkannya. Yang
+  tidak boleh terjadi adalah menebak bentuk kontraknya lalu membangun ke arah tebakan itu.

--- a/docs/phases/08-subscription/td.md
+++ b/docs/phases/08-subscription/td.md
@@ -1,0 +1,395 @@
+# Phase 8 — Subscription · TD
+
+> **Bagaimana.** Apa & kenapa di [`prd.md`](./prd.md).
+> Ini **delta** untuk phase ini. Aturan yang sudah ada di [`freeze.md`](../../architecture/freeze.md) tidak diulang, hanya dirujuk.
+
+---
+
+## 1. Schema — **tidak ada migration di phase ini**
+
+Kolom yang dibutuhkan sudah ada sejak `0002_identity.sql` (Phase 1, amandemen S1):
+
+```sql
+CREATE TABLE subscriptions (
+    id                    uuid PRIMARY KEY,
+    organization_id       uuid NOT NULL REFERENCES organizations (id),
+    plan_code             text NOT NULL DEFAULT 'free',   -- ← pembacanya lahir di phase ini
+    status                text NOT NULL,                  -- ← ikut dibaca
+    current_period_start  timestamptz,
+    current_period_end    timestamptz,
+    external_reference    text,                           -- ← titik sambung payment service, TIDAK disentuh
+    ...
+    CONSTRAINT ck_subscriptions_status CHECK (status IN ('active','past_due','suspended','canceled')),
+    CONSTRAINT uq_subscriptions_id_org UNIQUE (id, organization_id)
+);
+CREATE UNIQUE INDEX uq_subscriptions_org_active ...;
+```
+
+**Phase kedua tanpa migration sama sekali**, setelah Phase 3. Itu bukan kebetulan melainkan hasil
+langsung amandemen S1: *"Membuat baris subscription tanpa mesin penegakan adalah biaya yang mendekati
+nol; menambahkan tabelnya belakangan berarti backfill untuk semua organization yang sudah ada."*
+Phase 8 menagih hasil dari keputusan itu.
+
+**Tidak ada `usage_counters` (prd D1) dan tidak ada `plans` (prd D2).** Keduanya penyimpangan tertulis
+dari `freeze.md` 8.4, dicatat penuh di PRD beserta kewajiban evaluasi ulangnya.
+
+### 1.1 `status` ikut menggerbangi, bukan hanya `plan_code`
+
+`ck_subscriptions_status` sudah membatasi ke `active`/`past_due`/`suspended`/`canceled`. Gerbang
+memperlakukan **hanya `active`** sebagai berlaku; tiga lainnya menutup seluruh kanal, apa pun
+`plan_code`-nya.
+
+Hari ini hanya `active` yang pernah ditulis (`CreateFree`), jadi cabang itu tak pernah terpakai — tapi
+ia gratis untuk ditulis sekarang dan **mahal untuk diingat nanti**: saat payment service mulai
+menuliskan `past_due`, gerbang yang hanya membaca `plan_code` akan diam-diam tetap membuka semuanya.
+
+---
+
+## 2. Paket & kanal — satu peta, satu tempat (prd D3)
+
+```go
+// internal/subscription/plan.go
+
+type Channel string
+
+const (
+    ChannelAPIKey  Channel = "api_key"
+    ChannelForm    Channel = "form"
+    ChannelWebhook Channel = "webhook"
+)
+
+// Channels is the closed set every table-driven test iterates over —
+// a hand-written list is what lets a new channel be forgotten.
+var Channels = []Channel{ChannelAPIKey, ChannelForm, ChannelWebhook}
+
+const PlanFree = "free"
+
+// planChannels is THE map. Opening or closing a channel for a plan is a
+// one-line change here and nowhere else (kriteria #2).
+//
+// Every channel is open on `free` today. That is not a placeholder: it is
+// the honest state of the product until pricing exists (ADR-012 §4, prd
+// kriteria #9). The mechanism is what ships now; the numbers replace this
+// literal later.
+var planChannels = map[string]map[Channel]bool{
+    PlanFree: {ChannelAPIKey: true, ChannelForm: true, ChannelWebhook: true},
+}
+```
+
+| Ketentuan | Alasan |
+|---|---|
+| Paket yang **tidak ada di peta** → seluruh kanal tertutup | Gagal **tertutup**, bukan gagal terbuka (kriteria #8). `plan_code` adalah `text` tanpa `CHECK` — nilai tak terduga bisa masuk dari luar CRM (payment service menulis `external_reference` dan paket), dan default-nya harus menolak |
+| `status != 'active'` → seluruh kanal tertutup | §1.1 |
+| Bentuknya cermin `authz.apiKeyScopeFor` / `publicFormAllows` | Pertanyaan yang sebentuk ("principal/paket jenis ini boleh apa"), dijawab dengan membaca **satu baris**. Keduanya sudah dikunci test yang mengulang seluruh himpunan `Action`; peta ini mendapat perlakuan yang sama atas `Channels` |
+
+**Kenapa bukan kolom di database.** Peta ini adalah *kebijakan produk*, bukan data pelanggan. Menaruhnya
+di tabel berarti mengubah paket = migration atau panel admin yang belum ada — dan tabel `plans` sudah
+ditolak D2. Sebagai literal Go ia ikut review kode, ikut test, dan ikut deploy; ketiganya justru yang
+diinginkan untuk keputusan yang jarang berubah dan berdampak luas.
+
+---
+
+## 3. Gerbang — di usecase, setelah `authz` (prd D4)
+
+### 3.1 Bentuk
+
+```go
+// internal/subscription/usecase.go
+func (u *Usecase) RequireChannel(ctx context.Context, t tenant.Context, ch Channel) error
+```
+
+Mengembalikan `nil` bila terbuka, dan **`*httpx.DomainError` (403 `plan_upgrade_required`)** bila
+tidak — bukan sentinel error.
+
+**Kenapa error HTTP dikembalikan langsung dari bridge.** Preseden #22: sentinel error domain
+(`lead.ErrAssigneeNotFound`) tidak bisa dikenali lintas paket tanpa melanggar ADR-011, dan
+diselesaikan dengan mengembalikan `*httpx.ValidationError` langsung dari bridge method itu sendiri.
+Bentuk yang sama dipakai di sini: `apikey`/`form`/`webhook` cukup `return err` tanpa perlu tahu paket
+mana yang memutuskan atau kenapa.
+
+### 3.2 Interface dideklarasikan konsumen (ADR-011)
+
+Tiga paket domain mendeklarasikan interface-nya sendiri, primitif saja — persis bentuk
+`lead.ActivityRecorder` (#21), `form.LeadCreator` (#87), `lead.WebhookEnqueuer` (#101):
+
+```go
+// internal/apikey/port.go  (dan padanannya di form/, webhook/)
+type PlanGate interface {
+    RequireChannel(ctx context.Context, t tenant.Context, ch string) error
+}
+```
+
+`ch` bertipe `string` di sisi konsumen, bukan `subscription.Channel` — kalau tipenya diimpor, paket
+itu mengimpor `internal/subscription`, yang justru dihindari interface ini. Nilai literalnya
+(`"api_key"`, `"form"`, `"webhook"`) adalah **kontrak kabel** antar-issue; lihat §7.
+
+Dijembatani di composition root (`cmd/api/subscription_gate.go`), bukan lewat impor langsung — bentuk
+yang sama dengan `activity.NewRecorder(q)` dan `webhook.NewEnqueuer(q)`.
+
+### 3.3 Urutan di dalam usecase — mengikat
+
+```go
+func (u *Usecase) Create(ctx context.Context, t tenant.Context, in CreateInput) (...) {
+    if err := authz.Require(t, authz.ActionAPIKeyCreate); err != nil {
+        return err                        // 1. role  → 403 forbidden
+    }
+    if err := u.plan.RequireChannel(ctx, t, "api_key"); err != nil {
+        return err                        // 2. paket → 403 plan_upgrade_required
+    }
+    // 3. validasi field, lalu kerja
+}
+```
+
+**Role lebih dulu, paket kedua — dan urutannya tidak boleh dibalik.** Manager yang memanggil
+`POST /v1/forms` harus menerima `403 forbidden`, bukan `403 plan_upgrade_required`: yang kedua
+membocorkan keadaan paket organization kepada orang yang memang tidak berhak mengelola kanal itu sama
+sekali. Semangatnya sama dengan Aturan #6 (404 alih-alih 403 untuk tenant lain) — jangan menjawab
+pertanyaan yang penanyanya tidak berhak ajukan.
+
+### 3.4 Titik pasang — hanya `POST` (prd D4)
+
+| Endpoint | Digerbangi | Tidak digerbangi |
+|---|---|---|
+| `POST /v1/api-keys` | ✅ | |
+| `POST /v1/forms` | ✅ | |
+| `POST /v1/webhook-endpoints` | ✅ | |
+| `GET`/`PATCH`/`DELETE` ketiganya | | ✅ resource yang sudah ada tetap dikelola |
+| `POST /v1/leads` (jalur API key) | | ✅ kunci yang sudah terbit tetap bekerja |
+| `POST /v1/forms/{public_key}/submit` | | ✅ form yang sudah tertanam tetap menerima |
+| Pengiriman webhook keluar (worker) | | ✅ endpoint yang sudah ada tetap terkirim |
+
+Baris-baris "tidak digerbangi" adalah konsekuensi langsung D4: menutup resource yang sudah jalan
+adalah perilaku **downgrade**, dan tidak ada jalur downgrade hari ini. Menambahkannya nanti berarti
+menambah titik pasang, bukan mengubah mekanisme.
+
+---
+
+## 4. `GET /v1/me` membawa kapabilitas yang sudah diselesaikan (prd D5)
+
+```json
+{
+  "data": {
+    "user_id": "…", "email": "…", "full_name": "…",
+    "organization_id": "…", "organization_name": "…",
+    "membership_id": "…", "role": "owner",
+    "plan": {
+      "code": "free",
+      "channels": { "api_key": true, "form": true, "webhook": true }
+    }
+  }
+}
+```
+
+| Ketentuan | Alasan |
+|---|---|
+| `channels` adalah **jawaban**, bukan bahan | Dashboard merender `channels.webhook` langsung. Tidak ada peta paket→kanal versi TypeScript — itu sumber kebenaran kedua yang pasti menyimpang (prd D5, kesalahan `lib/lead-status.ts` di #33) |
+| `code` tetap dikirim | Untuk **ditampilkan** ("Paket: Free"), bukan untuk diputuskan. Kriteria #6 melarang keputusan UI berdasarkan `code` |
+| Tidak ada endpoint `GET /v1/subscription` baru | `SessionGate` sudah memanggil `/v1/me` di **setiap** layar terproteksi (#31). Endpoint kedua berarti request kedua untuk data yang sudah di tangan — Aturan #27 |
+| `status`, `current_period_*`, `external_reference` **tidak** dikirim | Belum ada layar yang memerlukannya, dan `external_reference` adalah rujukan internal ke payment service yang tidak punya urusan di klien |
+
+`internal/auth` mendeklarasikan interface consumer-nya sendiri untuk ini — bentuk yang sama dengan
+`auth.RefreshTokenRevoker` (#11):
+
+```go
+// internal/auth/port.go
+type PlanResolver interface {
+    ResolvePlan(ctx context.Context, t tenant.Context) (code string, channels map[string]bool, err error)
+}
+```
+
+---
+
+## 5. Error code baru
+
+| Status | Code | Kapan |
+|---|---|---|
+| `403` | `plan_upgrade_required` | Paket organization tidak membuka kanal yang diminta, atau `status != 'active'` |
+
+Satu kode untuk kedua sebab — sama seperti `webhook_url_not_allowed` (Phase 7 §7) dan
+`invalid_api_key` (Phase 4): membedakan *"paketmu tidak mencakup ini"* dari *"tagihanmu tertunggak"*
+di response HTTP tidak berguna bagi klien dan membocorkan keadaan penagihan ke permukaan yang salah.
+Alasan detailnya masuk log server, bukan response.
+
+`403 forbidden` (role) tetap terpisah dan **selalu didahulukan** (§3.3).
+
+---
+
+## 6. Paket & berkas
+
+```
+crm_be/internal/subscription/
+    entity.go               Subscription (ada) + Plan, Channel, Channels
+    plan.go                 planChannels + resolve — BARU, jantung phase ini
+    port.go                 Repository (consumer-declared) — BARU
+    usecase.go              ResolvePlan + RequireChannel — BARU
+    repository_postgres.go  CreateFree (ada) + FindActiveByOrg — BARU
+
+crm_be/internal/{apikey,form,webhook}/port.go   + PlanGate (masing-masing miliknya sendiri)
+crm_be/internal/auth/port.go                    + PlanResolver
+crm_be/cmd/api/subscription_gate.go             bridge di composition root
+
+crm_dashboard/src/lib/session-context.tsx       + plan pada tipe sesi
+crm_dashboard/src/lib/plan.ts                   helper baca channels (BUKAN peta paket)
+```
+
+**Tidak ada `Store`/`InTx` di `internal/subscription`.** Phase ini hanya **membaca** — preseden
+`internal/metrics` (#30, TD Phase 3 §2), yang juga sengaja tanpa Store. `CreateFree` yang sudah ada
+tetap dipanggil sebagai repository polos dari dalam transaksi registrasi `internal/auth`, tidak
+berubah.
+
+---
+
+## 7. Kontrak kabel antar-issue
+
+Nilai literal yang gagal **diam-diam** kalau tidak dicocokkan persis — dicatat di sini, dicek di
+`docs/issues/` saat issue-nya dikerjakan (pola `docs/issues/087`, `101`):
+
+- `"api_key"`, `"form"`, `"webhook"` — string kanal, dipakai di **empat** tempat: `planChannels`,
+  ketiga `PlanGate` call site, kunci JSON `plan.channels` di `/v1/me`, dan pembacaan di TypeScript.
+  Salah ketik di salah satunya menghasilkan kanal yang **selalu tertutup** (peta tidak punya kuncinya)
+  atau **selalu terbuka** (dashboard membaca `undefined` lalu memperlakukannya sebagai apa pun) —
+  keduanya tanpa error.
+- Karena itu §12 mewajibkan satu test yang membandingkan **himpunan kunci** `plan.channels` di response
+  `/v1/me` dengan `subscription.Channels`, dan satu di TypeScript yang membandingkan literalnya dengan
+  daftar yang sama — bentuk yang sudah dipakai `WEBHOOK_EVENTS` vs `webhook.KnownEvents` (#103).
+
+---
+
+## 8. Dashboard — keadaan "terkunci oleh paket" (prd D6)
+
+Kartu Connect punya **tiga** keadaan sekarang, dan ketiganya harus dibedakan dengan jujur:
+
+| Keadaan | Kapan | Tampilan |
+|---|---|---|
+| **Aktif** | `channels[x] === true` | Seperti sekarang — bisa diklik |
+| **Terkunci oleh paket** | `channels[x] === false` | **Terlihat, redup, tidak bisa diklik**, dengan penjelasan bahwa kanal ini tidak termasuk paket saat ini. **Tanpa tombol upgrade, tanpa harga** (D6) |
+| **Belum tersedia** | Kanal yang produknya memang belum punya | Sudah tidak dipakai satu pun kanal sejak #103 — dipertahankan untuk kanal berikutnya (inbound webhook), **jangan dihapus dan jangan dipakai untuk terkunci** |
+
+> Perbedaan "terkunci" vs "belum tersedia" bukan kosmetik. `06/td.md` §416 sudah menuliskannya:
+> *"keadaan terkunci-oleh-paket baru lahir di Phase 8. Menyatakannya terkunci sekarang akan berbohong."*
+> Kebalikannya berlaku sekarang: menyatakan kanal berbayar sebagai "belum tersedia" juga berbohong.
+
+**Gerbang paket berdiri di samping gerbang role, bukan menggantikannya.** `canManageAPIKeys`/
+`canManageForms`/`canManageWebhooks` tetap apa adanya. Manager yang membuka `/connect/webhook` tetap
+melihat *"tidak tersedia untuk role Anda"* — bukan keadaan terkunci paket, karena paket bukan
+alasannya (§3.3 di UI).
+
+Layar tujuan (`/connect/api`, `/connect/form`, `/connect/webhook`) juga menangani
+`403 plan_upgrade_required` yang datang dari **balapan** — paket berubah antara render dan klik.
+Ditangani inline seperti `delivery_not_retryable` di #103: pesan backend apa adanya, bukan tombol yang
+diam (kriteria #7).
+
+---
+
+## 9. Konfigurasi
+
+**Tidak ada env var baru.** Peta paket adalah literal Go (§2), bukan konfigurasi — dan tidak ada
+angka apa pun di phase ini (kriteria #9).
+
+---
+
+## 10. Otorisasi
+
+**Tidak ada `Action` baru.** Membaca paket sendiri bukan aksi ber-otorisasi terpisah: ia ikut di
+`GET /v1/me`, yang sudah terbuka untuk setiap principal user terautentikasi. Gerbang paket adalah
+dimensi **kedua** di samping `authz` (§3.3), bukan perluasan matriksnya.
+
+`authorization.md` tetap diperbarui — dengan satu bagian yang menjelaskan bahwa sejak Phase 8 ada
+**dua** pertanyaan berbeda yang harus dilewati sebuah `POST` kanal: *"role ini boleh?"* (`authz`) dan
+*"paket ini membuka?"* (`subscription`), dan keduanya tidak boleh tertukar.
+
+---
+
+## 11. Principal non-user
+
+`api_key` dan `public_form` **tidak** melewati gerbang paket, dan itu disengaja:
+
+| Principal | Kenapa tidak digerbangi |
+|---|---|
+| `api_key` (`POST /v1/leads`) | Kunci yang sudah terbit adalah resource yang sudah ada — D4. Menutupnya adalah downgrade |
+| `public_form` (`POST /v1/forms/{public_key}/submit`) | Sama; ditambah: pengunjung situs pelanggan tidak boleh menerima error tentang paket pelanggan |
+
+Yang digerbangi adalah **penerbitan** kredensialnya (`POST /v1/api-keys`, `POST /v1/forms`), bukan
+pemakaiannya. Bila kelak kuota mendarat, di situlah `usage_counters` masuk — dan itu mekanisme berbeda
+(TD Phase 4 §19: *"`usage_counters` menghitung; `ratelimit` melindungi"* — dan gerbang kapabilitas
+tidak melakukan keduanya).
+
+---
+
+## 12. Rencana test
+
+| Berkas | Menguji |
+|---|---|
+| `internal/subscription/plan_test.go` | **Tabel atas seluruh `Channels` × seluruh paket yang dikenal** — bukan daftar tulis tangan, supaya kanal baru phase berikutnya otomatis ikut. Plus: paket tak dikenal → **semua tertutup**; `status` non-`active` → semua tertutup (§1.1) |
+| `internal/subscription/usecase_unit_test.go` | `RequireChannel` mengembalikan `nil` vs `*httpx.DomainError` 403 `plan_upgrade_required`; `ResolvePlan` mengembalikan himpunan kunci = `Channels` |
+| `internal/subscription/repository_test.go` | Postgres asli: `FindActiveByOrg` mengambil baris yang benar, dan **tidak** melihat organization lain |
+| `internal/{apikey,form,webhook}/usecase_unit_test.go` | Gerbang dipanggil, dan **urutannya benar**: fake yang menolak role **dan** paket sekaligus harus menghasilkan `forbidden`, bukan `plan_upgrade_required` (§3.3) — ini yang membuktikan urutannya, bukan komentar di kode |
+| `internal/{apikey,form,webhook}/handler_test.go` | `POST` → `403 plan_upgrade_required` saat kanal tertutup; `GET`/`PATCH`/`DELETE` **tetap** bekerja (D4) |
+| `internal/auth/handler_test.go` | `GET /v1/me` membawa `plan.code` dan `plan.channels`; **himpunan kunci `channels` = `subscription.Channels`** (kontrak kabel §7) |
+| `cmd/api/plan_gate_test.go` | **Terbukti bisa gagal**: satu entri `planChannels[free][webhook]` dibalik jadi `false` → `POST /v1/webhook-endpoints` yang tadinya `201` menjadi `403`, sementara `GET`-nya tetap `200`. Dijalankan, lalu dikembalikan — tidak pernah commit dalam keadaan disabotase (prosedur harness isolasi tenant #11/#23) |
+| `crm_dashboard/src/lib/plan.test.ts` | Literal `"api_key"`/`"form"`/`"webhook"` dibandingkan dengan daftar yang sama (§7); `channels` yang tidak punya kunci → diperlakukan **tertutup**, bukan terbuka |
+
+### Verifikasi manual wajib
+
+Kriteria #3 mensyaratkan penolakan dibuktikan **lewat `curl`**, bukan lewat UI yang menyembunyikan
+tombol — ADR-012 §3 menyatakan justru itu bedanya kenyamanan dan penegakan. Prosedurnya masuk
+`docs/testing/flow/` saat issue penutup, termasuk membalik satu entri peta lalu memanggil endpoint
+langsung.
+
+---
+
+## 13. Risiko teknis
+
+| Risiko | Penanganan |
+|---|---|
+| **Gerbang gagal terbuka** — paket tak dikenal diperlakukan sebagai "boleh semua" | Peta mengembalikan `false` untuk paket yang tidak ada (§2), diuji eksplisit. `plan_code` adalah `text` tanpa `CHECK`; nilai tak terduga bisa datang dari luar CRM |
+| **Peta kedua lahir di TypeScript** | Dicegah secara struktural: `/v1/me` mengirim kapabilitas yang sudah diselesaikan, jadi tidak ada yang perlu disalin (D5). Dikunci test kontrak kabel §7 |
+| **Urutan role-vs-paket tertukar**, membocorkan keadaan paket ke role yang tidak berhak | §3.3, diuji dengan fake yang menolak keduanya sekaligus — satu-satunya cara membedakan urutan dari luar |
+| **Gerbang dipasang di tempat yang salah** dan menutup resource yang sudah jalan | Tabel §3.4 mengikat; test D4 memastikan `GET`/`PATCH`/`DELETE` dan jalur publik tetap `200` |
+| **Angka menyusup lebih awal** — harga atau limit ditulis "sementara" lalu bertahan | Kriteria #9, dan §9 menghapus tempatnya (tidak ada env var, tidak ada kolom). ADR-012 §4 menamai risiko ini sendiri |
+| **`status` diabaikan** dan `past_due` tetap membuka semuanya | §1.1 — ditulis sekarang meski belum pernah terpakai, karena ia mahal untuk diingat nanti |
+
+---
+
+## 14. Yang harus disiapkan pemilik produk
+
+**Tidak ada.** Tidak ada pihak ketiga, tidak ada akun, tidak ada angka yang harus diputuskan sebelum
+phase ini bisa dikerjakan — itu justru bentuk yang dipilih (prd, *Kenapa mekanismenya dibangun sebelum
+angkanya*).
+
+**Yang tetap terbuka dan jatuh tempo bersama-sama**, di luar phase ini: harga, limit free tier, retensi
+data free tier, peta kanal-per-paket yang sesungguhnya, dan kontrak integrasi payment service.
+Kelimanya butuh data dari pengguna nyata (gate freeze), bukan keputusan yang bisa dipercepat dengan
+menulis kode.
+
+**Tidak memblokir issue manapun.**
+
+---
+
+## 15. Yang berubah pada dokumentasi
+
+| Berkas | Perubahan |
+|---|---|
+| `architecture/api.md` | Error code baru `plan_upgrade_required`; bab singkat *Gerbang Paket* — apa yang digerbangi, apa yang sengaja tidak (§3.4), dan bahwa CRM tidak pernah tahu tentang uang |
+| `architecture/authorization.md` | Bagian baru: **dua pertanyaan berbeda** yang harus dilewati sebuah `POST` kanal (role vs paket), urutannya, dan kenapa paket **bukan** baris di matriks `Action` (§10) |
+| `architecture/authentication.md` | Tidak disentuh — subscription bukan kredensial dan bukan jalur autentikasi |
+| `docs/testing/flow/` | Bagian pada berkas yang ada (bukan berkas baru): membalik satu entri peta, lalu membuktikan `403` lewat `curl` dan kartu terkunci di browser |
+| `STATUS.md` | Baris Selesai; Phase 8 di *Progress per Phase*; `Keputusan Belum Diambil` diperbarui — pricing/limit/retensi **tetap** terbuka, dan sekarang punya tempat yang menunggunya |
+
+`freeze.md` **tidak disentuh.** Penyimpangan D1 (`usage_counters`) dan D2 (`plans`) dicatat di
+`prd.md` sebagai keputusan phase beserta kewajiban evaluasi ulangnya — bukan diselipkan seolah freeze
+memang mengizinkannya (Aturan #30). ADR baru **tidak diperlukan**: mekanismenya sudah ditetapkan
+ADR-012, dan phase ini mengimplementasikannya, bukan mengubahnya.
+
+---
+
+## 16. Kewajiban yang diteruskan ke phase berikutnya
+
+- **Saat angka mendarat** (setelah gate freeze): isi `planChannels` dengan paket sesungguhnya —
+  perubahan pada satu literal, bukan pada usecase manapun. Bersamaan dengan itu, evaluasi ulang
+  `usage_counters` (prd D1) dan jawab pertanyaan downgrade (prd D4).
+- **Saat payment service punya kontrak**: kartu terkunci mendapat satu tautan keluar (prd D6), dan
+  `external_reference` mendapat pembacanya. Bentuk kartunya tidak berubah.
+- **Saat kanal keempat lahir** (inbound webhook Phase 7.5, dst.): tambahkan satu konstanta ke
+  `Channels` dan satu entri ke `planChannels`. Test tabel §12 otomatis mencakupnya — itu memang
+  alasan `Channels` ada sebagai slice, bukan daftar tulis tangan di tiap test.


### PR DESCRIPTION
Membuka **Phase 8 — Subscription** atas keputusan pemilik produk. **Phase 7.5 (Inbound Webhook) ditunda** — konsepnya masih dicari.

Milestone [11](https://github.com/Pravasta/jualin-crm/milestone/11) + issue [#112](https://github.com/Pravasta/jualin-crm/issues/112)–[#115](https://github.com/Pravasta/jualin-crm/issues/115) sudah dibuat.

## Bentuknya: mekanisme, bukan angka

ADR-012 §4 mengikat harga, limit free tier, dan peta kanal-per-paket yang sesungguhnya ke *"setelah gate freeze (3–5 pengguna nyata) memberi data yang membuat angka itu bisa dipilih dengan jujur"* — gate itu belum terlewati. Tapi ADR yang sama menulis: ***"ADR ini menetapkan mekanismenya, bukan angkanya."***

Phase ini mengerjakan bagian kedua kalimat itu, dan **tidak satu pun angka** masuk (kriteria AC #9).

| | Mekanisme (phase ini) | Angka (menyusul) |
|---|---|---|
| Butuh pengguna nyata? | **Tidak** — bentuknya sudah ditetapkan ADR-012 | **Ya** — itu yang gate freeze minta |
| Biaya menundanya | Kanal terus bertambah tanpa tempat digerbangi | Nol — mengisi peta yang sudah ada |
| Biaya salah | Rendah & terlihat | **Tinggi & tidak terlihat** — angka tebakan bertahan karena terlanjur tertulis (ADR-012 menamai risiko ini sendiri) |

## Isi

- `internal/subscription` naik dari `CreateFree`-saja jadi domain penuh — **pembaca pertama `plan_code`** sejak dibuat di Phase 1 (amandemen S1) dan tidak pernah dibaca sekali pun
- **Satu peta paket→kanal di satu tempat**, cermin `authz.apiKeyScopeFor`. Gagal **tertutup**: paket tak dikenal dan `status != 'active'` menutup semuanya
- Gerbang ditegakkan **di usecase**, dan **selalu setelah `authz`** — urutannya mengikat: `plan_upgrade_required` yang mendahului `forbidden` membocorkan keadaan paket kepada role yang tidak berhak mengelola kanalnya (semangat Aturan #6)
- `GET /v1/me` membawa **kapabilitas yang sudah diselesaikan**, bukan `plan_code` — supaya tidak ada peta paket kedua yang tumbuh di TypeScript (kesalahan `lib/lead-status.ts` yang #33 harus koreksi; di sini bisa dihindari sepenuhnya)
- Kartu Connect punya keadaan **"terkunci oleh paket"** yang nyata: terlihat, tanpa tombol upgrade (payment service belum punya kontrak), tanpa harga

## Dua penyimpangan tertulis dari `freeze.md` 8.4

Ditulis di `prd.md` sebagai keputusan phase, **bukan diselipkan** seolah freeze mengizinkannya (Aturan #30):

- **D1 — tidak ada `usage_counters`.** Kuota adalah *"berapa banyak"*, dan tidak ada satu pun angka untuk ditegakkan. Penghitung tanpa pembanding hanya menulis baris (Aturan #28/#29). Bentuk yang sama persis dengan **D1 Phase 7** yang menolak tabel `jobs` generik.
- **D2 — tidak ada tabel `plans`.** ADR-012 §4 sudah memutuskannya; `plan_code` sebagai `text` masih cukup untuk satu paket. `freeze.md` 8.4 mendaftarkan `plans`; ADR lebih baru dan lebih spesifik, dan pertentangannya dilaporkan di PRD.

**Tidak ada migration sama sekali** — phase kedua setelah Phase 3. Kolomnya sudah ada sejak `0002`; amandemen S1 menyebut biayanya *"mendekati nol"*, dan phase ini yang menagih hasilnya.

## Yang phase ini **tidak** selesaikan

Ditulis terbuka di `issues.md` dan `STATUS.md`: setelah #115 merge, produk punya gerbang paket yang bekerja dan **nol paket berbayar untuk digerbangi**. Kartu terkunci tidak akan muncul di layar siapa pun sampai `planChannels` diisi paket kedua — dan itu menunggu data pengguna nyata, bukan kode.

## Phase 7.5 — ditunda, analisisnya disimpan

Supaya tidak diulang dari nol, `STATUS.md` mencatat hasil analisis awal: kasus penggunanya **WordPress** (form yang sudah ada, plugin hanya bisa diberi satu URL) → kredensial harus di **path**, dan **signature tidak bisa jadi penjaga utama** — yang **bertentangan** dengan `07/prd.md` (*"verifikasi signature menggantikan honeypot"*). Endpoint-nya hampir persis `POST /v1/forms/{public_key}/submit` minus tiga pertahanan khusus-browser (Origin allowlist, honeypot, time-trap).

Plus satu klaim Phase 7 yang perlu dikoreksi saat 7.5 dibuka: `07/td.md` §11/§16 menulis `safedial` akan dipakai ulang inbound — kemungkinan keliru, `safedial` menjaga panggilan **keluar**.

## Cek

Hanya `.md`. Tidak ada kode yang tersentuh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZ6FLA12uTzT1yPDywWezt